### PR TITLE
feat: add multi-account support for GitHub Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A reverse-engineered proxy for the GitHub Copilot API that exposes it as an Open
 - **Token Visibility**: Option to display GitHub and Copilot tokens during authentication and refresh for debugging (`--show-token`).
 - **Flexible Authentication**: Authenticate interactively or provide a GitHub token directly, suitable for CI/CD environments.
 - **Support for Different Account Types**: Works with individual, business, and enterprise GitHub Copilot plans.
+- **Multi-Account Support**: Use multiple GitHub Copilot accounts with automatic switching. When one account's quota is exhausted, the proxy automatically switches to the next available account.
 
 ## Demo
 
@@ -79,6 +80,21 @@ docker run -p 4141:4141 -v $(pwd)/copilot-data:/root/.local/share/copilot-api co
 
 > **Note:**
 > The GitHub token and related data will be stored in `copilot-data` on your host. This is mapped to `/root/.local/share/copilot-api` inside the container, ensuring persistence across restarts.
+
+### Adding Multiple Accounts in Docker
+
+To add multiple accounts when running in Docker:
+
+```sh
+# Add accounts interactively (one at a time)
+docker run -it -v $(pwd)/copilot-data:/root/.local/share/copilot-api copilot-api --auth add
+docker run -it -v $(pwd)/copilot-data:/root/.local/share/copilot-api copilot-api --auth add
+
+# List registered accounts
+docker run -it -v $(pwd)/copilot-data:/root/.local/share/copilot-api copilot-api --auth ls -q
+```
+
+> **Note:** When using multiple accounts, all account data (tokens and registry) is stored in the mounted `copilot-data` directory. The proxy will automatically switch to the next account when the current account's quota is exhausted.
 
 ### Docker with Environment Variables
 
@@ -141,7 +157,12 @@ npx copilot-api@latest auth
 Copilot API now uses a subcommand structure with these main commands:
 
 - `start`: Start the Copilot API server. This command will also handle authentication if needed.
-- `auth`: Run GitHub authentication flow without starting the server. This is typically used if you need to generate a token for use with the `--github-token` option, especially in non-interactive environments.
+- `auth`: Manage GitHub Copilot accounts. Supports subcommands:
+  - `auth add`: Add a new account via GitHub OAuth flow
+  - `auth ls`: List all registered accounts (use `-q` to show quota)
+  - `auth rm <id|index>`: Remove an account by ID or 1-based index
+
+  Running `auth` without a subcommand defaults to `auth add` for backward compatibility.
 - `check-usage`: Show your current GitHub Copilot usage and quota information directly in the terminal (no server required).
 - `debug`: Display diagnostic information including version, runtime details, file paths, and authentication status. Useful for troubleshooting and support.
 
@@ -166,10 +187,31 @@ The following command line options are available for the `start` command:
 
 ### Auth Command Options
 
-| Option       | Description               | Default | Alias |
-| ------------ | ------------------------- | ------- | ----- |
-| --verbose    | Enable verbose logging    | false   | -v    |
-| --show-token | Show GitHub token on auth | false   | none  |
+The `auth` command has three subcommands for managing multiple accounts:
+
+#### `auth add` - Add a new account
+
+| Option         | Description                                     | Default    | Alias |
+| -------------- | ----------------------------------------------- | ---------- | ----- |
+| --account-type | Account type (individual, business, enterprise) | individual | -a    |
+| --verbose      | Enable verbose logging                          | false      | -v    |
+| --show-token   | Show GitHub token after auth                    | false      | none  |
+
+#### `auth ls` - List registered accounts
+
+| Option       | Description                                | Default | Alias |
+| ------------ | ------------------------------------------ | ------- | ----- |
+| --show-quota | Show quota information (requires API call) | false   | -q    |
+| --verbose    | Enable verbose logging                     | false   | -v    |
+
+#### `auth rm <target>` - Remove an account
+
+| Option    | Description              | Default | Alias |
+| --------- | ------------------------ | ------- | ----- |
+| --force   | Skip confirmation prompt | false   | -f    |
+| --verbose | Enable verbose logging   | false   | -v    |
+
+The `<target>` can be either the account ID (GitHub username) or a 1-based index.
 
 ### Debug Command Options
 
@@ -225,12 +267,13 @@ These endpoints are designed to be compatible with the Anthropic Messages API.
 
 ### Usage Monitoring Endpoints
 
-New endpoints for monitoring your Copilot usage and quotas.
+Endpoints for monitoring your Copilot usage and quotas across all accounts.
 
-| Endpoint     | Method | Description                                                  |
-| ------------ | ------ | ------------------------------------------------------------ |
-| `GET /usage` | `GET`  | Get detailed Copilot usage statistics and quota information. |
-| `GET /token` | `GET`  | Get the current Copilot token being used by the API.         |
+| Endpoint             | Method | Description                                                                   |
+| -------------------- | ------ | ----------------------------------------------------------------------------- |
+| `GET /usage`         | `GET`  | Get status of all registered accounts (ID, remaining quota, unlimited flag).  |
+| `GET /usage/:index`  | `GET`  | Get detailed Copilot usage for a specific account by index (0-based).         |
+| `GET /token`         | `GET`  | Get the current Copilot token being used by the API.                          |
 
 ## Example Usage
 
@@ -266,6 +309,22 @@ npx copilot-api@latest auth
 
 # Run auth flow with verbose logging
 npx copilot-api@latest auth --verbose
+
+# Add multiple accounts (each account is added in order)
+npx copilot-api@latest auth add
+npx copilot-api@latest auth add  # add second account
+
+# List all registered accounts
+npx copilot-api@latest auth ls
+
+# List accounts with quota information
+npx copilot-api@latest auth ls -q
+
+# Remove an account by index (1-based)
+npx copilot-api@latest auth rm 2
+
+# Remove an account by ID (GitHub username)
+npx copilot-api@latest auth rm octocat
 
 # Show your Copilot usage/quota in the terminal (no server needed)
 npx copilot-api@latest check-usage
