### PR TITLE
feat(accounts): configurable free-model load balancing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 
 # build output
 dist/
+/.serena

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A reverse-engineered proxy for the GitHub Copilot API that exposes it as an Open
 - **Token Visibility**: Option to display GitHub and Copilot tokens during authentication and refresh for debugging (`--show-token`).
 - **Flexible Authentication**: Authenticate interactively or provide a GitHub token directly, suitable for CI/CD environments.
 - **Support for Different Account Types**: Works with individual, business, and enterprise GitHub Copilot plans.
-- **Multi-Account Support**: Use multiple GitHub Copilot accounts with automatic switching. When one account's quota is exhausted, the proxy automatically switches to the next available account.
+- **Multi-Account Support**: Use multiple GitHub Copilot accounts with automatic routing: premium models use accounts in order and fall back on quota exhaustion; free models are distributed round-robin across accounts by default (configurable in config.json).
 
 ## Demo
 
@@ -96,7 +96,8 @@ docker run -it -v $(pwd)/copilot-data:/root/.local/share/copilot-api copilot-api
 docker run -it -v $(pwd)/copilot-data:/root/.local/share/copilot-api copilot-api --auth ls -q
 ```
 
-> **Note:** When using multiple accounts, all account data (tokens and registry) is stored in the mounted `copilot-data` directory. The proxy will automatically switch to the next account when the current account's quota is exhausted.
+> **Note:** When using multiple accounts, all account data (tokens and registry) is stored in the mounted `copilot-data` directory.
+> Premium-model requests use accounts in order and automatically switch when premium quota is exhausted; free-model requests are distributed round-robin across accounts by default (configurable in config.json).
 
 ### Docker with Environment Variables
 
@@ -232,6 +233,7 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
       "gpt-5.1-codex-max": "<built-in exploration prompt>"
     },
     "smallModel": "gpt-5-mini",
+    "freeModelLoadBalancing": true,
     "modelReasoningEfforts": {
       "gpt-5-mini": "low"
     }
@@ -239,6 +241,7 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
   ```
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Copilot. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts.
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests) to avoid spending premium requests; defaults to `gpt-5-mini`.
+- **freeModelLoadBalancing:** Enable round-robin routing for free-model requests across multiple accounts. Defaults to `true`. Set to `false` to route free-model requests sequentially (same ordering strategy as premium models).
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
 
 Edit this file to customize prompts or swap in your own fast model. Restart the server (or rerun the command) after changes so the cached config is refreshed.
@@ -438,4 +441,7 @@ bun run start
   - `--rate-limit <seconds>`: Enforces a minimum time interval between requests. For example, `copilot-api start --rate-limit 30` will ensure there's at least a 30-second gap between requests.
   - `--wait`: Use this with `--rate-limit`. It makes the server wait for the cooldown period to end instead of rejecting the request with an error. This is useful for clients that don't automatically retry on rate limit errors.
 - If you have a GitHub business or enterprise plan account with Copilot, use the `--account-type` flag (e.g., `--account-type business`). See the [official documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network#configuring-copilot-subscription-based-network-routing-for-your-enterprise-or-organization) for more details.
-- **Multi-account quota management**: Add multiple GitHub Copilot accounts using `auth add`. Accounts are used in the order they were added. When an account's premium request quota (`remaining=0`) is exhausted, the proxy automatically switches to the next account.
+- **Multi-account request routing**: Add multiple GitHub Copilot accounts using `auth add`.
+  - **Premium models**: Accounts are tried in the order they were added. When an account's premium request quota (`remaining=0`) is exhausted (or insufficient for the selected model), the proxy automatically switches to the next eligible account.
+  - **Free models**: By default, requests are distributed round-robin across all eligible accounts (including the temporary account created via `start --github-token ...`). Set `freeModelLoadBalancing=false` in `config.json` to disable this and route free-model requests sequentially.
+  - **Model classification**: Based on Copilot model metadata (`billing.is_premium` / `billing.multiplier`). Missing billing info or `billing.is_premium !== true` is treated as free.

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -80,6 +80,7 @@ export class AccountsManager {
   private temporaryAccount?: AccountRuntime
   private vsCodeVersion?: string
   private freeModelCursor = 0
+  private freeModelLoadBalancingEnabled = true
 
   // Registry file watcher for hot reload
   private registryWatcher?: fs.FSWatcher
@@ -138,6 +139,10 @@ export class AccountsManager {
 
     // Start watching the registry file for hot reload
     this.startRegistryWatcher()
+  }
+
+  setFreeModelLoadBalancingEnabled(enabled: boolean): void {
+    this.freeModelLoadBalancingEnabled = enabled
   }
 
   /**
@@ -530,9 +535,20 @@ export class AccountsManager {
       const { candidate, model } = supported
       const costUnits = this.getCostUnits(model)
 
-      // Free model: RR load balancing across accounts (including temporaryAccount).
       if (costUnits <= 0) {
-        return this.selectFreeAccountForRequest(orderedAccounts, candidates)
+        if (this.freeModelLoadBalancingEnabled) {
+          // Free model: RR load balancing across accounts (including temporaryAccount).
+          return this.selectFreeAccountForRequest(orderedAccounts, candidates)
+        }
+
+        // Free model: sequential routing (same ordering strategy as premium models).
+        return {
+          ok: true,
+          account,
+          selectedModel: model,
+          endpoint: candidate.endpoint,
+          costUnits,
+        }
       }
 
       if (!account.unlimited && this.isQuotaCacheExpired(account)) {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -79,6 +79,7 @@ export class AccountsManager {
   private accountOrder: Array<string> = []
   private temporaryAccount?: AccountRuntime
   private vsCodeVersion?: string
+  private freeModelCursor = 0
 
   // Registry file watcher for hot reload
   private registryWatcher?: fs.FSWatcher
@@ -434,6 +435,55 @@ export class AccountsManager {
     return null
   }
 
+  private selectFreeAccountForRequest(
+    orderedAccounts: Array<AccountRuntime>,
+    candidates: Array<AccountRequestCandidate>,
+  ): SelectAccountForRequestResult {
+    const count = orderedAccounts.length
+    const start = this.freeModelCursor % count
+
+    let supportedCandidateFound = false
+
+    for (let i = 0; i < count; i++) {
+      const idx = (start + i) % count
+      const account = orderedAccounts[idx]
+      if (this.isAccountFailed(account)) {
+        continue
+      }
+
+      const supported = this.pickSupportedCandidate(account, candidates)
+      if (!supported) {
+        continue
+      }
+
+      supportedCandidateFound = true
+
+      const { candidate, model } = supported
+      const costUnits = this.getCostUnits(model)
+
+      // Defensive: free path should only be used for free models.
+      if (costUnits > 0) {
+        continue
+      }
+
+      this.freeModelCursor = (idx + 1) % count
+
+      return {
+        ok: true,
+        account,
+        selectedModel: model,
+        endpoint: candidate.endpoint,
+        costUnits,
+      }
+    }
+
+    if (!supportedCandidateFound) {
+      return { ok: false, reason: "MODEL_NOT_SUPPORTED" }
+    }
+
+    return { ok: false, reason: "NO_QUOTA" }
+  }
+
   /**
    * Select an available account for a specific request (model + endpoint).
    * Uses reservation to avoid oversubscribing premium quota under concurrency.
@@ -478,6 +528,12 @@ export class AccountsManager {
       supportedCandidateFound = true
 
       const { candidate, model } = supported
+      const costUnits = this.getCostUnits(model)
+
+      // Free model: RR load balancing across accounts (including temporaryAccount).
+      if (costUnits <= 0) {
+        return this.selectFreeAccountForRequest(orderedAccounts, candidates)
+      }
 
       if (!account.unlimited && this.isQuotaCacheExpired(account)) {
         await this.refreshQuota(account)
@@ -487,9 +543,7 @@ export class AccountsManager {
         continue
       }
 
-      const costUnits = this.getCostUnits(model)
-
-      if (account.unlimited || costUnits <= 0) {
+      if (account.unlimited) {
         return {
           ok: true,
           account,
@@ -808,6 +862,9 @@ export class AccountsManager {
       this.accountOrder = newMetas
         .map((m) => m.id)
         .filter((id) => this.accounts.has(id))
+
+      // Reset free-model RR cursor on account list/order changes.
+      this.freeModelCursor = 0
 
       this.logRegistryReloadChanges(added, removed, updated)
     } catch (error) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -115,17 +115,36 @@ function mergeDefaultFreeModelLoadBalancing(config: AppConfig): {
   }
 }
 
+type ConfigMergeResult = {
+  mergedConfig: AppConfig
+  changed: boolean
+}
+
+type ConfigMergeFn = (config: AppConfig) => ConfigMergeResult
+
+function applyConfigMerges(
+  config: AppConfig,
+  mergeFns: ReadonlyArray<ConfigMergeFn>,
+): ConfigMergeResult {
+  return mergeFns.reduce<ConfigMergeResult>(
+    (acc, mergeFn) => {
+      const result = mergeFn(acc.mergedConfig)
+      return {
+        mergedConfig: result.mergedConfig,
+        changed: acc.changed || result.changed,
+      }
+    },
+    { mergedConfig: config, changed: false },
+  )
+}
+
 export function mergeConfigWithDefaults(): AppConfig {
   const config = readConfigFromDisk()
 
-  const extraPromptsMerge = mergeDefaultExtraPrompts(config)
-  const freeModelLoadBalancingMerge = mergeDefaultFreeModelLoadBalancing(
-    extraPromptsMerge.mergedConfig,
-  )
-
-  const mergedConfig = freeModelLoadBalancingMerge.mergedConfig
-  const changed =
-    extraPromptsMerge.changed || freeModelLoadBalancingMerge.changed
+  const { mergedConfig, changed } = applyConfigMerges(config, [
+    mergeDefaultExtraPrompts,
+    mergeDefaultFreeModelLoadBalancing,
+  ])
 
   if (changed) {
     try {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,7 @@ import { PATHS } from "./paths"
 export interface AppConfig {
   extraPrompts?: Record<string, string>
   smallModel?: string
+  freeModelLoadBalancing?: boolean
   modelReasoningEfforts?: Record<
     string,
     "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
@@ -25,6 +26,7 @@ const defaultConfig: AppConfig = {
     "gpt-5.1-codex-max": gpt5ExplorationPrompt,
   },
   smallModel: "gpt-5-mini",
+  freeModelLoadBalancing: true,
   modelReasoningEfforts: {
     "gpt-5-mini": "low",
   },
@@ -96,9 +98,34 @@ function mergeDefaultExtraPrompts(config: AppConfig): {
   }
 }
 
+function mergeDefaultFreeModelLoadBalancing(config: AppConfig): {
+  mergedConfig: AppConfig
+  changed: boolean
+} {
+  if (typeof config.freeModelLoadBalancing === "boolean") {
+    return { mergedConfig: config, changed: false }
+  }
+
+  return {
+    mergedConfig: {
+      ...config,
+      freeModelLoadBalancing: defaultConfig.freeModelLoadBalancing ?? true,
+    },
+    changed: true,
+  }
+}
+
 export function mergeConfigWithDefaults(): AppConfig {
   const config = readConfigFromDisk()
-  const { mergedConfig, changed } = mergeDefaultExtraPrompts(config)
+
+  const extraPromptsMerge = mergeDefaultExtraPrompts(config)
+  const freeModelLoadBalancingMerge = mergeDefaultFreeModelLoadBalancing(
+    extraPromptsMerge.mergedConfig,
+  )
+
+  const mergedConfig = freeModelLoadBalancingMerge.mergedConfig
+  const changed =
+    extraPromptsMerge.changed || freeModelLoadBalancingMerge.changed
 
   if (changed) {
     try {
@@ -108,10 +135,7 @@ export function mergeConfigWithDefaults(): AppConfig {
         "utf8",
       )
     } catch (writeError) {
-      consola.warn(
-        "Failed to write merged extraPrompts to config file",
-        writeError,
-      )
+      consola.warn("Failed to write merged config defaults", writeError)
     }
   }
 
@@ -132,6 +156,11 @@ export function getExtraPromptForModel(model: string): string {
 export function getSmallModel(): string {
   const config = getConfig()
   return config.smallModel ?? "gpt-5-mini"
+}
+
+export function isFreeModelLoadBalancingEnabled(): boolean {
+  const config = getConfig()
+  return config.freeModelLoadBalancing ?? true
 }
 
 export function getReasoningEffortForModel(

--- a/src/start.ts
+++ b/src/start.ts
@@ -8,7 +8,10 @@ import invariant from "tiny-invariant"
 
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
-import { mergeConfigWithDefaults } from "./lib/config"
+import {
+  isFreeModelLoadBalancingEnabled,
+  mergeConfigWithDefaults,
+} from "./lib/config"
 import { ensurePaths } from "./lib/paths"
 import { initProxyFromEnv } from "./lib/proxy"
 import { generateEnvScript } from "./lib/shell"
@@ -73,6 +76,9 @@ async function runAuthFlow(accountType: AccountType): Promise<void> {
 export async function runServer(options: RunServerOptions): Promise<void> {
   // Ensure config is merged with defaults at startup
   mergeConfigWithDefaults()
+  accountsManager.setFreeModelLoadBalancingEnabled(
+    isFreeModelLoadBalancingEnabled(),
+  )
 
   if (options.proxyEnv) {
     initProxyFromEnv()

--- a/tests/accounts-manager-free-lb.test.ts
+++ b/tests/accounts-manager-free-lb.test.ts
@@ -302,3 +302,50 @@ test("free RR does not affect premium selection", async () => {
   expect([free1.account.id, free2.account.id]).toEqual(["a", "b"])
   expect(premiumSelection.account.id).toBe("a")
 })
+
+test("selectAccountForRequest routes free models sequentially when freeModelLoadBalancing is disabled", async () => {
+  const model = makeModel({ id: "free-model" })
+
+  const a: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+
+  const b: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  const c: AccountRuntime = {
+    id: "c",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_c",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([a, b, c])
+  manager.setFreeModelLoadBalancingEnabled(false)
+
+  const seen: Array<string> = []
+  for (let i = 0; i < 3; i++) {
+    const selection = await manager.selectAccountForRequest([
+      { modelId: "free-model", endpoint: "/chat/completions" },
+    ])
+
+    expect(selection.ok).toBe(true)
+    if (!selection.ok) return
+
+    seen.push(selection.account.id)
+    expect(selection.costUnits).toBe(0)
+    expect(selection.reservation).toBeUndefined()
+  }
+
+  expect(seen).toEqual(["a", "a", "a"])
+})

--- a/tests/accounts-manager-free-lb.test.ts
+++ b/tests/accounts-manager-free-lb.test.ts
@@ -1,0 +1,304 @@
+import { expect, test } from "bun:test"
+
+import type { AccountRuntime } from "../src/lib/types/account"
+import type { Model, ModelsResponse } from "../src/services/copilot/get-models"
+
+import { AccountsManager } from "../src/lib/accounts-manager"
+
+const makeModel = (overrides: Partial<Model> = {}): Model => {
+  const base: Model = {
+    billing: {
+      is_premium: false,
+      multiplier: 0,
+    },
+    capabilities: {
+      family: "test",
+      limits: {},
+      object: "model_capabilities",
+      supports: {},
+      tokenizer: "test",
+      type: "test",
+    },
+    id: "test-model",
+    model_picker_enabled: true,
+    name: "Test model",
+    object: "model",
+    preview: false,
+    supported_endpoints: ["/chat/completions"],
+    vendor: "test",
+    version: "0",
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  }
+}
+
+const makeModelsResponse = (models: Array<Model>): ModelsResponse => ({
+  object: "list",
+  data: models,
+})
+
+const setupManager = (
+  accounts: Array<AccountRuntime>,
+  options?: { temporaryAccount?: AccountRuntime },
+): AccountsManager => {
+  const manager = new AccountsManager()
+  const internals = manager as unknown as {
+    accounts: Map<string, AccountRuntime>
+    accountOrder: Array<string>
+    temporaryAccount?: AccountRuntime
+  }
+
+  for (const account of accounts) {
+    internals.accounts.set(account.id, account)
+    internals.accountOrder.push(account.id)
+  }
+
+  if (options?.temporaryAccount) {
+    internals.temporaryAccount = options.temporaryAccount
+  }
+
+  return manager
+}
+
+test("selectAccountForRequest round-robins free models across accounts", async () => {
+  const model = makeModel({
+    id: "free-model",
+    billing: {
+      is_premium: false,
+      multiplier: 0,
+    },
+  })
+
+  const a: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const b: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+  const c: AccountRuntime = {
+    id: "c",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_c",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([a, b, c])
+
+  const seen: Array<string> = []
+  for (let i = 0; i < 6; i++) {
+    const selection = await manager.selectAccountForRequest([
+      { modelId: "free-model", endpoint: "/chat/completions" },
+    ])
+
+    expect(selection.ok).toBe(true)
+    if (!selection.ok) return
+
+    seen.push(selection.account.id)
+    expect(selection.costUnits).toBe(0)
+    expect(selection.reservation).toBeUndefined()
+  }
+
+  expect(seen).toEqual(["a", "b", "c", "a", "b", "c"])
+})
+
+test("selectAccountForRequest includes temporaryAccount in free-model RR", async () => {
+  const model = makeModel({ id: "free-model" })
+
+  const temp: AccountRuntime = {
+    id: "temp",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_temp",
+    models: makeModelsResponse([model]),
+  }
+
+  const a: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+
+  const b: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([a, b], { temporaryAccount: temp })
+
+  const seen: Array<string> = []
+  for (let i = 0; i < 6; i++) {
+    const selection = await manager.selectAccountForRequest([
+      { modelId: "free-model", endpoint: "/chat/completions" },
+    ])
+
+    expect(selection.ok).toBe(true)
+    if (!selection.ok) return
+
+    seen.push(selection.account.id)
+  }
+
+  expect(seen).toEqual(["temp", "a", "b", "temp", "a", "b"])
+})
+
+test("selectAccountForRequest skips failed accounts in free-model RR", async () => {
+  const model = makeModel({ id: "free-model" })
+
+  const a: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const b: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+    failed: true,
+    failureReason: "test",
+  }
+  const c: AccountRuntime = {
+    id: "c",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_c",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([a, b, c])
+
+  const seen: Array<string> = []
+  for (let i = 0; i < 4; i++) {
+    const selection = await manager.selectAccountForRequest([
+      { modelId: "free-model", endpoint: "/chat/completions" },
+    ])
+
+    expect(selection.ok).toBe(true)
+    if (!selection.ok) return
+
+    seen.push(selection.account.id)
+  }
+
+  expect(seen).toEqual(["a", "c", "a", "c"])
+})
+
+test("selectAccountForRequest keeps premium model selection sequential (no RR)", async () => {
+  const premium = makeModel({
+    id: "gpt-5",
+    billing: {
+      is_premium: true,
+      multiplier: 1,
+    },
+  })
+
+  const a: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([premium]),
+    premiumRemaining: 10,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const b: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([premium]),
+    premiumRemaining: 10,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const manager = setupManager([a, b])
+
+  const seen: Array<string> = []
+  for (let i = 0; i < 3; i++) {
+    const selection = await manager.selectAccountForRequest([
+      { modelId: "gpt-5", endpoint: "/chat/completions" },
+    ])
+
+    expect(selection.ok).toBe(true)
+    if (!selection.ok) return
+
+    seen.push(selection.account.id)
+    expect(selection.costUnits).toBe(1)
+    expect(selection.reservation).toBeDefined()
+  }
+
+  expect(seen).toEqual(["a", "a", "a"])
+})
+
+test("free RR does not affect premium selection", async () => {
+  const free = makeModel({ id: "free-model" })
+  const premium = makeModel({
+    id: "gpt-5",
+    billing: {
+      is_premium: true,
+      multiplier: 1,
+    },
+  })
+
+  const a: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([free, premium]),
+    premiumRemaining: 10,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const b: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([free, premium]),
+    premiumRemaining: 10,
+    lastQuotaFetch: Date.now(),
+  }
+
+  const manager = setupManager([a, b])
+
+  const free1 = await manager.selectAccountForRequest([
+    { modelId: "free-model", endpoint: "/chat/completions" },
+  ])
+  expect(free1.ok).toBe(true)
+  if (!free1.ok) return
+
+  const free2 = await manager.selectAccountForRequest([
+    { modelId: "free-model", endpoint: "/chat/completions" },
+  ])
+  expect(free2.ok).toBe(true)
+  if (!free2.ok) return
+
+  const premiumSelection = await manager.selectAccountForRequest([
+    { modelId: "gpt-5", endpoint: "/chat/completions" },
+  ])
+  expect(premiumSelection.ok).toBe(true)
+  if (!premiumSelection.ok) return
+
+  expect([free1.account.id, free2.account.id]).toEqual(["a", "b"])
+  expect(premiumSelection.account.id).toBe("a")
+})


### PR DESCRIPTION
## Summary
- Add `freeModelLoadBalancing` config (default: true) in `~/.local/share/copilot-api/config.json` to control routing for free models (`costUnits=0`).
- When enabled, free-model requests are distributed round-robin across eligible accounts (including the temporary account).
- When disabled, free-model requests follow the same sequential account-order strategy as premium models.
- Update README and tests for both modes.

## Test plan
- [x] bun test