@@ -372,3 +431,4 @@ bun run start
   - `--rate-limit <seconds>`: Enforces a minimum time interval between requests. For example, `copilot-api start --rate-limit 30` will ensure there's at least a 30-second gap between requests.
   - `--wait`: Use this with `--rate-limit`. It makes the server wait for the cooldown period to end instead of rejecting the request with an error. This is useful for clients that don't automatically retry on rate limit errors.
 - If you have a GitHub business or enterprise plan account with Copilot, use the `--account-type` flag (e.g., `--account-type business`). See the [official documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network#configuring-copilot-subscription-based-network-routing-for-your-enterprise-or-organization) for more details.
+- **Multi-account quota management**: Add multiple GitHub Copilot accounts using `auth add`. Accounts are used in the order they were added. When an account's premium request quota (`remaining=0`) is exhausted, the proxy automatically switches to the next account.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ docker run -p 4141:4141 -v $(pwd)/copilot-data:/root/.local/share/copilot-api co
 
 To add multiple accounts when running in Docker:
 
+> **Note:** The Docker image uses an entrypoint that runs the `start` command by default. To run `auth` subcommands inside the container, prefix them with `--auth` (e.g. `--auth add`).
+
 ```sh
 # Add accounts interactively (one at a time)
 docker run -it -v $(pwd)/copilot-data:/root/.local/share/copilot-api copilot-api --auth add
@@ -108,7 +110,7 @@ docker build --build-arg GH_TOKEN=your_github_token_here -t copilot-api .
 docker run -p 4141:4141 -e GH_TOKEN=your_github_token_here copilot-api
 
 # Run with additional options
-docker run -p 4141:4141 -e GH_TOKEN=your_token copilot-api start --verbose --port 4141
+docker run -p 4141:4141 -e GH_TOKEN=your_token copilot-api --verbose --port 4141
 ```
 
 ### Docker Compose Example
@@ -274,6 +276,11 @@ Endpoints for monitoring your Copilot usage and quotas across all accounts.
 | `GET /usage`         | `GET`  | Get status of all registered accounts (ID, remaining quota, unlimited flag).  |
 | `GET /usage/:index`  | `GET`  | Get detailed Copilot usage for a specific account by index (0-based).         |
 | `GET /token`         | `GET`  | Get the current Copilot token being used by the API.                          |
+
+> **Note on account indices**
+> - `/usage/:index` is **0-based**.
+> - If you start the server with `start --github-token ...`, a temporary account is included and shown as `"(temporary)"` in `GET /usage`. In that case, `index=0` refers to the temporary account and registered accounts start at `index=1`.
+> - `auth rm <index>` uses a **1-based** index (as shown by `auth ls`).
 
 ## Example Usage
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "copilot-api",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 if [ "$1" = "--auth" ]; then
   # Run auth command
-  exec bun run dist/main.js auth
+  shift
+  exec bun run dist/main.js auth "$@"
 else
   # Default command
   exec bun run dist/main.js start -g "$GH_TOKEN" "$@"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,8 +3,6 @@
 import { defineCommand } from "citty"
 import consola from "consola"
 
-import type { AccountMeta, AccountType } from "./lib/types/account"
-
 import {
   addAccountToRegistry,
   listAccountsFromRegistry,
@@ -15,6 +13,11 @@ import {
 } from "./lib/accounts-registry"
 import { ensurePaths } from "./lib/paths"
 import { state } from "./lib/state"
+import {
+  parseAccountType,
+  type AccountMeta,
+  type AccountType,
+} from "./lib/types/account"
 import { getCopilotUsage } from "./services/github/get-copilot-usage"
 import { getDeviceCode } from "./services/github/get-device-code"
 import { getGitHubUser } from "./services/github/get-user"
@@ -79,7 +82,14 @@ const authAdd = defineCommand({
     }
 
     state.showToken = args["show-token"]
-    const accountType = args["account-type"] as AccountType
+
+    let accountType: AccountType
+    try {
+      accountType = parseAccountType(args["account-type"])
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error))
+      process.exit(1)
+    }
 
     await ensurePaths()
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -302,10 +302,12 @@ export const auth = defineCommand({
     },
   },
   async run(ctx) {
-    // Check if a subcommand was specified in rawArgs
-    // If so, don't run the default 'add' behavior (the subcommand will handle it)
-    const subCommandNames = new Set(["add", "ls", "rm"])
-    const hasSubCommand = ctx.rawArgs.some((arg) => subCommandNames.has(arg))
+    // Check if a subcommand was specified in rawArgs.
+    // Only treat the *first* raw arg as a subcommand to avoid false positives
+    // when flags accept values like "add"/"ls"/"rm".
+    const firstArg = ctx.rawArgs[0]
+    const hasSubCommand =
+      firstArg === "add" || firstArg === "ls" || firstArg === "rm"
 
     // Backward compatibility: if no subcommand, run 'add'
     if (!hasSubCommand && authAdd.run) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -103,21 +103,23 @@ const authAdd = defineCommand({
     const user = await getGitHubUser({ githubToken: token, accountType })
     const accountId = user.login
 
-    // Check if account already exists
+    // Save token and check if account already exists
+    await saveAccountToken(accountId, token)
     const existingAccounts = await listAccountsFromRegistry()
+
     if (existingAccounts.some((acc) => acc.id === accountId)) {
-      consola.warn(`Account "${accountId}" already exists. Updating token...`)
+      consola.success(
+        `Account "${accountId}" already exists. Token has been updated.`,
+      )
+    } else {
+      await addAccountToRegistry({
+        id: accountId,
+        accountType,
+        addedAt: Date.now(),
+      })
+      consola.success(`Account "${accountId}" added successfully!`)
     }
 
-    // Save token and add to registry
-    await saveAccountToken(accountId, token)
-    await addAccountToRegistry({
-      id: accountId,
-      accountType,
-      addedAt: Date.now(),
-    })
-
-    consola.success(`Account "${accountId}" added successfully!`)
     consola.info(`Account type: ${accountType}`)
   },
 })

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,34 +3,63 @@
 import { defineCommand } from "citty"
 import consola from "consola"
 
-import { PATHS, ensurePaths } from "./lib/paths"
+import type { AccountMeta, AccountType } from "./lib/types/account"
+
+import {
+  addAccountToRegistry,
+  listAccountsFromRegistry,
+  loadAccountToken,
+  removeAccountFromRegistry,
+  removeAccountToken,
+  saveAccountToken,
+} from "./lib/accounts-registry"
+import { ensurePaths } from "./lib/paths"
 import { state } from "./lib/state"
-import { setupGitHubToken } from "./lib/token"
+import { getCopilotUsage } from "./services/github/get-copilot-usage"
+import { getDeviceCode } from "./services/github/get-device-code"
+import { getGitHubUser } from "./services/github/get-user"
+import { pollAccessToken } from "./services/github/poll-access-token"
 
-interface RunAuthOptions {
-  verbose: boolean
-  showToken: boolean
-}
+/**
+ * Fetch quota info for an account (used by auth ls -q)
+ */
+async function fetchQuotaInfo(account: AccountMeta): Promise<string> {
+  try {
+    const token = await loadAccountToken(account.id)
+    if (!token) {
+      return " | Quota: (no token)"
+    }
 
-export async function runAuth(options: RunAuthOptions): Promise<void> {
-  if (options.verbose) {
-    consola.level = 5
-    consola.info("Verbose logging enabled")
+    const usage = await getCopilotUsage({
+      githubToken: token,
+      accountType: account.accountType,
+    })
+    const premium = usage.quota_snapshots.premium_interactions
+
+    return premium.unlimited ?
+        " | Quota: unlimited"
+      : ` | Quota: ${premium.remaining}/${premium.entitlement}`
+  } catch (error) {
+    consola.debug(`Failed to fetch quota for ${account.id}:`, error)
+    return " | Quota: (failed to fetch)"
   }
-
-  state.showToken = options.showToken
-
-  await ensurePaths()
-  await setupGitHubToken({ force: true })
-  consola.success("GitHub token written to", PATHS.GITHUB_TOKEN_PATH)
 }
 
-export const auth = defineCommand({
+/**
+ * auth add - Add a new GitHub Copilot account
+ */
+const authAdd = defineCommand({
   meta: {
-    name: "auth",
-    description: "Run GitHub auth flow without running the server",
+    name: "add",
+    description: "Add a new GitHub Copilot account",
   },
   args: {
+    "account-type": {
+      alias: "a",
+      type: "string",
+      default: "individual",
+      description: "Account type (individual, business, enterprise)",
+    },
     verbose: {
       alias: "v",
       type: "boolean",
@@ -40,13 +69,230 @@ export const auth = defineCommand({
     "show-token": {
       type: "boolean",
       default: false,
-      description: "Show GitHub token on auth",
+      description: "Show GitHub token after auth",
     },
   },
-  run({ args }) {
-    return runAuth({
-      verbose: args.verbose,
-      showToken: args["show-token"],
+  async run({ args }) {
+    if (args.verbose) {
+      consola.level = 5
+      consola.info("Verbose logging enabled")
+    }
+
+    state.showToken = args["show-token"]
+    const accountType = args["account-type"] as AccountType
+
+    await ensurePaths()
+
+    // Start device code flow
+    consola.info("Starting GitHub device code authentication...")
+    const deviceResponse = await getDeviceCode()
+    consola.debug("Device code response:", deviceResponse)
+
+    consola.info(
+      `Please enter the code "${deviceResponse.user_code}" at ${deviceResponse.verification_uri}`,
+    )
+
+    // Poll for access token
+    const token = await pollAccessToken(deviceResponse)
+
+    if (state.showToken) {
+      consola.info("GitHub token:", token)
+    }
+
+    // Get user info to determine account ID
+    const user = await getGitHubUser({ githubToken: token, accountType })
+    const accountId = user.login
+
+    // Check if account already exists
+    const existingAccounts = await listAccountsFromRegistry()
+    if (existingAccounts.some((acc) => acc.id === accountId)) {
+      consola.warn(`Account "${accountId}" already exists. Updating token...`)
+    }
+
+    // Save token and add to registry
+    await saveAccountToken(accountId, token)
+    await addAccountToRegistry({
+      id: accountId,
+      accountType,
+      addedAt: Date.now(),
     })
+
+    consola.success(`Account "${accountId}" added successfully!`)
+    consola.info(`Account type: ${accountType}`)
+  },
+})
+
+/**
+ * auth ls - List all registered accounts
+ */
+const authLs = defineCommand({
+  meta: {
+    name: "ls",
+    description: "List all registered accounts",
+  },
+  args: {
+    "show-quota": {
+      alias: "q",
+      type: "boolean",
+      default: false,
+      description: "Show quota information (requires API call)",
+    },
+    verbose: {
+      alias: "v",
+      type: "boolean",
+      default: false,
+      description: "Enable verbose logging",
+    },
+  },
+  async run({ args }) {
+    if (args.verbose) {
+      consola.level = 5
+    }
+
+    await ensurePaths()
+
+    const accounts = await listAccountsFromRegistry()
+
+    if (accounts.length === 0) {
+      consola.info("No accounts registered. Use 'auth add' to add an account.")
+      return
+    }
+
+    consola.info(`Found ${accounts.length} account(s):\n`)
+
+    for (const [i, account] of accounts.entries()) {
+      const addedDate = new Date(account.addedAt).toLocaleString()
+
+      const quotaInfo = args["show-quota"] ? await fetchQuotaInfo(account) : ""
+
+      console.log(
+        `  ${i + 1}. ${account.id} (${account.accountType})${quotaInfo}`,
+      )
+      console.log(`     Added: ${addedDate}\n`)
+    }
+  },
+})
+
+/**
+ * auth rm - Remove an account
+ */
+const authRm = defineCommand({
+  meta: {
+    name: "rm",
+    description: "Remove an account",
+  },
+  args: {
+    target: {
+      type: "positional",
+      description: "Account ID or index (1-based)",
+      required: true,
+    },
+    force: {
+      alias: "f",
+      type: "boolean",
+      default: false,
+      description: "Skip confirmation prompt",
+    },
+    verbose: {
+      alias: "v",
+      type: "boolean",
+      default: false,
+      description: "Enable verbose logging",
+    },
+  },
+  async run({ args }) {
+    if (args.verbose) {
+      consola.level = 5
+    }
+
+    await ensurePaths()
+
+    const target = args.target
+    const accounts = await listAccountsFromRegistry()
+
+    if (accounts.length === 0) {
+      consola.error("No accounts to remove.")
+      return
+    }
+
+    // Determine account to remove (by ID or index)
+    let accountToRemove: { id: string; index: number } | undefined
+
+    // Try parsing as index (1-based)
+    const index = Number.parseInt(target, 10)
+    if (!Number.isNaN(index) && index >= 1 && index <= accounts.length) {
+      accountToRemove = { id: accounts[index - 1].id, index: index - 1 }
+    } else {
+      // Try finding by ID
+      const foundIndex = accounts.findIndex((acc) => acc.id === target)
+      if (foundIndex !== -1) {
+        accountToRemove = { id: accounts[foundIndex].id, index: foundIndex }
+      }
+    }
+
+    if (!accountToRemove) {
+      consola.error(`Account "${target}" not found.`)
+      consola.info("Use 'auth ls' to see available accounts.")
+      return
+    }
+
+    // Confirmation
+    if (!args.force) {
+      const confirmed = await consola.prompt(
+        `Are you sure you want to remove account "${accountToRemove.id}"?`,
+        { type: "confirm" },
+      )
+      if (!confirmed) {
+        consola.info("Cancelled.")
+        return
+      }
+    }
+
+    // Remove token file and registry entry
+    await removeAccountToken(accountToRemove.id)
+    await removeAccountFromRegistry(accountToRemove.id)
+
+    consola.success(`Account "${accountToRemove.id}" removed.`)
+  },
+})
+
+/**
+ * Main auth command with subcommands
+ */
+export const auth = defineCommand({
+  meta: {
+    name: "auth",
+    description: "Manage GitHub Copilot accounts",
+  },
+  subCommands: {
+    add: authAdd,
+    ls: authLs,
+    rm: authRm,
+  },
+  args: {
+    // Legacy args for backward compatibility (when no subcommand)
+    "account-type": {
+      alias: "a",
+      type: "string",
+      default: "individual",
+      description: "Account type (individual, business, enterprise)",
+    },
+    verbose: {
+      alias: "v",
+      type: "boolean",
+      default: false,
+      description: "Enable verbose logging",
+    },
+    "show-token": {
+      type: "boolean",
+      default: false,
+      description: "Show GitHub token after auth",
+    },
+  },
+  async run(ctx) {
+    // Backward compatibility: if no subcommand, run 'add'
+    if (authAdd.run) {
+      await authAdd.run(ctx)
+    }
   },
 })

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,6 +10,7 @@ import {
   removeAccountFromRegistry,
   removeAccountToken,
   saveAccountToken,
+  saveRegistry,
 } from "./lib/accounts-registry"
 import { ensurePaths } from "./lib/paths"
 import { state } from "./lib/state"
@@ -116,8 +117,12 @@ const authAdd = defineCommand({
     // Save token and check if account already exists
     await saveAccountToken(accountId, token)
     const existingAccounts = await listAccountsFromRegistry()
+    const alreadyExists = existingAccounts.some((acc) => acc.id === accountId)
 
-    if (existingAccounts.some((acc) => acc.id === accountId)) {
+    if (alreadyExists) {
+      // Touch registry file so a running server can hot-reload updated tokens.
+      await saveRegistry({ version: 1, accounts: existingAccounts })
+
       consola.success(
         `Account "${accountId}" already exists. Token has been updated.`,
       )

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -290,8 +290,13 @@ export const auth = defineCommand({
     },
   },
   async run(ctx) {
+    // Check if a subcommand was specified in rawArgs
+    // If so, don't run the default 'add' behavior (the subcommand will handle it)
+    const subCommandNames = new Set(["add", "ls", "rm"])
+    const hasSubCommand = ctx.rawArgs.some((arg) => subCommandNames.has(arg))
+
     // Backward compatibility: if no subcommand, run 'add'
-    if (authAdd.run) {
+    if (!hasSubCommand && authAdd.run) {
       await authAdd.run(ctx)
     }
   },

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -7,6 +7,7 @@ import type {
   AccountType,
 } from "~/lib/types/account"
 
+import { HTTPError } from "~/lib/error"
 import { getModels } from "~/services/copilot/get-models"
 import { getCopilotToken } from "~/services/github/get-copilot-token"
 import { getCopilotUsage } from "~/services/github/get-copilot-usage"
@@ -234,8 +235,13 @@ export class AccountsManager {
       // eslint-disable-next-line require-atomic-updates
       account.failureReason = undefined
     } catch (error) {
+      if (error instanceof HTTPError && error.response.status === 401) {
+        this.markAccountFailed(account.id, "Unauthorized (401)")
+        return
+      }
+
       consola.error(`Failed to refresh quota for ${account.id}:`, error)
-      // Don't mark as failed for quota refresh errors
+      // Don't mark as failed for non-401 quota refresh errors
     } finally {
       // eslint-disable-next-line require-atomic-updates
       account.isRefreshingQuota = false
@@ -250,38 +256,46 @@ export class AccountsManager {
     return Date.now() - account.lastQuotaFetch > QUOTA_CACHE_TTL
   }
 
+  private isAccountFailed(account: AccountRuntime): boolean {
+    return account.failed === true
+  }
+
   /**
    * Select an available account based on quota.
    * Returns null if all accounts are exhausted.
    */
   // eslint-disable-next-line complexity
   async selectAccount(): Promise<AccountRuntime | null> {
+    const tempAccount = this.temporaryAccount
+
     // Check temporary account first (--github-token)
-    if (this.temporaryAccount && !this.temporaryAccount.failed) {
-      if (this.temporaryAccount.unlimited) {
-        return this.temporaryAccount
+    if (tempAccount && !this.isAccountFailed(tempAccount)) {
+      if (tempAccount.unlimited) {
+        return tempAccount
       }
 
-      if (this.isQuotaCacheExpired(this.temporaryAccount)) {
-        await this.refreshQuota(this.temporaryAccount)
+      if (this.isQuotaCacheExpired(tempAccount)) {
+        await this.refreshQuota(tempAccount)
       }
 
-      if (
-        this.temporaryAccount.premiumRemaining === undefined
-        || this.temporaryAccount.premiumRemaining > 0
-      ) {
+      const hasQuota =
+        tempAccount.premiumRemaining === undefined
+        || tempAccount.premiumRemaining > 0
+
+      // refreshQuota may mark the account as failed (e.g., 401)
+      if (!this.isAccountFailed(tempAccount) && hasQuota) {
         // Optimistic decrement
-        if (this.temporaryAccount.premiumRemaining !== undefined) {
-          this.temporaryAccount.premiumRemaining--
+        if (tempAccount.premiumRemaining !== undefined) {
+          tempAccount.premiumRemaining--
         }
-        return this.temporaryAccount
+        return tempAccount
       }
     }
 
     // Check registered accounts in order
     for (const id of this.accountOrder) {
       const account = this.accounts.get(id)
-      if (!account || account.failed) continue
+      if (!account || this.isAccountFailed(account)) continue
 
       // Unlimited accounts are always available
       if (account.unlimited) {
@@ -290,14 +304,9 @@ export class AccountsManager {
 
       // Refresh quota if cache is expired
       if (this.isQuotaCacheExpired(account)) {
-        try {
-          await this.refreshQuota(account)
-        } catch (error) {
-          // If quota refresh fails with 401, mark account as failed
-          if (error instanceof Error && error.message.includes("401")) {
-            this.markAccountFailed(id, "Unauthorized (401)")
-            continue
-          }
+        await this.refreshQuota(account)
+        if (this.isAccountFailed(account)) {
+          continue
         }
       }
 
@@ -337,6 +346,13 @@ export class AccountsManager {
     if (account) {
       account.failed = true
       account.failureReason = reason
+      consola.warn(`Account ${id} marked as failed: ${reason}`)
+      return
+    }
+
+    if (this.temporaryAccount && this.temporaryAccount.id === id) {
+      this.temporaryAccount.failed = true
+      this.temporaryAccount.failureReason = reason
       consola.warn(`Account ${id} marked as failed: ${reason}`)
     }
   }
@@ -589,6 +605,8 @@ export class AccountsManager {
       }
     } catch (error) {
       consola.error("Failed to reload registry:", error)
+      this.shutdown()
+      process.exit(1)
     } finally {
       this.isReloading = false
     }

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1,4 +1,5 @@
 import consola from "consola"
+import fs from "node:fs"
 
 import type {
   AccountContext,
@@ -20,9 +21,13 @@ import {
   saveAccountToken,
   addAccountToRegistry,
 } from "./accounts-registry"
+import { PATHS } from "./paths"
 
 /** Quota cache TTL in milliseconds (45 seconds) */
 const QUOTA_CACHE_TTL = 45 * 1000
+
+/** Debounce delay for registry reload in milliseconds */
+const RELOAD_DEBOUNCE_MS = 500
 
 /**
  * Manages multiple GitHub Copilot accounts at runtime.
@@ -33,6 +38,11 @@ export class AccountsManager {
   private accountOrder: Array<string> = []
   private temporaryAccount?: AccountRuntime
   private vsCodeVersion?: string
+
+  // Registry file watcher for hot reload
+  private registryWatcher?: fs.FSWatcher
+  private reloadDebounceTimer?: ReturnType<typeof setTimeout>
+  private isReloading = false
 
   /**
    * Initialize the accounts manager.
@@ -81,6 +91,9 @@ export class AccountsManager {
     }
 
     consola.info(`Loaded ${this.accounts.size} account(s)`)
+
+    // Start watching the registry file for hot reload
+    this.startRegistryWatcher()
   }
 
   /**
@@ -458,9 +471,167 @@ export class AccountsManager {
   }
 
   /**
+   * Start watching the registry file for changes.
+   * Enables hot reload of accounts when the file is modified.
+   */
+  private startRegistryWatcher(): void {
+    // Stop existing watcher if any
+    this.stopRegistryWatcher()
+
+    try {
+      this.registryWatcher = fs.watch(
+        PATHS.ACCOUNTS_REGISTRY_PATH,
+        (eventType) => {
+          // Only react to 'change' events (file content modified)
+          if (eventType === "change") {
+            this.scheduleReload()
+          }
+        },
+      )
+
+      // Handle watcher errors (e.g., file deleted)
+      this.registryWatcher.on("error", (error) => {
+        consola.debug("Registry watcher error:", error)
+        // Try to restart the watcher after a delay
+        setTimeout(() => this.startRegistryWatcher(), 1000)
+      })
+
+      consola.debug("Started registry file watcher")
+    } catch (error) {
+      consola.warn("Failed to start registry watcher:", error)
+    }
+  }
+
+  /**
+   * Schedule a registry reload with debouncing.
+   */
+  private scheduleReload(): void {
+    // Clear existing timer
+    if (this.reloadDebounceTimer) {
+      clearTimeout(this.reloadDebounceTimer)
+    }
+
+    // Schedule reload after debounce delay
+    this.reloadDebounceTimer = setTimeout(() => {
+      void this.reloadRegistry()
+    }, RELOAD_DEBOUNCE_MS)
+  }
+
+  /**
+   * Reload the registry and perform incremental updates.
+   * Only adds new accounts and removes deleted ones.
+   */
+  private async reloadRegistry(): Promise<void> {
+    // Prevent concurrent reloads
+    if (this.isReloading) {
+      return
+    }
+    this.isReloading = true
+
+    try {
+      const newMetas = await listAccountsFromRegistry()
+      const newIds = new Set(newMetas.map((m) => m.id))
+      const currentIds = new Set(this.accountOrder)
+
+      // Track changes for logging
+      const added: Array<string> = []
+      const removed: Array<string> = []
+
+      // 1. Find and remove deleted accounts (currentIds - newIds)
+      for (const id of currentIds) {
+        if (!newIds.has(id)) {
+          const account = this.accounts.get(id)
+          if (account) {
+            this.stopTokenRefresh(account)
+            this.accounts.delete(id)
+            removed.push(id)
+          }
+        }
+      }
+
+      // 2. Find and add new accounts (newIds - currentIds)
+      for (const meta of newMetas) {
+        if (!currentIds.has(meta.id)) {
+          await this.addNewAccount(meta, added)
+        }
+      }
+
+      // 3. Update accountOrder to reflect new order
+      this.accountOrder = newMetas
+        .map((m) => m.id)
+        .filter((id) => this.accounts.has(id))
+
+      // Log changes if any
+      if (added.length > 0 || removed.length > 0) {
+        const changes: Array<string> = []
+        if (added.length > 0) {
+          changes.push(`added: ${added.join(", ")}`)
+        }
+        if (removed.length > 0) {
+          changes.push(`removed: ${removed.join(", ")}`)
+        }
+        consola.info(
+          `Registry reloaded (${changes.join("; ")}). Total: ${this.accounts.size} account(s)`,
+        )
+      }
+    } catch (error) {
+      consola.error("Failed to reload registry:", error)
+    } finally {
+      this.isReloading = false
+    }
+  }
+
+  /**
+   * Helper to add a new account during reload.
+   */
+  private async addNewAccount(
+    meta: { id: string; accountType: AccountType; addedAt: number },
+    added: Array<string>,
+  ): Promise<void> {
+    const token = await loadAccountToken(meta.id)
+    if (!token) {
+      consola.warn(`No token found for new account ${meta.id}, skipping`)
+      return
+    }
+
+    const runtime: AccountRuntime = {
+      ...meta,
+      githubToken: token,
+      vsCodeVersion: this.vsCodeVersion,
+    }
+
+    try {
+      await this.initializeAccount(runtime)
+      this.accounts.set(meta.id, runtime)
+      added.push(meta.id)
+    } catch (error) {
+      consola.error(`Failed to initialize new account ${meta.id}:`, error)
+      runtime.failed = true
+      runtime.failureReason = String(error)
+      this.accounts.set(meta.id, runtime)
+      added.push(`${meta.id} (failed)`)
+    }
+  }
+
+  /**
+   * Stop the registry file watcher.
+   */
+  private stopRegistryWatcher(): void {
+    if (this.reloadDebounceTimer) {
+      clearTimeout(this.reloadDebounceTimer)
+      this.reloadDebounceTimer = undefined
+    }
+    if (this.registryWatcher) {
+      this.registryWatcher.close()
+      this.registryWatcher = undefined
+    }
+  }
+
+  /**
    * Shutdown the manager and clean up resources.
    */
   shutdown(): void {
+    this.stopRegistryWatcher()
     this.stopAllTokenRefresh()
     this.accounts.clear()
     this.accountOrder = []

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -130,7 +130,10 @@ export class AccountsManager {
 
     try {
       // Get user info to determine the account ID
-      const user = await getGitHubUser({ githubToken: token } as AccountContext)
+      const user = await getGitHubUser({
+        githubToken: token,
+        accountType: "individual",
+      })
       const id = user.login
 
       // Save token to new location
@@ -206,9 +209,16 @@ export class AccountsManager {
 
   /**
    * Refresh quota information for an account.
+   * Uses a flag to prevent concurrent refresh calls.
    */
   async refreshQuota(account: AccountRuntime): Promise<void> {
+    // Skip if already refreshing to prevent concurrent API calls
+    if (account.isRefreshingQuota) {
+      return
+    }
+
     try {
+      account.isRefreshingQuota = true
       const ctx = this.toAccountContext(account)
       const usage = await getCopilotUsage(ctx)
       const premium = usage.quota_snapshots.premium_interactions
@@ -226,6 +236,9 @@ export class AccountsManager {
     } catch (error) {
       consola.error(`Failed to refresh quota for ${account.id}:`, error)
       // Don't mark as failed for quota refresh errors
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      account.isRefreshingQuota = false
     }
   }
 

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -37,6 +37,11 @@ const QUOTA_CACHE_TTL = 45 * 1000
 /** Debounce delay for registry reload in milliseconds */
 const RELOAD_DEBOUNCE_MS = 500
 
+/** Registry watcher restart initial delay in milliseconds */
+const WATCHER_RESTART_INITIAL_DELAY_MS = 1000
+/** Registry watcher restart max delay in milliseconds */
+const WATCHER_RESTART_MAX_DELAY_MS = 60 * 1000
+
 export interface AccountRequestCandidate {
   modelId: string
   endpoint: string
@@ -78,6 +83,8 @@ export class AccountsManager {
   // Registry file watcher for hot reload
   private registryWatcher?: fs.FSWatcher
   private reloadDebounceTimer?: ReturnType<typeof setTimeout>
+  private registryWatcherRestartTimer?: ReturnType<typeof setTimeout>
+  private registryWatcherRestartDelayMs = WATCHER_RESTART_INITIAL_DELAY_MS
   private isReloading = false
 
   /**
@@ -207,6 +214,10 @@ export class AccountsManager {
         const { token, refresh_in } = await getCopilotToken(ctx)
         // eslint-disable-next-line require-atomic-updates
         account.copilotToken = token
+        // eslint-disable-next-line require-atomic-updates
+        account.failed = false
+        // eslint-disable-next-line require-atomic-updates
+        account.failureReason = undefined
         consola.debug(`Refreshed token for account ${account.id}`)
 
         // Update the timer with new refresh interval
@@ -709,11 +720,33 @@ export class AccountsManager {
         },
       )
 
+      // Successful start: reset restart backoff.
+      this.registryWatcherRestartDelayMs = WATCHER_RESTART_INITIAL_DELAY_MS
+      if (this.registryWatcherRestartTimer) {
+        clearTimeout(this.registryWatcherRestartTimer)
+        this.registryWatcherRestartTimer = undefined
+      }
+
       // Handle watcher errors (e.g., file deleted)
       this.registryWatcher.on("error", (error) => {
         consola.debug("Registry watcher error:", error)
-        // Try to restart the watcher after a delay
-        setTimeout(() => this.startRegistryWatcher(), 1000)
+
+        const delayMs = this.registryWatcherRestartDelayMs
+        this.registryWatcherRestartDelayMs = Math.min(
+          this.registryWatcherRestartDelayMs * 2,
+          WATCHER_RESTART_MAX_DELAY_MS,
+        )
+
+        // Close broken watcher to avoid repeated error events.
+        this.stopRegistryWatcher()
+
+        // Try to restart the watcher after a delay (with backoff)
+        this.registryWatcherRestartTimer = setTimeout(() => {
+          this.registryWatcherRestartTimer = undefined
+          this.startRegistryWatcher()
+        }, delayMs)
+
+        consola.debug(`Restarting registry watcher in ${delayMs}ms`)
       })
 
       consola.debug("Started registry file watcher")
@@ -739,7 +772,8 @@ export class AccountsManager {
 
   /**
    * Reload the registry and perform incremental updates.
-   * Only adds new accounts and removes deleted ones.
+   * Adds new accounts, removes deleted ones, and reinitializes existing accounts
+   * when token/accountType changes.
    */
   private async reloadRegistry(): Promise<void> {
     // Prevent concurrent reloads
@@ -756,44 +790,26 @@ export class AccountsManager {
       // Track changes for logging
       const added: Array<string> = []
       const removed: Array<string> = []
+      const updated: Array<string> = []
 
-      // 1. Find and remove deleted accounts (currentIds - newIds)
-      for (const id of currentIds) {
-        if (!newIds.has(id)) {
-          const account = this.accounts.get(id)
-          if (account) {
-            this.stopTokenRefresh(account)
-            this.accounts.delete(id)
-            removed.push(id)
-          }
-        }
-      }
+      this.removeDeletedAccounts(currentIds, newIds, removed)
 
-      // 2. Find and add new accounts (newIds - currentIds)
+      // Add new accounts (newIds - currentIds)
       for (const meta of newMetas) {
         if (!currentIds.has(meta.id)) {
           await this.addNewAccount(meta, added)
         }
       }
 
-      // 3. Update accountOrder to reflect new order
+      // Update existing accounts when meta/token changed
+      await this.reinitializeUpdatedAccounts(newMetas, currentIds, updated)
+
+      // Update accountOrder to reflect new order
       this.accountOrder = newMetas
         .map((m) => m.id)
         .filter((id) => this.accounts.has(id))
 
-      // Log changes if any
-      if (added.length > 0 || removed.length > 0) {
-        const changes: Array<string> = []
-        if (added.length > 0) {
-          changes.push(`added: ${added.join(", ")}`)
-        }
-        if (removed.length > 0) {
-          changes.push(`removed: ${removed.join(", ")}`)
-        }
-        consola.info(
-          `Registry reloaded (${changes.join("; ")}). Total: ${this.accounts.size} account(s)`,
-        )
-      }
+      this.logRegistryReloadChanges(added, removed, updated)
     } catch (error) {
       consola.error("Failed to reload registry:", error)
       this.shutdown()
@@ -801,6 +817,105 @@ export class AccountsManager {
     } finally {
       this.isReloading = false
     }
+  }
+
+  private removeDeletedAccounts(
+    currentIds: Set<string>,
+    newIds: Set<string>,
+    removed: Array<string>,
+  ): void {
+    for (const id of currentIds) {
+      if (!newIds.has(id)) {
+        const account = this.accounts.get(id)
+        if (!account) {
+          continue
+        }
+
+        this.stopTokenRefresh(account)
+        this.accounts.delete(id)
+        removed.push(id)
+      }
+    }
+  }
+
+  private async reinitializeUpdatedAccounts(
+    newMetas: Array<{ id: string; accountType: AccountType; addedAt: number }>,
+    currentIds: Set<string>,
+    updated: Array<string>,
+  ): Promise<void> {
+    for (const meta of newMetas) {
+      if (!currentIds.has(meta.id)) {
+        continue
+      }
+
+      const account = this.accounts.get(meta.id)
+      if (!account) {
+        continue
+      }
+
+      const token = await loadAccountToken(meta.id)
+      if (!token) {
+        consola.warn(`No token found for account ${meta.id}, skipping update`)
+        continue
+      }
+
+      const accountTypeChanged = account.accountType !== meta.accountType
+      const tokenChanged = account.githubToken !== token
+      const addedAtChanged = account.addedAt !== meta.addedAt
+
+      // Keep runtime metadata in sync with the registry.
+      if (accountTypeChanged) {
+        account.accountType = meta.accountType
+      }
+      if (addedAtChanged) {
+        account.addedAt = meta.addedAt
+      }
+      if (tokenChanged) {
+        account.githubToken = token
+      }
+
+      if (!accountTypeChanged && !tokenChanged) {
+        continue
+      }
+
+      try {
+        await this.initializeAccount(account)
+        updated.push(meta.id)
+      } catch (error) {
+        consola.error(
+          `Failed to reinitialize account ${meta.id} after update:`,
+          error,
+        )
+        account.failed = true
+        account.failureReason = String(error)
+        updated.push(`${meta.id} (failed)`)
+      }
+    }
+  }
+
+  private logRegistryReloadChanges(
+    added: Array<string>,
+    removed: Array<string>,
+    updated: Array<string>,
+  ): void {
+    if (added.length === 0 && removed.length === 0 && updated.length === 0) {
+      return
+    }
+
+    const changes: Array<string> = []
+    if (added.length > 0) {
+      changes.push(`added: ${added.join(", ")}`)
+    }
+    if (removed.length > 0) {
+      changes.push(`removed: ${removed.join(", ")}`)
+    }
+    if (updated.length > 0) {
+      changes.push(`updated: ${updated.join(", ")}`)
+    }
+
+    consola.info(
+      `Registry reloaded (${changes.join("; ")}). Total: ${this.accounts.size} account(s)`,
+    )
   }
 
   /**
@@ -842,6 +957,10 @@ export class AccountsManager {
     if (this.reloadDebounceTimer) {
       clearTimeout(this.reloadDebounceTimer)
       this.reloadDebounceTimer = undefined
+    }
+    if (this.registryWatcherRestartTimer) {
+      clearTimeout(this.registryWatcherRestartTimer)
+      this.registryWatcherRestartTimer = undefined
     }
     if (this.registryWatcher) {
       this.registryWatcher.close()

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -412,6 +412,40 @@ export class AccountsManager {
   }
 
   /**
+   * Get account context by index.
+   * Index 0 is the temporary account (if exists), otherwise the first registered account.
+   * Returns null if index is out of bounds.
+   */
+  getAccountContextByIndex(index: number): AccountContext | null {
+    // Build the same order as getAccountStatus()
+    const allAccounts: Array<AccountRuntime> = []
+
+    if (this.temporaryAccount) {
+      allAccounts.push(this.temporaryAccount)
+    }
+
+    for (const id of this.accountOrder) {
+      const account = this.accounts.get(id)
+      if (account) {
+        allAccounts.push(account)
+      }
+    }
+
+    if (index < 0 || index >= allAccounts.length) {
+      return null
+    }
+
+    return this.toAccountContext(allAccounts[index])
+  }
+
+  /**
+   * Get the total number of accounts (including temporary).
+   */
+  getAccountCount(): number {
+    return (this.temporaryAccount ? 1 : 0) + this.accountOrder.length
+  }
+
+  /**
    * Convert AccountRuntime to AccountContext for service calls.
    */
   private toAccountContext(account: AccountRuntime): AccountContext {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1,0 +1,438 @@
+import consola from "consola"
+
+import type {
+  AccountContext,
+  AccountRuntime,
+  AccountType,
+} from "~/lib/types/account"
+
+import { getModels } from "~/services/copilot/get-models"
+import { getCopilotToken } from "~/services/github/get-copilot-token"
+import { getCopilotUsage } from "~/services/github/get-copilot-usage"
+import { getGitHubUser } from "~/services/github/get-user"
+
+import {
+  hasLegacyToken,
+  hasRegistry,
+  listAccountsFromRegistry,
+  loadAccountToken,
+  readLegacyToken,
+  saveAccountToken,
+  addAccountToRegistry,
+} from "./accounts-registry"
+
+/** Quota cache TTL in milliseconds (45 seconds) */
+const QUOTA_CACHE_TTL = 45 * 1000
+
+/**
+ * Manages multiple GitHub Copilot accounts at runtime.
+ * Handles account selection, token refresh, and quota management.
+ */
+export class AccountsManager {
+  private accounts: Map<string, AccountRuntime> = new Map()
+  private accountOrder: Array<string> = []
+  private temporaryAccount?: AccountRuntime
+  private vsCodeVersion?: string
+
+  /**
+   * Initialize the accounts manager.
+   * Loads accounts from registry and migrates legacy token if needed.
+   */
+  async initialize(vsCodeVersion?: string): Promise<void> {
+    this.vsCodeVersion = vsCodeVersion
+
+    // Check if we need to migrate legacy token
+    const hasReg = await hasRegistry()
+    const hasLegacy = await hasLegacyToken()
+
+    if (!hasReg && hasLegacy) {
+      await this.migrateLegacyToken()
+    }
+
+    // Load accounts from registry
+    const accountMetas = await listAccountsFromRegistry()
+
+    for (const meta of accountMetas) {
+      const token = await loadAccountToken(meta.id)
+      if (!token) {
+        consola.warn(`No token found for account ${meta.id}, skipping`)
+        continue
+      }
+
+      const runtime: AccountRuntime = {
+        ...meta,
+        githubToken: token,
+        vsCodeVersion: this.vsCodeVersion,
+      }
+
+      this.accounts.set(meta.id, runtime)
+      this.accountOrder.push(meta.id)
+    }
+
+    // Initialize Copilot tokens for all accounts
+    for (const account of this.accounts.values()) {
+      try {
+        await this.initializeAccount(account)
+      } catch (error) {
+        consola.error(`Failed to initialize account ${account.id}:`, error)
+        account.failed = true
+        account.failureReason = String(error)
+      }
+    }
+
+    consola.info(`Loaded ${this.accounts.size} account(s)`)
+  }
+
+  /**
+   * Initialize a single account: get Copilot token and start refresh timer.
+   */
+  private async initializeAccount(account: AccountRuntime): Promise<void> {
+    const ctx = this.toAccountContext(account)
+
+    // Get Copilot token
+    const { token, refresh_in } = await getCopilotToken(ctx)
+    // eslint-disable-next-line require-atomic-updates
+    account.copilotToken = token
+
+    // Start token refresh timer
+    this.startTokenRefresh(account, refresh_in)
+
+    // Get models
+    const updatedCtx = this.toAccountContext(account)
+    // eslint-disable-next-line require-atomic-updates
+    account.models = await getModels(updatedCtx)
+
+    // Refresh quota
+    await this.refreshQuota(account)
+
+    consola.debug(`Account ${account.id} initialized`)
+  }
+
+  /**
+   * Migrate legacy github_token to the new multi-account system.
+   */
+  private async migrateLegacyToken(): Promise<void> {
+    const token = await readLegacyToken()
+    if (!token) return
+
+    try {
+      // Get user info to determine the account ID
+      const user = await getGitHubUser({ githubToken: token } as AccountContext)
+      const id = user.login
+
+      // Save token to new location
+      await saveAccountToken(id, token)
+
+      // Add to registry
+      await addAccountToRegistry({
+        id,
+        accountType: "individual",
+        addedAt: Date.now(),
+      })
+
+      consola.info(`Migrated legacy token to account: ${id}`)
+    } catch (error) {
+      consola.error("Failed to migrate legacy token:", error)
+    }
+  }
+
+  /**
+   * Start token refresh timer for an account.
+   */
+  private startTokenRefresh(
+    account: AccountRuntime,
+    refreshInSeconds: number,
+  ): void {
+    // Stop existing timer if any
+    this.stopTokenRefresh(account)
+
+    // Refresh 60 seconds before expiration
+    const intervalMs = (refreshInSeconds - 60) * 1000
+
+    account.refreshTimer = setInterval(async () => {
+      try {
+        const ctx = this.toAccountContext(account)
+        const { token, refresh_in } = await getCopilotToken(ctx)
+        // eslint-disable-next-line require-atomic-updates
+        account.copilotToken = token
+        consola.debug(`Refreshed token for account ${account.id}`)
+
+        // Update the timer with new refresh interval
+        this.startTokenRefresh(account, refresh_in)
+      } catch (error) {
+        consola.error(`Failed to refresh token for ${account.id}:`, error)
+
+        account.failed = true
+
+        account.failureReason = String(error)
+      }
+    }, intervalMs)
+  }
+
+  /**
+   * Stop token refresh timer for an account.
+   */
+  private stopTokenRefresh(account: AccountRuntime): void {
+    if (account.refreshTimer) {
+      clearInterval(account.refreshTimer)
+      account.refreshTimer = undefined
+    }
+  }
+
+  /**
+   * Stop all token refresh timers.
+   */
+  private stopAllTokenRefresh(): void {
+    for (const account of this.accounts.values()) {
+      this.stopTokenRefresh(account)
+    }
+    if (this.temporaryAccount) {
+      this.stopTokenRefresh(this.temporaryAccount)
+    }
+  }
+
+  /**
+   * Refresh quota information for an account.
+   */
+  async refreshQuota(account: AccountRuntime): Promise<void> {
+    try {
+      const ctx = this.toAccountContext(account)
+      const usage = await getCopilotUsage(ctx)
+      const premium = usage.quota_snapshots.premium_interactions
+
+      // eslint-disable-next-line require-atomic-updates
+      account.premiumRemaining = premium.remaining
+      // eslint-disable-next-line require-atomic-updates
+      account.unlimited = premium.unlimited
+      // eslint-disable-next-line require-atomic-updates
+      account.lastQuotaFetch = Date.now()
+      // eslint-disable-next-line require-atomic-updates
+      account.failed = false
+      // eslint-disable-next-line require-atomic-updates
+      account.failureReason = undefined
+    } catch (error) {
+      consola.error(`Failed to refresh quota for ${account.id}:`, error)
+      // Don't mark as failed for quota refresh errors
+    }
+  }
+
+  /**
+   * Check if quota cache is expired.
+   */
+  private isQuotaCacheExpired(account: AccountRuntime): boolean {
+    if (!account.lastQuotaFetch) return true
+    return Date.now() - account.lastQuotaFetch > QUOTA_CACHE_TTL
+  }
+
+  /**
+   * Select an available account based on quota.
+   * Returns null if all accounts are exhausted.
+   */
+  // eslint-disable-next-line complexity
+  async selectAccount(): Promise<AccountRuntime | null> {
+    // Check temporary account first (--github-token)
+    if (this.temporaryAccount && !this.temporaryAccount.failed) {
+      if (this.temporaryAccount.unlimited) {
+        return this.temporaryAccount
+      }
+
+      if (this.isQuotaCacheExpired(this.temporaryAccount)) {
+        await this.refreshQuota(this.temporaryAccount)
+      }
+
+      if (
+        this.temporaryAccount.premiumRemaining === undefined
+        || this.temporaryAccount.premiumRemaining > 0
+      ) {
+        // Optimistic decrement
+        if (this.temporaryAccount.premiumRemaining !== undefined) {
+          this.temporaryAccount.premiumRemaining--
+        }
+        return this.temporaryAccount
+      }
+    }
+
+    // Check registered accounts in order
+    for (const id of this.accountOrder) {
+      const account = this.accounts.get(id)
+      if (!account || account.failed) continue
+
+      // Unlimited accounts are always available
+      if (account.unlimited) {
+        return account
+      }
+
+      // Refresh quota if cache is expired
+      if (this.isQuotaCacheExpired(account)) {
+        try {
+          await this.refreshQuota(account)
+        } catch (error) {
+          // If quota refresh fails with 401, mark account as failed
+          if (error instanceof Error && error.message.includes("401")) {
+            this.markAccountFailed(id, "Unauthorized (401)")
+            continue
+          }
+        }
+      }
+
+      // Check if account has remaining quota
+      if (
+        account.premiumRemaining === undefined
+        || account.premiumRemaining > 0
+      ) {
+        // Optimistic decrement
+        if (account.premiumRemaining !== undefined) {
+          account.premiumRemaining--
+        }
+        return account
+      }
+    }
+
+    return null
+  }
+
+  /**
+   * Finalize quota after a request completes.
+   * This refreshes the actual quota from the API.
+   */
+  async finalizeQuota(account: AccountRuntime): Promise<void> {
+    try {
+      await this.refreshQuota(account)
+    } catch (error) {
+      consola.debug(`Failed to finalize quota for ${account.id}:`, error)
+    }
+  }
+
+  /**
+   * Mark an account as failed.
+   */
+  markAccountFailed(id: string, reason: string): void {
+    const account = this.accounts.get(id)
+    if (account) {
+      account.failed = true
+      account.failureReason = reason
+      consola.warn(`Account ${id} marked as failed: ${reason}`)
+    }
+  }
+
+  /**
+   * Get status of all accounts.
+   */
+  getAccountStatus(): Array<{
+    id: string
+    remaining?: number
+    unlimited?: boolean
+    failed?: boolean
+    failureReason?: string
+  }> {
+    const statuses: Array<{
+      id: string
+      remaining?: number
+      unlimited?: boolean
+      failed?: boolean
+      failureReason?: string
+    }> = []
+
+    if (this.temporaryAccount) {
+      statuses.push({
+        id: "(temporary)",
+        remaining: this.temporaryAccount.premiumRemaining,
+        unlimited: this.temporaryAccount.unlimited,
+        failed: this.temporaryAccount.failed,
+        failureReason: this.temporaryAccount.failureReason,
+      })
+    }
+
+    for (const id of this.accountOrder) {
+      const account = this.accounts.get(id)
+      if (account) {
+        statuses.push({
+          id: account.id,
+          remaining: account.premiumRemaining,
+          unlimited: account.unlimited,
+          failed: account.failed,
+          failureReason: account.failureReason,
+        })
+      }
+    }
+
+    return statuses
+  }
+
+  /**
+   * Set a temporary account from a GitHub token (--github-token).
+   * This account takes priority over registered accounts.
+   */
+  async setTemporaryAccount(
+    githubToken: string,
+    accountType: AccountType,
+  ): Promise<void> {
+    const runtime: AccountRuntime = {
+      id: "(temporary)",
+      accountType,
+      addedAt: Date.now(),
+      githubToken,
+      vsCodeVersion: this.vsCodeVersion,
+    }
+
+    try {
+      await this.initializeAccount(runtime)
+      this.temporaryAccount = runtime
+      consola.info("Temporary account initialized")
+    } catch (error) {
+      consola.error("Failed to initialize temporary account:", error)
+      throw error
+    }
+  }
+
+  /**
+   * Check if any accounts are available.
+   */
+  hasAccounts(): boolean {
+    return this.accounts.size > 0 || this.temporaryAccount !== undefined
+  }
+
+  /**
+   * Get the first available account's models.
+   * Used for caching models in legacy compatibility mode.
+   */
+  getFirstAccountModels(): AccountRuntime["models"] {
+    if (this.temporaryAccount?.models) {
+      return this.temporaryAccount.models
+    }
+
+    for (const id of this.accountOrder) {
+      const account = this.accounts.get(id)
+      if (account?.models) {
+        return account.models
+      }
+    }
+
+    return undefined
+  }
+
+  /**
+   * Convert AccountRuntime to AccountContext for service calls.
+   */
+  private toAccountContext(account: AccountRuntime): AccountContext {
+    return {
+      githubToken: account.githubToken,
+      copilotToken: account.copilotToken,
+      accountType: account.accountType,
+      vsCodeVersion: account.vsCodeVersion,
+    }
+  }
+
+  /**
+   * Shutdown the manager and clean up resources.
+   */
+  shutdown(): void {
+    this.stopAllTokenRefresh()
+    this.accounts.clear()
+    this.accountOrder = []
+    this.temporaryAccount = undefined
+  }
+}
+
+/** Singleton instance of AccountsManager */
+export const accountsManager = new AccountsManager()

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -24,7 +24,14 @@ import {
 } from "./accounts-registry"
 import { PATHS } from "./paths"
 
-/** Quota cache TTL in milliseconds (45 seconds) */
+/**
+ * Quota cache TTL in milliseconds (45 seconds).
+ *
+ * This TTL only applies to the cached quota used during the pre-request
+ * check in `selectAccountForRequest`. After a request completes,
+ * `finalizeQuota` calls `refreshQuota`, which always fetches the latest
+ * quota from the API, effectively bypassing this TTL for active accounts.
+ */
 const QUOTA_CACHE_TTL = 45 * 1000
 
 /** Debounce delay for registry reload in milliseconds */
@@ -192,7 +199,7 @@ export class AccountsManager {
     this.stopTokenRefresh(account)
 
     // Refresh 60 seconds before expiration
-    const intervalMs = (refreshInSeconds - 60) * 1000
+    const intervalMs = Math.max((refreshInSeconds - 60) * 1000, 1000)
 
     account.refreshTimer = setInterval(async () => {
       try {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -8,7 +8,7 @@ import type {
 } from "~/lib/types/account"
 
 import { HTTPError } from "~/lib/error"
-import { getModels } from "~/services/copilot/get-models"
+import { getModels, type Model } from "~/services/copilot/get-models"
 import { getCopilotToken } from "~/services/github/get-copilot-token"
 import { getCopilotUsage } from "~/services/github/get-copilot-usage"
 import { getGitHubUser } from "~/services/github/get-user"
@@ -29,6 +29,34 @@ const QUOTA_CACHE_TTL = 45 * 1000
 
 /** Debounce delay for registry reload in milliseconds */
 const RELOAD_DEBOUNCE_MS = 500
+
+export interface AccountRequestCandidate {
+  modelId: string
+  endpoint: string
+}
+
+export interface QuotaReservation {
+  id: symbol
+}
+
+export type SelectAccountForRequestFailureReason =
+  | "NO_ACCOUNTS"
+  | "MODEL_NOT_SUPPORTED"
+  | "NO_QUOTA"
+
+export type SelectAccountForRequestResult =
+  | {
+      ok: true
+      account: AccountRuntime
+      selectedModel: Model
+      endpoint: string
+      costUnits: number
+      reservation?: QuotaReservation
+    }
+  | {
+      ok: false
+      reason: SelectAccountForRequestFailureReason
+    }
 
 /**
  * Manages multiple GitHub Copilot accounts at runtime.
@@ -213,39 +241,47 @@ export class AccountsManager {
    * Uses a flag to prevent concurrent refresh calls.
    */
   async refreshQuota(account: AccountRuntime): Promise<void> {
-    // Skip if already refreshing to prevent concurrent API calls
-    if (account.isRefreshingQuota) {
+    if (account.quotaRefreshPromise) {
+      await account.quotaRefreshPromise
       return
     }
 
-    try {
-      account.isRefreshingQuota = true
-      const ctx = this.toAccountContext(account)
-      const usage = await getCopilotUsage(ctx)
-      const premium = usage.quota_snapshots.premium_interactions
+    const promise = (async () => {
+      try {
+        const ctx = this.toAccountContext(account)
+        const usage = await getCopilotUsage(ctx)
+        const premium = usage.quota_snapshots.premium_interactions
 
-      // eslint-disable-next-line require-atomic-updates
-      account.premiumRemaining = premium.remaining
-      // eslint-disable-next-line require-atomic-updates
-      account.unlimited = premium.unlimited
-      // eslint-disable-next-line require-atomic-updates
-      account.lastQuotaFetch = Date.now()
-      // eslint-disable-next-line require-atomic-updates
-      account.failed = false
-      // eslint-disable-next-line require-atomic-updates
-      account.failureReason = undefined
-    } catch (error) {
-      if (error instanceof HTTPError && error.response.status === 401) {
-        this.markAccountFailed(account.id, "Unauthorized (401)")
-        return
+        // eslint-disable-next-line require-atomic-updates
+        account.premiumRemaining = premium.remaining
+        // eslint-disable-next-line require-atomic-updates
+        account.unlimited = premium.unlimited
+        // eslint-disable-next-line require-atomic-updates
+        account.lastQuotaFetch = Date.now()
+        // eslint-disable-next-line require-atomic-updates
+        account.failed = false
+        // eslint-disable-next-line require-atomic-updates
+        account.failureReason = undefined
+      } catch (error) {
+        if (error instanceof HTTPError && error.response.status === 401) {
+          this.markAccountFailed(account.id, "Unauthorized (401)")
+          return
+        }
+
+        consola.error(`Failed to refresh quota for ${account.id}:`, error)
+        // Don't mark as failed for non-401 quota refresh errors
+      } finally {
+        // eslint-disable-next-line require-atomic-updates
+        account.isRefreshingQuota = false
+        // eslint-disable-next-line require-atomic-updates
+        account.quotaRefreshPromise = undefined
       }
+    })()
 
-      consola.error(`Failed to refresh quota for ${account.id}:`, error)
-      // Don't mark as failed for non-401 quota refresh errors
-    } finally {
-      // eslint-disable-next-line require-atomic-updates
-      account.isRefreshingQuota = false
-    }
+    account.isRefreshingQuota = true
+    account.quotaRefreshPromise = promise
+
+    await promise
   }
 
   /**
@@ -260,77 +296,225 @@ export class AccountsManager {
     return account.failed === true
   }
 
-  /**
-   * Select an available account based on quota.
-   * Returns null if all accounts are exhausted.
-   */
-  // eslint-disable-next-line complexity
-  async selectAccount(): Promise<AccountRuntime | null> {
-    const tempAccount = this.temporaryAccount
-
-    // Check temporary account first (--github-token)
-    if (tempAccount && !this.isAccountFailed(tempAccount)) {
-      if (tempAccount.unlimited) {
-        return tempAccount
-      }
-
-      if (this.isQuotaCacheExpired(tempAccount)) {
-        await this.refreshQuota(tempAccount)
-      }
-
-      const hasQuota =
-        tempAccount.premiumRemaining === undefined
-        || tempAccount.premiumRemaining > 0
-
-      // refreshQuota may mark the account as failed (e.g., 401)
-      if (!this.isAccountFailed(tempAccount) && hasQuota) {
-        // Optimistic decrement
-        if (tempAccount.premiumRemaining !== undefined) {
-          tempAccount.premiumRemaining--
-        }
-        return tempAccount
-      }
+  private isModelSupportedForEndpoint(model: Model, endpoint: string): boolean {
+    if (endpoint === "/responses") {
+      return model.supported_endpoints?.includes(endpoint) ?? false
     }
 
-    // Check registered accounts in order
-    for (const id of this.accountOrder) {
-      const account = this.accounts.get(id)
-      if (!account || this.isAccountFailed(account)) continue
+    const supported = model.supported_endpoints
+    if (!supported) {
+      return true
+    }
 
-      // Unlimited accounts are always available
-      if (account.unlimited) {
-        return account
+    return supported.includes(endpoint)
+  }
+
+  private getCostUnits(model: Model): number {
+    // Per user decision: missing billing => treat as free (costUnits = 0)
+    const billing = model.billing
+    if (!billing) {
+      return 0
+    }
+
+    if (billing.is_premium !== true) {
+      return 0
+    }
+
+    const multiplier = billing.multiplier
+    if (
+      typeof multiplier !== "number"
+      || !Number.isFinite(multiplier)
+      || multiplier <= 0
+    ) {
+      return 1
+    }
+
+    return multiplier
+  }
+
+  private getEffectivePremiumRemaining(
+    account: AccountRuntime,
+  ): number | undefined {
+    if (account.premiumRemaining === undefined) {
+      return undefined
+    }
+
+    const reserved = account.premiumReserved ?? 0
+    return account.premiumRemaining - reserved
+  }
+
+  private reservePremiumUnits(
+    account: AccountRuntime,
+    units: number,
+  ): QuotaReservation | undefined {
+    if (units <= 0) {
+      return undefined
+    }
+
+    const id = Symbol("quotaReservation")
+
+    if (!account.premiumReservations) {
+      account.premiumReservations = new Map()
+    }
+
+    account.premiumReservations.set(id, units)
+    account.premiumReserved = (account.premiumReserved ?? 0) + units
+
+    return { id }
+  }
+
+  private releasePremiumReservation(
+    account: AccountRuntime,
+    reservation?: QuotaReservation,
+  ): void {
+    if (!reservation) {
+      return
+    }
+
+    const reservations = account.premiumReservations
+    if (!reservations) {
+      return
+    }
+
+    const reservedUnits = reservations.get(reservation.id)
+    if (reservedUnits === undefined) {
+      return
+    }
+
+    reservations.delete(reservation.id)
+
+    const nextReserved = (account.premiumReserved ?? 0) - reservedUnits
+    account.premiumReserved = Math.max(0, nextReserved)
+
+    if (reservations.size === 0) {
+      account.premiumReservations = undefined
+    }
+  }
+
+  private pickSupportedCandidate(
+    account: AccountRuntime,
+    candidates: Array<AccountRequestCandidate>,
+  ): { candidate: AccountRequestCandidate; model: Model } | null {
+    const models = account.models?.data
+    if (!models) {
+      return null
+    }
+
+    for (const candidate of candidates) {
+      const model = models.find((m) => m.id === candidate.modelId)
+      if (!model) {
+        continue
       }
 
-      // Refresh quota if cache is expired
-      if (this.isQuotaCacheExpired(account)) {
-        await this.refreshQuota(account)
-        if (this.isAccountFailed(account)) {
-          continue
-        }
+      if (!this.isModelSupportedForEndpoint(model, candidate.endpoint)) {
+        continue
       }
 
-      // Check if account has remaining quota
-      if (
-        account.premiumRemaining === undefined
-        || account.premiumRemaining > 0
-      ) {
-        // Optimistic decrement
-        if (account.premiumRemaining !== undefined) {
-          account.premiumRemaining--
-        }
-        return account
-      }
+      return { candidate, model }
     }
 
     return null
   }
 
   /**
-   * Finalize quota after a request completes.
-   * This refreshes the actual quota from the API.
+   * Select an available account for a specific request (model + endpoint).
+   * Uses reservation to avoid oversubscribing premium quota under concurrency.
    */
-  async finalizeQuota(account: AccountRuntime): Promise<void> {
+  // eslint-disable-next-line complexity
+  async selectAccountForRequest(
+    candidates: Array<AccountRequestCandidate>,
+  ): Promise<SelectAccountForRequestResult> {
+    if (candidates.length === 0) {
+      throw new Error("selectAccountForRequest requires at least one candidate")
+    }
+
+    const orderedAccounts: Array<AccountRuntime> = []
+
+    if (this.temporaryAccount) {
+      orderedAccounts.push(this.temporaryAccount)
+    }
+
+    for (const id of this.accountOrder) {
+      const account = this.accounts.get(id)
+      if (account) {
+        orderedAccounts.push(account)
+      }
+    }
+
+    if (orderedAccounts.length === 0) {
+      return { ok: false, reason: "NO_ACCOUNTS" }
+    }
+
+    let supportedCandidateFound = false
+
+    for (const account of orderedAccounts) {
+      if (this.isAccountFailed(account)) {
+        continue
+      }
+
+      const supported = this.pickSupportedCandidate(account, candidates)
+      if (!supported) {
+        continue
+      }
+
+      supportedCandidateFound = true
+
+      const { candidate, model } = supported
+
+      if (!account.unlimited && this.isQuotaCacheExpired(account)) {
+        await this.refreshQuota(account)
+      }
+
+      if (this.isAccountFailed(account)) {
+        continue
+      }
+
+      const costUnits = this.getCostUnits(model)
+
+      if (account.unlimited || costUnits <= 0) {
+        return {
+          ok: true,
+          account,
+          selectedModel: model,
+          endpoint: candidate.endpoint,
+          costUnits,
+        }
+      }
+
+      const effectiveRemaining = this.getEffectivePremiumRemaining(account)
+      if (effectiveRemaining !== undefined && effectiveRemaining < costUnits) {
+        continue
+      }
+
+      const reservation = this.reservePremiumUnits(account, costUnits)
+
+      return {
+        ok: true,
+        account,
+        selectedModel: model,
+        endpoint: candidate.endpoint,
+        costUnits,
+        reservation,
+      }
+    }
+
+    if (!supportedCandidateFound) {
+      return { ok: false, reason: "MODEL_NOT_SUPPORTED" }
+    }
+
+    return { ok: false, reason: "NO_QUOTA" }
+  }
+
+  /**
+   * Finalize quota after a request completes.
+   * This releases any in-flight reservation and refreshes the actual quota from the API.
+   */
+  async finalizeQuota(
+    account: AccountRuntime,
+    reservation?: QuotaReservation,
+  ): Promise<void> {
+    this.releasePremiumReservation(account, reservation)
+
     try {
       await this.refreshQuota(account)
     } catch (error) {

--- a/src/lib/accounts-registry.ts
+++ b/src/lib/accounts-registry.ts
@@ -1,18 +1,39 @@
 import fs from "node:fs/promises"
+import { z } from "zod"
 
 import type { AccountMeta, AccountRegistry } from "~/lib/types/account"
 
 import { accountTokenPath, PATHS } from "./paths"
 
 /**
- * Validate account ID to prevent path traversal attacks.
- * Only allows alphanumeric characters, hyphens, and underscores.
+ * Validate account ID (GitHub login).
+ * Rules:
+ * - Only alphanumeric characters or single hyphens
+ * - 1-39 chars
+ * - Cannot begin or end with a hyphen
+ * - No consecutive hyphens
  */
 export function validateAccountId(id: string): boolean {
-  // GitHub usernames: alphanumeric and hyphens, 1-39 chars, no consecutive hyphens
-  // We're a bit more permissive here to handle edge cases
-  return /^[a-z0-9][-\w]{0,38}$/i.test(id)
+  if (id.length === 0 || id.length > 39) return false
+  if (!/^[a-z0-9-]+$/i.test(id)) return false
+  if (id.startsWith("-") || id.endsWith("-")) return false
+  if (id.includes("--")) return false
+  return true
 }
+
+const accountMetaSchema = z.object({
+  id: z.string().refine(validateAccountId, {
+    message:
+      "Invalid account id. Expected a GitHub login (1-39 chars, alphanumeric or single hyphens, no leading/trailing hyphen, no consecutive hyphens).",
+  }),
+  accountType: z.enum(["individual", "business", "enterprise"]),
+  addedAt: z.number(),
+})
+
+const accountRegistrySchema = z.object({
+  version: z.literal(1),
+  accounts: z.array(accountMetaSchema),
+})
 
 /**
  * Create an empty registry with the current schema version.
@@ -34,12 +55,41 @@ export async function loadRegistry(): Promise<AccountRegistry> {
     if (!content.trim()) {
       return createEmptyRegistry()
     }
-    const registry = JSON.parse(content) as AccountRegistry
-    // Validate version (type assertion for future-proofing)
-    const version = registry.version as number
-    if (version !== 1) {
-      throw new Error(`Unsupported registry version: ${version}`)
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(content) as unknown
+    } catch (error) {
+      throw new Error(
+        `Invalid accounts registry JSON at ${PATHS.ACCOUNTS_REGISTRY_PATH}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
     }
+
+    const result = accountRegistrySchema.safeParse(parsed)
+    if (!result.success) {
+      const issues = result.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ")
+
+      throw new Error(
+        `Invalid accounts registry at ${PATHS.ACCOUNTS_REGISTRY_PATH}: ${issues}`,
+      )
+    }
+
+    const registry = result.data
+
+    const seen = new Set<string>()
+    for (const account of registry.accounts) {
+      if (seen.has(account.id)) {
+        throw new Error(
+          `Invalid accounts registry at ${PATHS.ACCOUNTS_REGISTRY_PATH}: duplicate account id "${account.id}"`,
+        )
+      }
+      seen.add(account.id)
+    }
+
     return registry
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -197,10 +247,6 @@ export async function readLegacyToken(): Promise<string | null> {
  * Check if the registry file exists and has accounts.
  */
 export async function hasRegistry(): Promise<boolean> {
-  try {
-    const registry = await loadRegistry()
-    return registry.accounts.length > 0
-  } catch {
-    return false
-  }
+  const registry = await loadRegistry()
+  return registry.accounts.length > 0
 }

--- a/src/lib/accounts-registry.ts
+++ b/src/lib/accounts-registry.ts
@@ -1,0 +1,206 @@
+import fs from "node:fs/promises"
+
+import type { AccountMeta, AccountRegistry } from "~/lib/types/account"
+
+import { accountTokenPath, PATHS } from "./paths"
+
+/**
+ * Validate account ID to prevent path traversal attacks.
+ * Only allows alphanumeric characters, hyphens, and underscores.
+ */
+export function validateAccountId(id: string): boolean {
+  // GitHub usernames: alphanumeric and hyphens, 1-39 chars, no consecutive hyphens
+  // We're a bit more permissive here to handle edge cases
+  return /^[a-z0-9][-\w]{0,38}$/i.test(id)
+}
+
+/**
+ * Create an empty registry with the current schema version.
+ */
+function createEmptyRegistry(): AccountRegistry {
+  return {
+    version: 1,
+    accounts: [],
+  }
+}
+
+/**
+ * Load the accounts registry from disk.
+ * Returns an empty registry if the file doesn't exist.
+ */
+export async function loadRegistry(): Promise<AccountRegistry> {
+  try {
+    const content = await fs.readFile(PATHS.ACCOUNTS_REGISTRY_PATH, "utf8")
+    if (!content.trim()) {
+      return createEmptyRegistry()
+    }
+    const registry = JSON.parse(content) as AccountRegistry
+    // Validate version (type assertion for future-proofing)
+    const version = registry.version as number
+    if (version !== 1) {
+      throw new Error(`Unsupported registry version: ${version}`)
+    }
+    return registry
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return createEmptyRegistry()
+    }
+    throw error
+  }
+}
+
+/**
+ * Save the accounts registry to disk with secure permissions.
+ */
+export async function saveRegistry(registry: AccountRegistry): Promise<void> {
+  const content = JSON.stringify(registry, null, 2)
+  await fs.writeFile(PATHS.ACCOUNTS_REGISTRY_PATH, content, { mode: 0o600 })
+}
+
+/**
+ * Add an account to the registry.
+ * The account is appended to the end of the list (lowest priority).
+ */
+export async function addAccountToRegistry(meta: AccountMeta): Promise<void> {
+  if (!validateAccountId(meta.id)) {
+    throw new Error(`Invalid account ID: ${meta.id}`)
+  }
+
+  const registry = await loadRegistry()
+
+  // Check for duplicate
+  if (registry.accounts.some((a) => a.id === meta.id)) {
+    throw new Error(`Account already exists: ${meta.id}`)
+  }
+
+  registry.accounts.push(meta)
+  await saveRegistry(registry)
+}
+
+/**
+ * Remove an account from the registry by ID or index (1-based).
+ * Returns the removed account metadata.
+ */
+export async function removeAccountFromRegistry(
+  idOrIndex: string | number,
+): Promise<AccountMeta> {
+  const registry = await loadRegistry()
+  let index: number
+
+  if (typeof idOrIndex === "number") {
+    // 1-based index
+    index = idOrIndex - 1
+    if (index < 0 || index >= registry.accounts.length) {
+      throw new Error(`Invalid account index: ${idOrIndex}`)
+    }
+  } else {
+    index = registry.accounts.findIndex((a) => a.id === idOrIndex)
+    if (index === -1) {
+      throw new Error(`Account not found: ${idOrIndex}`)
+    }
+  }
+
+  const [removed] = registry.accounts.splice(index, 1)
+  await saveRegistry(registry)
+  return removed
+}
+
+/**
+ * List all accounts from the registry.
+ */
+export async function listAccountsFromRegistry(): Promise<Array<AccountMeta>> {
+  const registry = await loadRegistry()
+  return registry.accounts
+}
+
+/**
+ * Load the GitHub token for a specific account.
+ * Returns null if the token file doesn't exist.
+ */
+export async function loadAccountToken(id: string): Promise<string | null> {
+  if (!validateAccountId(id)) {
+    throw new Error(`Invalid account ID: ${id}`)
+  }
+
+  try {
+    const tokenPath = accountTokenPath(id)
+    const token = await fs.readFile(tokenPath, "utf8")
+    return token.trim() || null
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null
+    }
+    throw error
+  }
+}
+
+/**
+ * Save the GitHub token for a specific account with secure permissions.
+ */
+export async function saveAccountToken(
+  id: string,
+  token: string,
+): Promise<void> {
+  if (!validateAccountId(id)) {
+    throw new Error(`Invalid account ID: ${id}`)
+  }
+
+  const tokenPath = accountTokenPath(id)
+  await fs.writeFile(tokenPath, token, { mode: 0o600 })
+}
+
+/**
+ * Remove the GitHub token file for a specific account.
+ */
+export async function removeAccountToken(id: string): Promise<void> {
+  if (!validateAccountId(id)) {
+    throw new Error(`Invalid account ID: ${id}`)
+  }
+
+  const tokenPath = accountTokenPath(id)
+  try {
+    await fs.unlink(tokenPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error
+    }
+    // File doesn't exist, nothing to remove
+  }
+}
+
+/**
+ * Check if the legacy github_token file exists.
+ */
+export async function hasLegacyToken(): Promise<boolean> {
+  try {
+    const content = await fs.readFile(PATHS.GITHUB_TOKEN_PATH, "utf8")
+    return content.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Read the legacy github_token file.
+ * Returns null if the file doesn't exist or is empty.
+ */
+export async function readLegacyToken(): Promise<string | null> {
+  try {
+    const content = await fs.readFile(PATHS.GITHUB_TOKEN_PATH, "utf8")
+    return content.trim() || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check if the registry file exists and has accounts.
+ */
+export async function hasRegistry(): Promise<boolean> {
+  try {
+    const registry = await loadRegistry()
+    return registry.accounts.length > 0
+  } catch {
+    return false
+  }
+}

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto"
 
-import type { State } from "./state"
+import type { AccountContext } from "./types/account"
 
 export const standardHeaders = () => ({
   "content-type": "application/json",
@@ -13,15 +13,18 @@ const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 
 const API_VERSION = "2025-10-01"
 
-export const copilotBaseUrl = (state: State) =>
-  `https://api.${state.accountType}.githubcopilot.com`
+export const copilotBaseUrl = (account: AccountContext) =>
+  `https://api.${account.accountType}.githubcopilot.com`
 
-export const copilotHeaders = (state: State, vision: boolean = false) => {
+export const copilotHeaders = (
+  account: AccountContext,
+  vision: boolean = false,
+) => {
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${state.copilotToken}`,
+    Authorization: `Bearer ${account.copilotToken}`,
     "content-type": standardHeaders()["content-type"],
     "copilot-integration-id": "vscode-chat",
-    "editor-version": `vscode/${state.vsCodeVersion}`,
+    "editor-version": `vscode/${account.vsCodeVersion}`,
     "editor-plugin-version": EDITOR_PLUGIN_VERSION,
     "user-agent": USER_AGENT,
     "openai-intent": "conversation-agent",
@@ -36,10 +39,10 @@ export const copilotHeaders = (state: State, vision: boolean = false) => {
 }
 
 export const GITHUB_API_BASE_URL = "https://api.github.com"
-export const githubHeaders = (state: State) => ({
+export const githubHeaders = (account: AccountContext) => ({
   ...standardHeaders(),
-  authorization: `token ${state.githubToken}`,
-  "editor-version": `vscode/${state.vsCodeVersion}`,
+  authorization: `token ${account.githubToken}`,
+  "editor-version": `vscode/${account.vsCodeVersion}`,
   "editor-plugin-version": EDITOR_PLUGIN_VERSION,
   "user-agent": USER_AGENT,
   "x-github-api-version": API_VERSION,

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -6,6 +6,7 @@ const APP_DIR = path.join(os.homedir(), ".local", "share", "copilot-api")
 
 const GITHUB_TOKEN_PATH = path.join(APP_DIR, "github_token")
 const CONFIG_PATH = path.join(APP_DIR, "config.json")
+const MODELS_PATH = path.join(APP_DIR, "models.json")
 
 // Multi-account paths
 const TOKENS_DIR = path.join(APP_DIR, "tokens")
@@ -15,6 +16,7 @@ export const PATHS = {
   APP_DIR,
   GITHUB_TOKEN_PATH,
   CONFIG_PATH,
+  MODELS_PATH,
   TOKENS_DIR,
   ACCOUNTS_REGISTRY_PATH,
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -7,14 +7,30 @@ const APP_DIR = path.join(os.homedir(), ".local", "share", "copilot-api")
 const GITHUB_TOKEN_PATH = path.join(APP_DIR, "github_token")
 const CONFIG_PATH = path.join(APP_DIR, "config.json")
 
+// Multi-account paths
+const TOKENS_DIR = path.join(APP_DIR, "tokens")
+const ACCOUNTS_REGISTRY_PATH = path.join(APP_DIR, "accounts-registry.json")
+
 export const PATHS = {
   APP_DIR,
   GITHUB_TOKEN_PATH,
   CONFIG_PATH,
+  TOKENS_DIR,
+  ACCOUNTS_REGISTRY_PATH,
+}
+
+/**
+ * Get the token file path for a specific account.
+ * @param id - The account ID (GitHub login)
+ * @returns The absolute path to the account's token file
+ */
+export function accountTokenPath(id: string): string {
+  return path.join(TOKENS_DIR, `github_${id}`)
 }
 
 export async function ensurePaths(): Promise<void> {
   await fs.mkdir(PATHS.APP_DIR, { recursive: true })
+  await fs.mkdir(PATHS.TOKENS_DIR, { recursive: true })
   await ensureFile(PATHS.GITHUB_TOKEN_PATH)
   await ensureFile(PATHS.CONFIG_PATH)
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,10 +1,12 @@
 import type { ModelsResponse } from "~/services/copilot/get-models"
 
+import type { AccountContext, AccountType } from "./types/account"
+
 export interface State {
   githubToken?: string
   copilotToken?: string
 
-  accountType: string
+  accountType: AccountType
   models?: ModelsResponse
   vsCodeVersion?: string
 
@@ -24,4 +26,21 @@ export const state: State = {
   rateLimitWait: false,
   showToken: false,
   verbose: false,
+}
+
+/**
+ * Create an AccountContext from the current global state.
+ * This is a compatibility layer for transitioning to multi-account support.
+ * @throws Error if githubToken is not set in state
+ */
+export function accountFromState(): AccountContext {
+  if (!state.githubToken) {
+    throw new Error("GitHub token not set in state")
+  }
+  return {
+    githubToken: state.githubToken,
+    copilotToken: state.copilotToken,
+    accountType: state.accountType,
+    vsCodeVersion: state.vsCodeVersion,
+  }
 }

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -1,0 +1,69 @@
+import type { ModelsResponse } from "~/services/copilot/get-models"
+
+/**
+ * Account type for GitHub Copilot subscription.
+ */
+export type AccountType = "individual" | "business" | "enterprise"
+
+/**
+ * Metadata for a registered account, stored in the registry file.
+ */
+export interface AccountMeta {
+  /** GitHub login (username) */
+  id: string
+  /** Account subscription type */
+  accountType: AccountType
+  /** Timestamp when the account was added */
+  addedAt: number
+}
+
+/**
+ * Registry file structure for storing account metadata.
+ */
+export interface AccountRegistry {
+  /** Schema version for future migrations */
+  version: 1
+  /** Ordered list of accounts (order = priority) */
+  accounts: Array<AccountMeta>
+}
+
+/**
+ * Runtime state for an account, including tokens and quota information.
+ */
+export interface AccountRuntime extends AccountMeta {
+  /** GitHub personal access token */
+  githubToken: string
+  /** Copilot API token (obtained from GitHub) */
+  copilotToken?: string
+  /** VS Code version for API headers */
+  vsCodeVersion?: string
+  /** Cached available models for this account */
+  models?: ModelsResponse
+  /** Remaining premium interactions quota */
+  premiumRemaining?: number
+  /** Whether this account has unlimited quota */
+  unlimited?: boolean
+  /** Timestamp of last quota fetch */
+  lastQuotaFetch?: number
+  /** Token refresh timer reference */
+  refreshTimer?: ReturnType<typeof setInterval>
+  /** Whether this account has failed (e.g., 401 error) */
+  failed?: boolean
+  /** Failure reason if failed */
+  failureReason?: string
+}
+
+/**
+ * Context required for making API calls on behalf of an account.
+ * This is a subset of AccountRuntime used by service functions.
+ */
+export interface AccountContext {
+  /** GitHub personal access token */
+  githubToken: string
+  /** Copilot API token */
+  copilotToken?: string
+  /** Account subscription type */
+  accountType: AccountType
+  /** VS Code version for API headers */
+  vsCodeVersion?: string
+}

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -5,6 +5,30 @@ import type { ModelsResponse } from "~/services/copilot/get-models"
  */
 export type AccountType = "individual" | "business" | "enterprise"
 
+export const ACCOUNT_TYPE_VALUES: ReadonlyArray<AccountType> = [
+  "individual",
+  "business",
+  "enterprise",
+]
+
+export function isAccountType(value: unknown): value is AccountType {
+  return (
+    typeof value === "string"
+    && (ACCOUNT_TYPE_VALUES as ReadonlyArray<string>).includes(value)
+  )
+}
+
+export function parseAccountType(value: unknown): AccountType {
+  if (!isAccountType(value)) {
+    throw new Error(
+      `Invalid account type: ${String(value)}. Valid values: ${ACCOUNT_TYPE_VALUES.join(
+        ", ",
+      )}`,
+    )
+  }
+  return value
+}
+
 /**
  * Metadata for a registered account, stored in the registry file.
  */

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -51,6 +51,8 @@ export interface AccountRuntime extends AccountMeta {
   failed?: boolean
   /** Failure reason if failed */
   failureReason?: string
+  /** Whether quota refresh is in progress (prevents concurrent refreshes) */
+  isRefreshingQuota?: boolean
 }
 
 /**

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -65,6 +65,10 @@ export interface AccountRuntime extends AccountMeta {
   models?: ModelsResponse
   /** Remaining premium interactions quota */
   premiumRemaining?: number
+  /** Reserved premium interaction units for in-flight requests */
+  premiumReserved?: number
+  /** Internal reservation map for idempotent release */
+  premiumReservations?: Map<symbol, number>
   /** Whether this account has unlimited quota */
   unlimited?: boolean
   /** Timestamp of last quota fetch */
@@ -77,6 +81,8 @@ export interface AccountRuntime extends AccountMeta {
   failureReason?: string
   /** Whether quota refresh is in progress (prevents concurrent refreshes) */
   isRefreshingQuota?: boolean
+  /** Promise for an in-flight quota refresh (allows concurrent callers to await the same refresh) */
+  quotaRefreshPromise?: Promise<void>
 }
 
 /**

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -18,12 +18,34 @@ import {
 
 const logger = createHandlerLogger("chat-completions-handler")
 
+const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
+
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
-  // Select an account with available quota
-  const account = await accountsManager.selectAccount()
-  if (!account) {
+  let payload = await c.req.json<ChatCompletionsPayload>()
+  logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
+
+  const selection = await accountsManager.selectAccountForRequest([
+    {
+      modelId: payload.model,
+      endpoint: CHAT_COMPLETIONS_ENDPOINT,
+    },
+  ])
+
+  if (!selection.ok) {
+    if (selection.reason === "MODEL_NOT_SUPPORTED") {
+      return c.json(
+        {
+          error: {
+            message: `Model "${payload.model}" is not available for any configured account.`,
+            type: "invalid_request_error",
+          },
+        },
+        400,
+      )
+    }
+
     return c.json(
       {
         error: {
@@ -35,22 +57,12 @@ export async function handleCompletion(c: Context) {
     )
   }
 
-  let payload = await c.req.json<ChatCompletionsPayload>()
-  logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
-
-  // Find the selected model from this account's models
-  const selectedModel = account.models?.data.find(
-    (model) => model.id === payload.model,
-  )
+  const { account, reservation, selectedModel } = selection
 
   // Calculate and display token count
   try {
-    if (selectedModel) {
-      const tokenCount = await getTokenCount(payload, selectedModel)
-      logger.info("Current token count:", tokenCount)
-    } else {
-      logger.warn("No model selected, skipping token count calculation")
-    }
+    const tokenCount = await getTokenCount(payload, selectedModel)
+    logger.info("Current token count:", tokenCount)
   } catch (error) {
     logger.warn("Failed to calculate token count:", error)
   }
@@ -60,7 +72,7 @@ export async function handleCompletion(c: Context) {
   if (isNullish(payload.max_tokens)) {
     payload = {
       ...payload,
-      max_tokens: selectedModel?.capabilities.limits.max_output_tokens,
+      max_tokens: selectedModel.capabilities.limits.max_output_tokens,
     }
     logger.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
   }
@@ -93,7 +105,7 @@ export async function handleCompletion(c: Context) {
     throw error
   } finally {
     // Refresh quota after request completes
-    await accountsManager.finalizeQuota(account)
+    await accountsManager.finalizeQuota(account, reservation)
   }
 }
 

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -49,7 +49,8 @@ export async function handleCompletion(c: Context) {
     return c.json(
       {
         error: {
-          message: "All accounts exhausted. Please try again later.",
+          message:
+            "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
           type: "rate_limit_error",
         },
       },

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono"
 
 import { streamSSE, type SSEMessage } from "hono/streaming"
 
+import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
@@ -19,11 +20,25 @@ const logger = createHandlerLogger("chat-completions-handler")
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
+  // Select an account with available quota
+  const account = await accountsManager.selectAccount()
+  if (!account) {
+    return c.json(
+      {
+        error: {
+          message: "All accounts exhausted. Please try again later.",
+          type: "rate_limit_error",
+        },
+      },
+      429,
+    )
+  }
+
   let payload = await c.req.json<ChatCompletionsPayload>()
   logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
 
-  // Find the selected model
-  const selectedModel = state.models?.data.find(
+  // Find the selected model from this account's models
+  const selectedModel = account.models?.data.find(
     (model) => model.id === payload.model,
   )
 
@@ -49,20 +64,31 @@ export async function handleCompletion(c: Context) {
     logger.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
   }
 
-  const response = await createChatCompletions(payload)
-
-  if (isNonStreaming(response)) {
-    logger.debug("Non-streaming response:", JSON.stringify(response))
-    return c.json(response)
-  }
-
-  logger.debug("Streaming response")
-  return streamSSE(c, async (stream) => {
-    for await (const chunk of response) {
-      logger.debug("Streaming chunk:", JSON.stringify(chunk))
-      await stream.writeSSE(chunk as SSEMessage)
+  try {
+    const ctx = {
+      githubToken: account.githubToken,
+      copilotToken: account.copilotToken,
+      accountType: account.accountType,
+      vsCodeVersion: account.vsCodeVersion,
     }
-  })
+    const response = await createChatCompletions(payload, ctx)
+
+    if (isNonStreaming(response)) {
+      logger.debug("Non-streaming response:", JSON.stringify(response))
+      return c.json(response)
+    }
+
+    logger.debug("Streaming response")
+    return streamSSE(c, async (stream) => {
+      for await (const chunk of response) {
+        logger.debug("Streaming chunk:", JSON.stringify(chunk))
+        await stream.writeSSE(chunk as SSEMessage)
+      }
+    })
+  } finally {
+    // Refresh quota after request completes
+    await accountsManager.finalizeQuota(account)
+  }
 }
 
 const isNonStreaming = (

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -4,6 +4,7 @@ import { streamSSE, type SSEMessage } from "hono/streaming"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
+import { HTTPError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
@@ -85,6 +86,11 @@ export async function handleCompletion(c: Context) {
         await stream.writeSSE(chunk as SSEMessage)
       }
     })
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 401) {
+      accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+    }
+    throw error
   } finally {
     // Refresh quota after request completes
     await accountsManager.finalizeQuota(account)

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -9,11 +9,32 @@ import {
 
 export const embeddingRoutes = new Hono()
 
+const EMBEDDINGS_ENDPOINT = "/embeddings"
+
 embeddingRoutes.post("/", async (c) => {
   try {
-    // Select an account with available quota
-    const account = await accountsManager.selectAccount()
-    if (!account) {
+    const payload = await c.req.json<EmbeddingRequest>()
+
+    const selection = await accountsManager.selectAccountForRequest([
+      {
+        modelId: payload.model,
+        endpoint: EMBEDDINGS_ENDPOINT,
+      },
+    ])
+
+    if (!selection.ok) {
+      if (selection.reason === "MODEL_NOT_SUPPORTED") {
+        return c.json(
+          {
+            error: {
+              message: `Model "${payload.model}" is not available for any configured account.`,
+              type: "invalid_request_error",
+            },
+          },
+          400,
+        )
+      }
+
       return c.json(
         {
           error: {
@@ -25,7 +46,7 @@ embeddingRoutes.post("/", async (c) => {
       )
     }
 
-    const payload = await c.req.json<EmbeddingRequest>()
+    const { account, reservation } = selection
 
     try {
       const ctx = {
@@ -44,7 +65,7 @@ embeddingRoutes.post("/", async (c) => {
       throw error
     } finally {
       // Refresh quota after request completes
-      await accountsManager.finalizeQuota(account)
+      await accountsManager.finalizeQuota(account, reservation)
     }
   } catch (error) {
     return await forwardError(c, error)

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 
+import { accountsManager } from "~/lib/accounts-manager"
 import { forwardError } from "~/lib/error"
 import {
   createEmbeddings,
@@ -10,10 +11,36 @@ export const embeddingRoutes = new Hono()
 
 embeddingRoutes.post("/", async (c) => {
   try {
-    const paylod = await c.req.json<EmbeddingRequest>()
-    const response = await createEmbeddings(paylod)
+    // Select an account with available quota
+    const account = await accountsManager.selectAccount()
+    if (!account) {
+      return c.json(
+        {
+          error: {
+            message: "All accounts exhausted. Please try again later.",
+            type: "rate_limit_error",
+          },
+        },
+        429,
+      )
+    }
 
-    return c.json(response)
+    const payload = await c.req.json<EmbeddingRequest>()
+
+    try {
+      const ctx = {
+        githubToken: account.githubToken,
+        copilotToken: account.copilotToken,
+        accountType: account.accountType,
+        vsCodeVersion: account.vsCodeVersion,
+      }
+      const response = await createEmbeddings(payload, ctx)
+
+      return c.json(response)
+    } finally {
+      // Refresh quota after request completes
+      await accountsManager.finalizeQuota(account)
+    }
   } catch (error) {
     return await forwardError(c, error)
   }

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -38,7 +38,8 @@ embeddingRoutes.post("/", async (c) => {
       return c.json(
         {
           error: {
-            message: "All accounts exhausted. Please try again later.",
+            message:
+              "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
             type: "rate_limit_error",
           },
         },

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono"
 
 import { accountsManager } from "~/lib/accounts-manager"
-import { forwardError } from "~/lib/error"
+import { forwardError, HTTPError } from "~/lib/error"
 import {
   createEmbeddings,
   type EmbeddingRequest,
@@ -37,6 +37,11 @@ embeddingRoutes.post("/", async (c) => {
       const response = await createEmbeddings(payload, ctx)
 
       return c.json(response)
+    } catch (error) {
+      if (error instanceof HTTPError && error.response.status === 401) {
+        accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+      }
+      throw error
     } finally {
       // Refresh quota after request completes
       await accountsManager.finalizeQuota(account)

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -7,6 +7,7 @@ import type { AccountContext, AccountRuntime } from "~/lib/types/account"
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { getSmallModel } from "~/lib/config"
+import { HTTPError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
@@ -83,6 +84,11 @@ export async function handleCompletion(c: Context) {
     }
 
     return await handleWithChatCompletions(c, anthropicPayload, account)
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 401) {
+      accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+    }
+    throw error
   } finally {
     // Refresh quota after request completes
     await accountsManager.finalizeQuota(account)

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -2,6 +2,9 @@ import type { Context } from "hono"
 
 import { streamSSE } from "hono/streaming"
 
+import type { AccountContext, AccountRuntime } from "~/lib/types/account"
+
+import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { getSmallModel } from "~/lib/config"
 import { createHandlerLogger } from "~/lib/logger"
@@ -43,6 +46,20 @@ const logger = createHandlerLogger("messages-handler")
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
+  // Select an account with available quota
+  const account = await accountsManager.selectAccount()
+  if (!account) {
+    return c.json(
+      {
+        error: {
+          message: "All accounts exhausted. Please try again later.",
+          type: "rate_limit_error",
+        },
+      },
+      429,
+    )
+  }
+
   const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
   logger.debug("Anthropic request payload:", JSON.stringify(anthropicPayload))
 
@@ -54,24 +71,37 @@ export async function handleCompletion(c: Context) {
     anthropicPayload.model = getSmallModel()
   }
 
-  const useResponsesApi = shouldUseResponsesApi(anthropicPayload.model)
+  const useResponsesApi = shouldUseResponsesApi(anthropicPayload.model, account)
 
   if (state.manualApprove) {
     await awaitApproval()
   }
 
-  if (useResponsesApi) {
-    return await handleWithResponsesApi(c, anthropicPayload)
-  }
+  try {
+    if (useResponsesApi) {
+      return await handleWithResponsesApi(c, anthropicPayload, account)
+    }
 
-  return await handleWithChatCompletions(c, anthropicPayload)
+    return await handleWithChatCompletions(c, anthropicPayload, account)
+  } finally {
+    // Refresh quota after request completes
+    await accountsManager.finalizeQuota(account)
+  }
 }
 
 const RESPONSES_ENDPOINT = "/responses"
 
+const toAccountContext = (account: AccountRuntime): AccountContext => ({
+  githubToken: account.githubToken,
+  copilotToken: account.copilotToken,
+  accountType: account.accountType,
+  vsCodeVersion: account.vsCodeVersion,
+})
+
 const handleWithChatCompletions = async (
   c: Context,
   anthropicPayload: AnthropicMessagesPayload,
+  account: AccountRuntime,
 ) => {
   const openAIPayload = translateToOpenAI(anthropicPayload)
   logger.debug(
@@ -79,7 +109,8 @@ const handleWithChatCompletions = async (
     JSON.stringify(openAIPayload),
   )
 
-  const response = await createChatCompletions(openAIPayload)
+  const ctx = toAccountContext(account)
+  const response = await createChatCompletions(openAIPayload, ctx)
 
   if (isNonStreaming(response)) {
     logger.debug(
@@ -131,6 +162,7 @@ const handleWithChatCompletions = async (
 const handleWithResponsesApi = async (
   c: Context,
   anthropicPayload: AnthropicMessagesPayload,
+  account: AccountRuntime,
 ) => {
   const responsesPayload =
     translateAnthropicMessagesToResponsesPayload(anthropicPayload)
@@ -140,10 +172,15 @@ const handleWithResponsesApi = async (
   )
 
   const { vision, initiator } = getResponsesRequestOptions(responsesPayload)
-  const response = await createResponses(responsesPayload, {
-    vision,
-    initiator,
-  })
+  const ctx = toAccountContext(account)
+  const response = await createResponses(
+    responsesPayload,
+    {
+      vision,
+      initiator,
+    },
+    ctx,
+  )
 
   if (responsesPayload.stream && isAsyncIterable(response)) {
     logger.debug("Streaming response from Copilot (Responses API)")
@@ -212,8 +249,13 @@ const handleWithResponsesApi = async (
   return c.json(anthropicResponse)
 }
 
-const shouldUseResponsesApi = (modelId: string): boolean => {
-  const selectedModel = state.models?.data.find((model) => model.id === modelId)
+const shouldUseResponsesApi = (
+  modelId: string,
+  account: AccountRuntime,
+): boolean => {
+  const selectedModel = account.models?.data.find(
+    (model) => model.id === modelId,
+  )
   return (
     selectedModel?.supported_endpoints?.includes(RESPONSES_ENDPOINT) ?? false
   )

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -25,6 +25,7 @@ import {
   createChatCompletions,
   type ChatCompletionChunk,
   type ChatCompletionResponse,
+  type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
 import {
   createResponses,
@@ -47,20 +48,6 @@ const logger = createHandlerLogger("messages-handler")
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
-  // Select an account with available quota
-  const account = await accountsManager.selectAccount()
-  if (!account) {
-    return c.json(
-      {
-        error: {
-          message: "All accounts exhausted. Please try again later.",
-          type: "rate_limit_error",
-        },
-      },
-      429,
-    )
-  }
-
   const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
   logger.debug("Anthropic request payload:", JSON.stringify(anthropicPayload))
 
@@ -72,18 +59,55 @@ export async function handleCompletion(c: Context) {
     anthropicPayload.model = getSmallModel()
   }
 
-  const useResponsesApi = shouldUseResponsesApi(anthropicPayload.model, account)
+  const openAIPayload = translateToOpenAI(anthropicPayload)
+
+  const selection = await accountsManager.selectAccountForRequest([
+    {
+      modelId: anthropicPayload.model,
+      endpoint: RESPONSES_ENDPOINT,
+    },
+    {
+      modelId: openAIPayload.model,
+      endpoint: CHAT_COMPLETIONS_ENDPOINT,
+    },
+  ])
+
+  if (!selection.ok) {
+    if (selection.reason === "MODEL_NOT_SUPPORTED") {
+      return c.json(
+        {
+          error: {
+            message: `Model "${anthropicPayload.model}" is not available for any configured account.`,
+            type: "invalid_request_error",
+          },
+        },
+        400,
+      )
+    }
+
+    return c.json(
+      {
+        error: {
+          message: "All accounts exhausted. Please try again later.",
+          type: "rate_limit_error",
+        },
+      },
+      429,
+    )
+  }
+
+  const { account, reservation, endpoint } = selection
 
   if (state.manualApprove) {
     await awaitApproval()
   }
 
   try {
-    if (useResponsesApi) {
+    if (endpoint === RESPONSES_ENDPOINT) {
       return await handleWithResponsesApi(c, anthropicPayload, account)
     }
 
-    return await handleWithChatCompletions(c, anthropicPayload, account)
+    return await handleWithChatCompletions(c, openAIPayload, account)
   } catch (error) {
     if (error instanceof HTTPError && error.response.status === 401) {
       accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
@@ -91,10 +115,11 @@ export async function handleCompletion(c: Context) {
     throw error
   } finally {
     // Refresh quota after request completes
-    await accountsManager.finalizeQuota(account)
+    await accountsManager.finalizeQuota(account, reservation)
   }
 }
 
+const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
 const RESPONSES_ENDPOINT = "/responses"
 
 const toAccountContext = (account: AccountRuntime): AccountContext => ({
@@ -106,10 +131,9 @@ const toAccountContext = (account: AccountRuntime): AccountContext => ({
 
 const handleWithChatCompletions = async (
   c: Context,
-  anthropicPayload: AnthropicMessagesPayload,
+  openAIPayload: ChatCompletionsPayload,
   account: AccountRuntime,
 ) => {
-  const openAIPayload = translateToOpenAI(anthropicPayload)
   logger.debug(
     "Translated OpenAI request payload:",
     JSON.stringify(openAIPayload),
@@ -253,18 +277,6 @@ const handleWithResponsesApi = async (
     JSON.stringify(anthropicResponse),
   )
   return c.json(anthropicResponse)
-}
-
-const shouldUseResponsesApi = (
-  modelId: string,
-  account: AccountRuntime,
-): boolean => {
-  const selectedModel = account.models?.data.find(
-    (model) => model.id === modelId,
-  )
-  return (
-    selectedModel?.supported_endpoints?.includes(RESPONSES_ENDPOINT) ?? false
-  )
 }
 
 const isNonStreaming = (

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -88,7 +88,8 @@ export async function handleCompletion(c: Context) {
     return c.json(
       {
         error: {
-          message: "All accounts exhausted. Please try again later.",
+          message:
+            "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
           type: "rate_limit_error",
         },
       },

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -1,19 +1,15 @@
 import { Hono } from "hono"
 
+import { accountsManager } from "~/lib/accounts-manager"
 import { forwardError } from "~/lib/error"
-import { state } from "~/lib/state"
-import { cacheModels } from "~/lib/utils"
 
 export const modelRoutes = new Hono()
 
 modelRoutes.get("/", async (c) => {
   try {
-    if (!state.models) {
-      // This should be handled by startup logic, but as a fallback.
-      await cacheModels()
-    }
+    const accountModels = accountsManager.getFirstAccountModels()
 
-    const models = state.models?.data.map((model) => ({
+    const models = accountModels?.data.map((model) => ({
       id: model.id,
       object: "model",
       type: "model",
@@ -25,7 +21,7 @@ modelRoutes.get("/", async (c) => {
 
     return c.json({
       object: "list",
-      data: models,
+      data: models ?? [],
       has_more: false,
     })
   } catch (error) {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono"
 
 import { streamSSE } from "hono/streaming"
 
+import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
@@ -21,10 +22,24 @@ const RESPONSES_ENDPOINT = "/responses"
 export const handleResponses = async (c: Context) => {
   await checkRateLimit(state)
 
+  // Select an account with available quota
+  const account = await accountsManager.selectAccount()
+  if (!account) {
+    return c.json(
+      {
+        error: {
+          message: "All accounts exhausted. Please try again later.",
+          type: "rate_limit_error",
+        },
+      },
+      429,
+    )
+  }
+
   const payload = await c.req.json<ResponsesPayload>()
   logger.debug("Responses request payload:", JSON.stringify(payload))
 
-  const selectedModel = state.models?.data.find(
+  const selectedModel = account.models?.data.find(
     (model) => model.id === payload.model,
   )
   const supportsResponses =
@@ -49,27 +64,38 @@ export const handleResponses = async (c: Context) => {
     await awaitApproval()
   }
 
-  const response = await createResponses(payload, { vision, initiator })
+  try {
+    const ctx = {
+      githubToken: account.githubToken,
+      copilotToken: account.copilotToken,
+      accountType: account.accountType,
+      vsCodeVersion: account.vsCodeVersion,
+    }
+    const response = await createResponses(payload, { vision, initiator }, ctx)
 
-  if (isStreamingRequested(payload) && isAsyncIterable(response)) {
-    logger.debug("Forwarding native Responses stream")
-    return streamSSE(c, async (stream) => {
-      for await (const chunk of response) {
-        logger.debug("Responses stream chunk:", JSON.stringify(chunk))
-        await stream.writeSSE({
-          id: (chunk as { id?: string }).id,
-          event: (chunk as { event?: string }).event,
-          data: (chunk as { data?: string }).data ?? "",
-        })
-      }
-    })
+    if (isStreamingRequested(payload) && isAsyncIterable(response)) {
+      logger.debug("Forwarding native Responses stream")
+      return streamSSE(c, async (stream) => {
+        for await (const chunk of response) {
+          logger.debug("Responses stream chunk:", JSON.stringify(chunk))
+          await stream.writeSSE({
+            id: (chunk as { id?: string }).id,
+            event: (chunk as { event?: string }).event,
+            data: (chunk as { data?: string }).data ?? "",
+          })
+        }
+      })
+    }
+
+    logger.debug(
+      "Forwarding native Responses result:",
+      JSON.stringify(response).slice(-400),
+    )
+    return c.json(response as ResponsesResult)
+  } finally {
+    // Refresh quota after request completes
+    await accountsManager.finalizeQuota(account)
   }
-
-  logger.debug(
-    "Forwarding native Responses result:",
-    JSON.stringify(response).slice(-400),
-  )
-  return c.json(response as ResponsesResult)
 }
 
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -4,6 +4,7 @@ import { streamSSE } from "hono/streaming"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
+import { HTTPError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
@@ -92,6 +93,11 @@ export const handleResponses = async (c: Context) => {
       JSON.stringify(response).slice(-400),
     )
     return c.json(response as ResponsesResult)
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 401) {
+      accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+    }
+    throw error
   } finally {
     // Refresh quota after request completes
     await accountsManager.finalizeQuota(account)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -23,9 +23,30 @@ const RESPONSES_ENDPOINT = "/responses"
 export const handleResponses = async (c: Context) => {
   await checkRateLimit(state)
 
-  // Select an account with available quota
-  const account = await accountsManager.selectAccount()
-  if (!account) {
+  const payload = await c.req.json<ResponsesPayload>()
+  logger.debug("Responses request payload:", JSON.stringify(payload))
+
+  const selection = await accountsManager.selectAccountForRequest([
+    {
+      modelId: payload.model,
+      endpoint: RESPONSES_ENDPOINT,
+    },
+  ])
+
+  if (!selection.ok) {
+    if (selection.reason === "MODEL_NOT_SUPPORTED") {
+      return c.json(
+        {
+          error: {
+            message:
+              "This model does not support the responses endpoint. Please choose a different model.",
+            type: "invalid_request_error",
+          },
+        },
+        400,
+      )
+    }
+
     return c.json(
       {
         error: {
@@ -37,27 +58,7 @@ export const handleResponses = async (c: Context) => {
     )
   }
 
-  const payload = await c.req.json<ResponsesPayload>()
-  logger.debug("Responses request payload:", JSON.stringify(payload))
-
-  const selectedModel = account.models?.data.find(
-    (model) => model.id === payload.model,
-  )
-  const supportsResponses =
-    selectedModel?.supported_endpoints?.includes(RESPONSES_ENDPOINT) ?? false
-
-  if (!supportsResponses) {
-    return c.json(
-      {
-        error: {
-          message:
-            "This model does not support the responses endpoint. Please choose a different model.",
-          type: "invalid_request_error",
-        },
-      },
-      400,
-    )
-  }
+  const { account, reservation } = selection
 
   const { vision, initiator } = getResponsesRequestOptions(payload)
 
@@ -100,7 +101,7 @@ export const handleResponses = async (c: Context) => {
     throw error
   } finally {
     // Refresh quota after request completes
-    await accountsManager.finalizeQuota(account)
+    await accountsManager.finalizeQuota(account, reservation)
   }
 }
 

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -50,7 +50,8 @@ export const handleResponses = async (c: Context) => {
     return c.json(
       {
         error: {
-          message: "All accounts exhausted. Please try again later.",
+          message:
+            "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
           type: "rate_limit_error",
         },
       },

--- a/src/routes/usage/route.ts
+++ b/src/routes/usage/route.ts
@@ -1,15 +1,17 @@
 import { Hono } from "hono"
 
-import { getCopilotUsage } from "~/services/github/get-copilot-usage"
+import { accountsManager } from "~/lib/accounts-manager"
 
 export const usageRoute = new Hono()
 
-usageRoute.get("/", async (c) => {
+usageRoute.get("/", (c) => {
   try {
-    const usage = await getCopilotUsage()
-    return c.json(usage)
+    const accountStatuses = accountsManager.getAccountStatus()
+    return c.json({
+      accounts: accountStatuses,
+    })
   } catch (error) {
-    console.error("Error fetching Copilot usage:", error)
-    return c.json({ error: "Failed to fetch Copilot usage" }, 500)
+    console.error("Error fetching account status:", error)
+    return c.json({ error: "Failed to fetch account status" }, 500)
   }
 })

--- a/src/routes/usage/route.ts
+++ b/src/routes/usage/route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 
 import { accountsManager } from "~/lib/accounts-manager"
+import { getCopilotUsage } from "~/services/github/get-copilot-usage"
 
 export const usageRoute = new Hono()
 
@@ -13,5 +14,40 @@ usageRoute.get("/", (c) => {
   } catch (error) {
     console.error("Error fetching account status:", error)
     return c.json({ error: "Failed to fetch account status" }, 500)
+  }
+})
+
+/**
+ * Get detailed usage information for a specific account by index.
+ * Index 0 is the temporary account (if exists), otherwise the first registered account.
+ */
+usageRoute.get("/:accountIndex", async (c) => {
+  try {
+    const indexParam = c.req.param("accountIndex")
+    const index = Number.parseInt(indexParam, 10)
+
+    if (Number.isNaN(index) || index < 0) {
+      return c.json({ error: "Invalid account index" }, 400)
+    }
+
+    const accountContext = accountsManager.getAccountContextByIndex(index)
+
+    if (!accountContext) {
+      const accountCount = accountsManager.getAccountCount()
+      return c.json(
+        {
+          error: `Account index ${index} not found`,
+          availableIndices: accountCount > 0 ? `0-${accountCount - 1}` : "none",
+        },
+        404,
+      )
+    }
+
+    const usage = await getCopilotUsage(accountContext)
+
+    return c.json(usage)
+  } catch (error) {
+    console.error("Error fetching account usage:", error)
+    return c.json({ error: "Failed to fetch account usage" }, 500)
   }
 })

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -1,14 +1,18 @@
 import consola from "consola"
 import { events } from "fetch-event-stream"
 
+import type { AccountContext } from "~/lib/types/account"
+
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
-import { state } from "~/lib/state"
+import { accountFromState } from "~/lib/state"
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
+  account?: AccountContext,
 ) => {
-  if (!state.copilotToken) throw new Error("Copilot token not found")
+  const ctx = account ?? accountFromState()
+  if (!ctx.copilotToken) throw new Error("Copilot token not found")
 
   const enableVision = payload.messages.some(
     (x) =>
@@ -24,11 +28,11 @@ export const createChatCompletions = async (
 
   // Build headers and add X-Initiator
   const headers: Record<string, string> = {
-    ...copilotHeaders(state, enableVision),
+    ...copilotHeaders(ctx, enableVision),
     "X-Initiator": isAgentCall ? "agent" : "user",
   }
 
-  const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
+  const response = await fetch(`${copilotBaseUrl(ctx)}/chat/completions`, {
     method: "POST",
     headers,
     body: JSON.stringify(payload),

--- a/src/services/copilot/create-embeddings.ts
+++ b/src/services/copilot/create-embeddings.ts
@@ -1,13 +1,19 @@
+import type { AccountContext } from "~/lib/types/account"
+
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
-import { state } from "~/lib/state"
+import { accountFromState } from "~/lib/state"
 
-export const createEmbeddings = async (payload: EmbeddingRequest) => {
-  if (!state.copilotToken) throw new Error("Copilot token not found")
+export const createEmbeddings = async (
+  payload: EmbeddingRequest,
+  account?: AccountContext,
+) => {
+  const ctx = account ?? accountFromState()
+  if (!ctx.copilotToken) throw new Error("Copilot token not found")
 
-  const response = await fetch(`${copilotBaseUrl(state)}/embeddings`, {
+  const response = await fetch(`${copilotBaseUrl(ctx)}/embeddings`, {
     method: "POST",
-    headers: copilotHeaders(state),
+    headers: copilotHeaders(ctx),
     body: JSON.stringify(payload),
   })
 

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,9 +1,11 @@
 import consola from "consola"
 import { events } from "fetch-event-stream"
 
+import type { AccountContext } from "~/lib/types/account"
+
 import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
-import { state } from "~/lib/state"
+import { accountFromState } from "~/lib/state"
 
 export interface ResponsesPayload {
   model: string
@@ -329,18 +331,20 @@ interface ResponsesRequestOptions {
 export const createResponses = async (
   payload: ResponsesPayload,
   { vision, initiator }: ResponsesRequestOptions,
+  account?: AccountContext,
 ): Promise<CreateResponsesReturn> => {
-  if (!state.copilotToken) throw new Error("Copilot token not found")
+  const ctx = account ?? accountFromState()
+  if (!ctx.copilotToken) throw new Error("Copilot token not found")
 
   const headers: Record<string, string> = {
-    ...copilotHeaders(state, vision),
+    ...copilotHeaders(ctx, vision),
     "X-Initiator": initiator,
   }
 
   // service_tier is not supported by github copilot
   payload.service_tier = null
 
-  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
+  const response = await fetch(`${copilotBaseUrl(ctx)}/responses`, {
     method: "POST",
     headers,
     body: JSON.stringify(payload),

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs/promises"
+
 import type { AccountContext } from "~/lib/types/account"
 
 import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { PATHS } from "~/lib/paths"
 import { accountFromState } from "~/lib/state"
 
 export const getModels = async (account?: AccountContext) => {
@@ -12,7 +15,25 @@ export const getModels = async (account?: AccountContext) => {
 
   if (!response.ok) throw new HTTPError("Failed to get models", response)
 
-  return (await response.json()) as ModelsResponse
+  const models = (await response.json()) as ModelsResponse
+
+  // Persist models response for debugging/inspection.
+  // Best effort: do not fail startup if the local write fails.
+  try {
+    await fs.mkdir(PATHS.APP_DIR, { recursive: true })
+    await fs.writeFile(
+      PATHS.MODELS_PATH,
+      `${JSON.stringify(models, null, 2)}\n`,
+      {
+        encoding: "utf8",
+        mode: 0o600,
+      },
+    )
+  } catch {
+    // ignore
+  }
+
+  return models
 }
 
 export interface ModelsResponse {

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -1,10 +1,13 @@
+import type { AccountContext } from "~/lib/types/account"
+
 import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
-import { state } from "~/lib/state"
+import { accountFromState } from "~/lib/state"
 
-export const getModels = async () => {
-  const response = await fetch(`${copilotBaseUrl(state)}/models`, {
-    headers: copilotHeaders(state),
+export const getModels = async (account?: AccountContext) => {
+  const ctx = account ?? accountFromState()
+  const response = await fetch(`${copilotBaseUrl(ctx)}/models`, {
+    headers: copilotHeaders(ctx),
   })
 
   if (!response.ok) throw new HTTPError("Failed to get models", response)

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -68,7 +68,13 @@ interface ModelCapabilities {
   type: string
 }
 
+interface ModelBilling {
+  is_premium?: boolean
+  multiplier?: number
+}
+
 export interface Model {
+  billing?: ModelBilling
   capabilities: ModelCapabilities
   id: string
   model_picker_enabled: boolean

--- a/src/services/github/get-copilot-token.ts
+++ b/src/services/github/get-copilot-token.ts
@@ -1,12 +1,15 @@
+import type { AccountContext } from "~/lib/types/account"
+
 import { GITHUB_API_BASE_URL, githubHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
-import { state } from "~/lib/state"
+import { accountFromState } from "~/lib/state"
 
-export const getCopilotToken = async () => {
+export const getCopilotToken = async (account?: AccountContext) => {
+  const ctx = account ?? accountFromState()
   const response = await fetch(
     `${GITHUB_API_BASE_URL}/copilot_internal/v2/token`,
     {
-      headers: githubHeaders(state),
+      headers: githubHeaders(ctx),
     },
   )
 
@@ -16,7 +19,7 @@ export const getCopilotToken = async () => {
 }
 
 // Trimmed for the sake of simplicity
-interface GetCopilotTokenResponse {
+export interface GetCopilotTokenResponse {
   expires_at: number
   refresh_in: number
   token: string

--- a/src/services/github/get-copilot-usage.ts
+++ b/src/services/github/get-copilot-usage.ts
@@ -1,10 +1,15 @@
+import type { AccountContext } from "~/lib/types/account"
+
 import { GITHUB_API_BASE_URL, githubHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
-import { state } from "~/lib/state"
+import { accountFromState } from "~/lib/state"
 
-export const getCopilotUsage = async (): Promise<CopilotUsageResponse> => {
+export const getCopilotUsage = async (
+  account?: AccountContext,
+): Promise<CopilotUsageResponse> => {
+  const ctx = account ?? accountFromState()
   const response = await fetch(`${GITHUB_API_BASE_URL}/copilot_internal/user`, {
-    headers: githubHeaders(state),
+    headers: githubHeaders(ctx),
   })
 
   if (!response.ok) {

--- a/src/services/github/get-user.ts
+++ b/src/services/github/get-user.ts
@@ -1,11 +1,15 @@
+import type { AccountContext } from "~/lib/types/account"
+
 import { GITHUB_API_BASE_URL, standardHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
 
-export async function getGitHubUser() {
+export async function getGitHubUser(account?: AccountContext) {
+  // Use provided account or fall back to state (for legacy compatibility)
+  const token = account?.githubToken ?? state.githubToken
   const response = await fetch(`${GITHUB_API_BASE_URL}/user`, {
     headers: {
-      authorization: `token ${state.githubToken}`,
+      authorization: `token ${token}`,
       ...standardHeaders(),
     },
   })
@@ -16,6 +20,6 @@ export async function getGitHubUser() {
 }
 
 // Trimmed for the sake of simplicity
-interface GithubUserResponse {
+export interface GithubUserResponse {
   login: string
 }

--- a/src/start.ts
+++ b/src/start.ts
@@ -6,8 +6,6 @@ import consola from "consola"
 import { serve, type ServerHandler } from "srvx"
 import invariant from "tiny-invariant"
 
-import type { AccountType } from "./lib/types/account"
-
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
 import { mergeConfigWithDefaults } from "./lib/config"
@@ -15,6 +13,7 @@ import { ensurePaths } from "./lib/paths"
 import { initProxyFromEnv } from "./lib/proxy"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"
+import { parseAccountType, type AccountType } from "./lib/types/account"
 import { cacheVSCodeVersion } from "./lib/utils"
 import { getDeviceCode } from "./services/github/get-device-code"
 import { getGitHubUser } from "./services/github/get-user"
@@ -263,10 +262,18 @@ export const start = defineCommand({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       rateLimitRaw === undefined ? undefined : Number.parseInt(rateLimitRaw, 10)
 
+    let accountType: AccountType
+    try {
+      accountType = parseAccountType(args["account-type"])
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error))
+      process.exit(1)
+    }
+
     return runServer({
       port: Number.parseInt(args.port, 10),
       verbose: args.verbose,
-      accountType: args["account-type"] as AccountType,
+      accountType,
       manual: args.manual,
       rateLimit,
       rateLimitWait: args.wait,

--- a/src/start.ts
+++ b/src/start.ts
@@ -6,18 +6,20 @@ import consola from "consola"
 import { serve, type ServerHandler } from "srvx"
 import invariant from "tiny-invariant"
 
+import type { AccountType } from "./lib/types/account"
+
+import { accountsManager } from "./lib/accounts-manager"
 import { mergeConfigWithDefaults } from "./lib/config"
 import { ensurePaths } from "./lib/paths"
 import { initProxyFromEnv } from "./lib/proxy"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"
-import { setupCopilotToken, setupGitHubToken } from "./lib/token"
-import { cacheModels, cacheVSCodeVersion } from "./lib/utils"
+import { cacheVSCodeVersion } from "./lib/utils"
 
 interface RunServerOptions {
   port: number
   verbose: boolean
-  accountType: string
+  accountType: AccountType
   manual: boolean
   rateLimit?: number
   rateLimitWait: boolean
@@ -54,30 +56,43 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   await ensurePaths()
   await cacheVSCodeVersion()
 
+  // Initialize accounts manager with VS Code version
+  await accountsManager.initialize(state.vsCodeVersion)
+
+  // If --github-token is provided, set it as a temporary (high priority) account
   if (options.githubToken) {
-    state.githubToken = options.githubToken
-    consola.info("Using provided GitHub token")
-  } else {
-    await setupGitHubToken()
+    await accountsManager.setTemporaryAccount(
+      options.githubToken,
+      options.accountType,
+    )
+    consola.info("Using provided GitHub token as temporary account")
   }
 
-  await setupCopilotToken()
-  await cacheModels()
+  // Check if we have any accounts
+  if (!accountsManager.hasAccounts()) {
+    consola.error(
+      "No accounts available. Please run 'copilot-api auth add' to add an account.",
+    )
+    process.exit(1)
+  }
+
+  // Get models from the first available account
+  const models = accountsManager.getFirstAccountModels()
 
   consola.info(
-    `Available models: \n${state.models?.data.map((model) => `- ${model.id}`).join("\n")}`,
+    `Available models: \n${models?.data.map((model) => `- ${model.id}`).join("\n") ?? "(no models loaded)"}`,
   )
 
   const serverUrl = `http://localhost:${options.port}`
 
   if (options.claudeCode) {
-    invariant(state.models, "Models should be loaded by now")
+    invariant(models, "Models should be loaded by now")
 
     const selectedModel = await consola.prompt(
       "Select a model to use with Claude Code",
       {
         type: "select",
-        options: state.models.data.map((model) => model.id),
+        options: models.data.map((model) => model.id),
       },
     )
 
@@ -85,7 +100,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
       "Select a small model to use with Claude Code",
       {
         type: "select",
-        options: state.models.data.map((model) => model.id),
+        options: models.data.map((model) => model.id),
       },
     )
 
@@ -203,7 +218,7 @@ export const start = defineCommand({
     return runServer({
       port: Number.parseInt(args.port, 10),
       verbose: args.verbose,
-      accountType: args["account-type"],
+      accountType: args["account-type"] as AccountType,
       manual: args.manual,
       rateLimit,
       rateLimitWait: args.wait,

--- a/src/start.ts
+++ b/src/start.ts
@@ -9,12 +9,16 @@ import invariant from "tiny-invariant"
 import type { AccountType } from "./lib/types/account"
 
 import { accountsManager } from "./lib/accounts-manager"
+import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
 import { mergeConfigWithDefaults } from "./lib/config"
 import { ensurePaths } from "./lib/paths"
 import { initProxyFromEnv } from "./lib/proxy"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"
 import { cacheVSCodeVersion } from "./lib/utils"
+import { getDeviceCode } from "./services/github/get-device-code"
+import { getGitHubUser } from "./services/github/get-user"
+import { pollAccessToken } from "./services/github/poll-access-token"
 
 interface RunServerOptions {
   port: number
@@ -27,6 +31,44 @@ interface RunServerOptions {
   claudeCode: boolean
   showToken: boolean
   proxyEnv: boolean
+}
+
+/**
+ * Run the interactive authentication flow to add a new account.
+ * Called automatically when no accounts are found.
+ */
+async function runAuthFlow(accountType: AccountType): Promise<void> {
+  consola.warn("No accounts found. Starting authentication flow...")
+
+  // Start device code flow
+  const deviceResponse = await getDeviceCode()
+  consola.info(
+    `Please enter the code "${deviceResponse.user_code}" at ${deviceResponse.verification_uri}`,
+  )
+
+  // Poll for access token
+  const token = await pollAccessToken(deviceResponse)
+
+  if (state.showToken) {
+    consola.info("GitHub token:", token)
+  }
+
+  // Get user info to determine account ID
+  const user = await getGitHubUser({
+    githubToken: token,
+    accountType,
+  })
+  const accountId = user.login
+
+  // Save token and add to registry
+  await saveAccountToken(accountId, token)
+  await addAccountToRegistry({
+    id: accountId,
+    accountType,
+    addedAt: Date.now(),
+  })
+
+  consola.success(`Account "${accountId}" added successfully!`)
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
@@ -68,12 +110,18 @@ export async function runServer(options: RunServerOptions): Promise<void> {
     consola.info("Using provided GitHub token as temporary account")
   }
 
-  // Check if we have any accounts
+  // Check if we have any accounts, if not, start the auth flow
   if (!accountsManager.hasAccounts()) {
-    consola.error(
-      "No accounts available. Please run 'copilot-api auth add' to add an account.",
-    )
-    process.exit(1)
+    try {
+      await runAuthFlow(options.accountType)
+
+      // Re-initialize accounts manager with the new account
+      accountsManager.shutdown()
+      await accountsManager.initialize(state.vsCodeVersion)
+    } catch (error) {
+      consola.error("Failed to add account:", error)
+      process.exit(1)
+    }
   }
 
   // Get models from the first available account

--- a/tests/account-type.test.ts
+++ b/tests/account-type.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+
+import { parseAccountType } from "../src/lib/types/account"
+
+test("parseAccountType accepts valid account types", () => {
+  expect(parseAccountType("individual")).toBe("individual")
+  expect(parseAccountType("business")).toBe("business")
+  expect(parseAccountType("enterprise")).toBe("enterprise")
+})
+
+test("parseAccountType rejects invalid account types", () => {
+  expect(() => parseAccountType("foo")).toThrow(
+    /Invalid account type: foo\. Valid values: individual, business, enterprise/,
+  )
+})

--- a/tests/accounts-manager-401.test.ts
+++ b/tests/accounts-manager-401.test.ts
@@ -1,0 +1,38 @@
+import { expect, mock, test } from "bun:test"
+
+import type { AccountRuntime } from "../src/lib/types/account"
+
+import { AccountsManager } from "../src/lib/accounts-manager"
+
+test("refreshQuota marks account failed on 401", async () => {
+  const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+  const originalFetch = fetchHolder.fetch
+
+  const fetchMock = mock(() => new Response("unauthorized", { status: 401 }))
+  // @ts-expect-error - mock doesn't implement full fetch signature
+  fetchHolder.fetch = fetchMock
+
+  try {
+    const manager = new AccountsManager()
+
+    const account: AccountRuntime = {
+      id: "octocat",
+      accountType: "individual",
+      addedAt: Date.now(),
+      githubToken: "ghp_test",
+      vsCodeVersion: "1.0.0",
+    }
+
+    const { accounts } = manager as unknown as {
+      accounts: Map<string, AccountRuntime>
+    }
+    accounts.set(account.id, account)
+
+    await manager.refreshQuota(account)
+
+    expect(account.failed).toBe(true)
+    expect(account.failureReason).toBe("Unauthorized (401)")
+  } finally {
+    fetchHolder.fetch = originalFetch
+  }
+})

--- a/tests/accounts-manager-reservation.test.ts
+++ b/tests/accounts-manager-reservation.test.ts
@@ -1,0 +1,191 @@
+import { expect, test } from "bun:test"
+
+import type { AccountRuntime } from "../src/lib/types/account"
+import type { Model, ModelsResponse } from "../src/services/copilot/get-models"
+
+import { AccountsManager } from "../src/lib/accounts-manager"
+
+const makeModel = (overrides: Partial<Model> = {}): Model => {
+  const base: Model = {
+    billing: {
+      is_premium: true,
+      multiplier: 1,
+    },
+    capabilities: {
+      family: "test",
+      limits: {},
+      object: "model_capabilities",
+      supports: {},
+      tokenizer: "test",
+      type: "test",
+    },
+    id: "test-model",
+    model_picker_enabled: true,
+    name: "Test model",
+    object: "model",
+    preview: false,
+    supported_endpoints: ["/chat/completions"],
+    vendor: "test",
+    version: "0",
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  }
+}
+
+const makeModelsResponse = (models: Array<Model>): ModelsResponse => ({
+  object: "list",
+  data: models,
+})
+
+const setupManagerWithAccount = (account: AccountRuntime): AccountsManager => {
+  const manager = new AccountsManager()
+  const internals = manager as unknown as {
+    accounts: Map<string, AccountRuntime>
+    accountOrder: Array<string>
+  }
+  internals.accounts.set(account.id, account)
+  internals.accountOrder.push(account.id)
+  return manager
+}
+
+test("selectAccountForRequest reserves multiplier units and releases on finalizeQuota", async () => {
+  const model = makeModel({
+    id: "gpt-5",
+    billing: {
+      is_premium: true,
+      multiplier: 2.5,
+    },
+  })
+
+  const account: AccountRuntime = {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_test",
+    vsCodeVersion: "1.0.0",
+    models: makeModelsResponse([model]),
+    premiumRemaining: 10,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const manager = setupManagerWithAccount(account)
+
+  const selection = await manager.selectAccountForRequest([
+    { modelId: "gpt-5", endpoint: "/chat/completions" },
+  ])
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.costUnits).toBe(2.5)
+  expect(selection.reservation).toBeDefined()
+  expect(account.premiumReserved).toBe(2.5)
+
+  // Avoid network calls from finalizeQuota() in unit test.
+  ;(manager as unknown as { refreshQuota: () => Promise<void> }).refreshQuota =
+    async () => {}
+
+  await manager.finalizeQuota(account, selection.reservation)
+
+  expect(account.premiumReserved).toBe(0)
+  expect(account.premiumReservations).toBeUndefined()
+})
+
+test("selectAccountForRequest prevents oversubscription with in-flight reservation", async () => {
+  const model = makeModel({
+    id: "gpt-5",
+    billing: {
+      is_premium: true,
+      multiplier: 1,
+    },
+  })
+
+  const account: AccountRuntime = {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_test",
+    vsCodeVersion: "1.0.0",
+    models: makeModelsResponse([model]),
+    premiumRemaining: 1,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const manager = setupManagerWithAccount(account)
+
+  const first = await manager.selectAccountForRequest([
+    { modelId: "gpt-5", endpoint: "/chat/completions" },
+  ])
+  expect(first.ok).toBe(true)
+
+  const second = await manager.selectAccountForRequest([
+    { modelId: "gpt-5", endpoint: "/chat/completions" },
+  ])
+  expect(second.ok).toBe(false)
+  if (second.ok) return
+
+  expect(second.reason).toBe("NO_QUOTA")
+})
+
+test("selectAccountForRequest returns MODEL_NOT_SUPPORTED when endpoint is not supported", async () => {
+  const model = makeModel({
+    id: "gpt-5",
+    supported_endpoints: ["/chat/completions"],
+  })
+
+  const account: AccountRuntime = {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_test",
+    vsCodeVersion: "1.0.0",
+    models: makeModelsResponse([model]),
+    premiumRemaining: 10,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const manager = setupManagerWithAccount(account)
+
+  const selection = await manager.selectAccountForRequest([
+    { modelId: "gpt-5", endpoint: "/responses" },
+  ])
+
+  expect(selection.ok).toBe(false)
+  if (selection.ok) return
+
+  expect(selection.reason).toBe("MODEL_NOT_SUPPORTED")
+})
+
+test("selectAccountForRequest treats missing billing as free (costUnits=0)", async () => {
+  const model = makeModel({
+    id: "free-model",
+    billing: undefined,
+  })
+
+  const account: AccountRuntime = {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_test",
+    vsCodeVersion: "1.0.0",
+    models: makeModelsResponse([model]),
+    premiumRemaining: 0,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const manager = setupManagerWithAccount(account)
+
+  const selection = await manager.selectAccountForRequest([
+    { modelId: "free-model", endpoint: "/chat/completions" },
+  ])
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.costUnits).toBe(0)
+  expect(selection.reservation).toBeUndefined()
+  expect(account.premiumReserved).toBeUndefined()
+})

--- a/tests/accounts-registry.test.ts
+++ b/tests/accounts-registry.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+
+import {
+  hasRegistry,
+  loadRegistry,
+  validateAccountId,
+} from "../src/lib/accounts-registry"
+
+type ReadFile = typeof fs.readFile
+
+const withMockedReadFile = async <T>(
+  impl: ReadFile,
+  run: () => Promise<T>,
+): Promise<T> => {
+  const original = fs.readFile
+  ;(fs as unknown as { readFile: ReadFile }).readFile = impl
+  try {
+    return await run()
+  } finally {
+    ;(fs as unknown as { readFile: ReadFile }).readFile = original
+  }
+}
+
+test("validateAccountId follows GitHub login rules", () => {
+  // valid
+  expect(validateAccountId("octocat")).toBe(true)
+  expect(validateAccountId("a-1")).toBe(true)
+  expect(validateAccountId("A1")).toBe(true)
+
+  // invalid
+  expect(validateAccountId("a_b")).toBe(false)
+  expect(validateAccountId("-abc")).toBe(false)
+  expect(validateAccountId("abc-")).toBe(false)
+  expect(validateAccountId("a--b")).toBe(false)
+  expect(validateAccountId("a".repeat(40))).toBe(false)
+})
+
+test("loadRegistry returns empty registry on ENOENT", async () => {
+  const registry = await withMockedReadFile(
+    (() => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException
+      err.code = "ENOENT"
+      throw err
+    }) as unknown as ReadFile,
+    loadRegistry,
+  )
+
+  expect(registry).toEqual({ version: 1, accounts: [] })
+})
+
+test("loadRegistry returns empty registry on empty file", async () => {
+  const registry = await withMockedReadFile(
+    (() => "   \n") as unknown as ReadFile,
+    loadRegistry,
+  )
+
+  expect(registry).toEqual({ version: 1, accounts: [] })
+})
+
+test("loadRegistry throws on invalid JSON", async () => {
+  try {
+    await withMockedReadFile((() => "{") as unknown as ReadFile, loadRegistry)
+    throw new Error("Expected loadRegistry to throw")
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    expect(message).toMatch(/Invalid accounts registry JSON at/)
+  }
+})
+
+test("loadRegistry throws on schema validation errors", async () => {
+  const content = JSON.stringify({
+    version: 1,
+    accounts: [{ id: "octocat", accountType: "foo", addedAt: 1 }],
+  })
+
+  try {
+    await withMockedReadFile(
+      (() => content) as unknown as ReadFile,
+      loadRegistry,
+    )
+    throw new Error("Expected loadRegistry to throw")
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    expect(message).toMatch(/accounts\.0\.accountType/)
+  }
+})
+
+test("loadRegistry throws on duplicate account ids", async () => {
+  const content = JSON.stringify({
+    version: 1,
+    accounts: [
+      { id: "octocat", accountType: "individual", addedAt: 1 },
+      { id: "octocat", accountType: "business", addedAt: 2 },
+    ],
+  })
+
+  try {
+    await withMockedReadFile(
+      (() => content) as unknown as ReadFile,
+      loadRegistry,
+    )
+    throw new Error("Expected loadRegistry to throw")
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    expect(message).toMatch(/duplicate account id "octocat"/)
+  }
+})
+
+test("hasRegistry fails fast on invalid registry JSON", async () => {
+  try {
+    await withMockedReadFile((() => "{") as unknown as ReadFile, hasRegistry)
+    throw new Error("Expected hasRegistry to throw")
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    expect(message).toMatch(/Invalid accounts registry JSON at/)
+  }
+})

--- a/tests/create-chat-completions.test.ts
+++ b/tests/create-chat-completions.test.ts
@@ -6,6 +6,7 @@ import { state } from "../src/lib/state"
 import { createChatCompletions } from "../src/services/copilot/create-chat-completions"
 
 // Mock state
+state.githubToken = "test-github-token"
 state.copilotToken = "test-token"
 state.vsCodeVersion = "1.0.0"
 state.accountType = "individual"


### PR DESCRIPTION
## Summary

- Add support for multiple GitHub Copilot accounts with automatic switching based on quota exhaustion
- Implement account management via CLI: `auth add`, `auth ls`, `auth rm`
- Add hot reload for accounts registry (auto-detect file changes)
- Add `/usage/:accountIndex` endpoint for detailed account usage
- Update documentation with multi-account usage instructions

## Key Features

- **Multi-account management**: Add multiple GitHub Copilot accounts (A→B→C…), used strictly in order
- **Automatic switching**: When an account's `premium_interactions.remaining=0`, automatically switch to the next account
- **CLI commands**:
  - `copilot-api auth add` - Add a new account
  - `copilot-api auth ls [-q]` - List accounts (with quota info)
  - `copilot-api auth rm <id|index>` - Remove an account
- **Hot reload**: Automatically detect changes to `accounts-registry.json`
- **Backward compatible**: Auto-migrate legacy single-account token

## Test Plan

- [ ] Add multiple accounts and verify they are stored correctly
- [ ] Exhaust first account quota and verify automatic switching
- [ ] Test `auth ls -q` shows correct quota information
- [ ] Test `auth rm` removes accounts correctly
- [ ] Verify hot reload works when modifying accounts-registry.json
- [ ] Test Docker multi-account workflow