### PR TITLE
feat(admin): add request logging dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules/
 # build output
 dist/
 /.serena
+.DS_Store
+/.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A reverse-engineered proxy for the GitHub Copilot API that exposes it as an Open
 - **OpenAI & Anthropic Compatibility**: Exposes GitHub Copilot as an OpenAI-compatible (`/v1/chat/completions`, `/v1/models`, `/v1/embeddings`) and Anthropic-compatible (`/v1/messages`) API.
 - **Claude Code Integration**: Easily configure and launch [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) to use Copilot as its backend with a simple command-line flag (`--claude-code`).
 - **Usage Dashboard**: A web-based dashboard to monitor your Copilot API usage, view quotas, and see detailed statistics.
+- **Admin UI**: Built-in admin page (`/admin`) to inspect account runtime status and request history (models/endpoints, tokens/usage, errors).
 - **Rate Limit Control**: Manage API usage with rate-limiting options (`--rate-limit`) and a waiting mechanism (`--wait`) to prevent errors from rapid requests.
 - **Manual Request Approval**: Manually approve or deny each API request for fine-grained control over usage (`--manual`).
 - **Token Visibility**: Option to display GitHub and Copilot tokens during authentication and refresh for debugging (`--show-token`).
@@ -79,7 +80,7 @@ docker run -p 4141:4141 -v $(pwd)/copilot-data:/root/.local/share/copilot-api co
 ```
 
 > **Note:**
-> The GitHub token and related data will be stored in `copilot-data` on your host. This is mapped to `/root/.local/share/copilot-api` inside the container, ensuring persistence across restarts.
+> The GitHub token and related data will be stored in `copilot-data` on your host. This is mapped to `/root/.local/share/copilot-api` inside the container, ensuring persistence across restarts. This directory also stores the admin request history database (`admin.sqlite`) used by `/admin`.
 
 ### Adding Multiple Accounts in Docker
 
@@ -110,6 +111,10 @@ docker build --build-arg GH_TOKEN=your_github_token_here -t copilot-api .
 # Run with GitHub token
 docker run -p 4141:4141 -e GH_TOKEN=your_github_token_here copilot-api
 
+# (Optional) Enable remote admin UI/API access
+# This requires setting ADMIN_TOKEN and sending it via request headers (x-admin-token / Authorization: Bearer)
+docker run -p 4141:4141 -e GH_TOKEN=your_github_token_here -e ADMIN_TOKEN=your_admin_token_here copilot-api
+
 # Run with additional options
 docker run -p 4141:4141 -e GH_TOKEN=your_token copilot-api --verbose --port 4141
 ```
@@ -125,6 +130,7 @@ services:
       - "4141:4141"
     environment:
       - GH_TOKEN=your_github_token_here
+      - ADMIN_TOKEN=your_admin_token_here
     restart: unless-stopped
 ```
 
@@ -285,6 +291,34 @@ Endpoints for monitoring your Copilot usage and quotas across all accounts.
 > - If you start the server with `start --github-token ...`, a temporary account is included and shown as `"(temporary)"` in `GET /usage`. In that case, `index=0` refers to the temporary account and registered accounts start at `index=1`.
 > - `auth rm <index>` uses a **1-based** index (as shown by `auth ls`).
 
+### Admin UI & Admin API
+
+The server also exposes a built-in admin UI and API for inspecting account status and request history captured by the proxy.
+
+| Endpoint                            | Method | Description                                                          |
+| ----------------------------------- | ------ | -------------------------------------------------------------------- |
+| `GET /admin`                        | `GET`  | Built-in admin UI (single-page web app).                             |
+| `GET /api/admin/meta`               | `GET`  | Admin DB metadata (db path, retention, etc.).                        |
+| `GET /api/admin/accounts`           | `GET`  | List accounts with runtime status and (optional) aggregated stats.    |
+| `GET /api/admin/requests`           | `GET`  | Query request logs with filters and cursor pagination.               |
+| `GET /api/admin/requests/:requestId`| `GET`  | Get a single request log entry by request ID.                        |
+
+#### Authentication & access
+
+- **Loopback access** is allowed by default when the hostname is `localhost`, `127.0.0.1`, or `::1`.
+- **Remote access** is disabled unless you set `ADMIN_TOKEN` on the server.
+- When `ADMIN_TOKEN` is set, send the token using one of:
+  - `x-admin-token: <token>`
+  - `Authorization: Bearer <token>`
+- Tokens in URL query parameters are intentionally not supported.
+
+#### Requests query (pagination & filters)
+
+- `limit` defaults to 50 and is clamped to a max of 200.
+- `cursor_id` is an integer cursor for pagination (use the `next_cursor_id` from the previous response).
+- Filters: `account_id`, `upstream_model`, `client_model`, `upstream_endpoint`, `path`, `status`, `has_error`, `from_ms`, `to_ms`.
+- Response fields: `items`, `next_cursor_id`, `has_more`.
+
 ## Example Usage
 
 Using with npx:
@@ -349,6 +383,27 @@ npx copilot-api@latest debug --json
 npx copilot-api@latest start --proxy-env
 ```
 
+### Admin API examples
+
+```sh
+# Loopback access (no token required)
+curl "http://localhost:4141/api/admin/meta"
+
+# Enable remote admin UI/API access (server-side)
+# ADMIN_TOKEN=your_admin_token_here npx copilot-api@latest start
+
+# Remote access (token required)
+curl -H "x-admin-token: your_admin_token_here" "http://localhost:4141/api/admin/accounts?include_stats=1"
+
+# Request logs (filters + pagination)
+curl "http://localhost:4141/api/admin/requests?limit=50&has_error=1"
+# Use next_cursor_id from the response for pagination:
+curl "http://localhost:4141/api/admin/requests?limit=50&cursor_id=<next_cursor_id>"
+
+# Single request detail
+curl "http://localhost:4141/api/admin/requests/<requestId>"
+```
+
 ## Using the Usage Viewer
 
 After starting the server, a URL to the Copilot Usage Dashboard will be displayed in your console. This dashboard is a web interface for monitoring your API usage.
@@ -369,6 +424,36 @@ The dashboard provides a user-friendly interface to view your Copilot usage data
 - **Detailed Information**: See the full JSON response from the API for a detailed breakdown of all available usage statistics.
 - **URL-based Configuration**: You can also specify the API endpoint directly in the URL using a query parameter. This is useful for bookmarks or sharing links. For example:
   `https://ericc-ch.github.io/copilot-api?endpoint=http://your-api-server/usage`
+
+## Using the Admin UI (/admin)
+
+The proxy includes a built-in admin UI served from your running instance. It lets you inspect account status and request history captured by the proxy (models/endpoints, tokens/usage, timing, and error summaries).
+
+1. Start the server. For example, using npx:
+    ```sh
+    npx copilot-api@latest start
+    ```
+2. Open the UI in your browser:
+    - `http://localhost:4141/admin` (replace the port if you changed it)
+
+### Access control
+
+- When accessing via `localhost` / `127.0.0.1` / `::1`, the admin API is available without a token.
+- For non-loopback access (e.g. using a machine IP or hostname), you must enable remote access by setting `ADMIN_TOKEN` on the server and provide the token in requests.
+
+The UI stores the token in `sessionStorage` and sends it as the `x-admin-token` header (it is never placed in the URL).
+
+If you see:
+- `403 forbidden`: the admin API is restricted to localhost unless `ADMIN_TOKEN` is set (or the request was blocked as cross-origin).
+- `401 unauthorized`: `ADMIN_TOKEN` is set but the request did not include a valid token.
+
+### Data storage (admin.sqlite)
+
+- Request history is stored in `admin.sqlite` under the app data directory:
+  - Linux/macOS: `~/.local/share/copilot-api/admin.sqlite`
+  - Windows: `%USERPROFILE%\.local\share\copilot-api\admin.sqlite`
+- By default, the proxy keeps up to 14 days of logs and caps the DB at 200,000 rows (older entries are cleaned up automatically).
+- For safety, the admin DB stores metadata only (no GitHub/Copilot tokens and no request/response content).
 
 ## Using with Claude Code
 

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -10,6 +10,31 @@ const DEFAULT_DB_PATH = path.join(PATHS.APP_DIR, ADMIN_DB_FILENAME)
 let sharedDb: Database | null = null
 let initialized = false
 
+const INIT_WARN_THROTTLE_MS = 30_000
+
+let lastInitWarnAtMs = 0
+let suppressedInitWarnCount = 0
+
+function warnAdminDbInitFailure(error: unknown): void {
+  const now = Date.now()
+
+  if (now - lastInitWarnAtMs < INIT_WARN_THROTTLE_MS) {
+    suppressedInitWarnCount++
+    return
+  }
+
+  const suppressed = suppressedInitWarnCount
+  suppressedInitWarnCount = 0
+  lastInitWarnAtMs = now
+
+  const suffix =
+    suppressed > 0 ? ` (suppressed ${suppressed} similar errors)` : ""
+  consola.warn(
+    `Failed to initialize admin DB; admin features disabled${suffix}`,
+    error,
+  )
+}
+
 export function getAdminDbPath(): string {
   return DEFAULT_DB_PATH
 }
@@ -34,15 +59,12 @@ export function getAdminDb(): Database {
     sharedDb = openAdminDb()
   }
   if (!initialized) {
-    initialized = true
     try {
       initAdminDb(sharedDb)
+      initialized = true
     } catch (error) {
       // Admin DB is a best-effort feature; server should continue to run.
-      consola.warn(
-        "Failed to initialize admin DB; admin features disabled",
-        error,
-      )
+      warnAdminDbInitFailure(error)
     }
   }
   return sharedDb

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -1,0 +1,130 @@
+import { Database } from "bun:sqlite"
+import consola from "consola"
+import path from "node:path"
+
+import { PATHS } from "./paths"
+
+const ADMIN_DB_FILENAME = "admin.sqlite"
+const DEFAULT_DB_PATH = path.join(PATHS.APP_DIR, ADMIN_DB_FILENAME)
+
+let sharedDb: Database | null = null
+let initialized = false
+
+export function getAdminDbPath(): string {
+  return DEFAULT_DB_PATH
+}
+
+export function openAdminDb(filePath: string = DEFAULT_DB_PATH): Database {
+  return new Database(filePath)
+}
+
+export function initAdminDb(db: Database): void {
+  // Pragmas: prefer WAL for concurrent reads, keep writes fast.
+  // Note: journal_mode=WAL is per-database and persists in the DB file.
+  db.run("PRAGMA journal_mode = WAL;")
+  db.run("PRAGMA synchronous = NORMAL;")
+  db.run("PRAGMA busy_timeout = 3000;")
+  db.run("PRAGMA foreign_keys = ON;")
+
+  migrateAdminDb(db)
+}
+
+export function getAdminDb(): Database {
+  if (!sharedDb) {
+    sharedDb = openAdminDb()
+  }
+  if (!initialized) {
+    initialized = true
+    try {
+      initAdminDb(sharedDb)
+    } catch (error) {
+      // Admin DB is a best-effort feature; server should continue to run.
+      consola.warn(
+        "Failed to initialize admin DB; admin features disabled",
+        error,
+      )
+    }
+  }
+  return sharedDb
+}
+
+export function getAdminDbUserVersion(db: Database = getAdminDb()): number {
+  try {
+    const row = db.query("PRAGMA user_version;").get() as {
+      user_version?: number
+    } | null
+    return row?.user_version ?? 0
+  } catch {
+    return 0
+  }
+}
+
+function migrateAdminDb(db: Database): void {
+  const row = db.query("PRAGMA user_version;").get() as {
+    user_version?: number
+  } | null
+  const current = row?.user_version ?? 0
+
+  if (current >= 1) {
+    return
+  }
+
+  // v1: request_log table
+  db.run(`
+    CREATE TABLE IF NOT EXISTS request_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      request_id TEXT NOT NULL UNIQUE,
+
+      started_at_ms INTEGER NOT NULL,
+      finished_at_ms INTEGER,
+      duration_ms INTEGER,
+      ttfb_ms INTEGER,
+
+      method TEXT NOT NULL,
+      path TEXT NOT NULL,
+      upstream_endpoint TEXT,
+      stream INTEGER NOT NULL DEFAULT 0,
+
+      account_id TEXT,
+      account_type TEXT,
+      cost_units REAL,
+      client_model TEXT,
+      upstream_model TEXT,
+
+      client_ip TEXT,
+      client_ip_source TEXT,
+      user_agent TEXT,
+
+      tokens_input INTEGER,
+      tokens_output INTEGER,
+      tokens_total INTEGER,
+      tokens_cached_input INTEGER,
+      usage_json TEXT,
+
+      premium_remaining_before REAL,
+      premium_remaining_after REAL,
+      premium_remaining_diff REAL,
+      premium_unlimited_before INTEGER,
+      premium_unlimited_after INTEGER,
+
+      http_status INTEGER,
+      error_name TEXT,
+      error_status INTEGER,
+      error_message TEXT,
+      selection_failure_reason TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_request_log_started_at
+      ON request_log(started_at_ms DESC);
+    CREATE INDEX IF NOT EXISTS idx_request_log_account_started_at
+      ON request_log(account_id, started_at_ms DESC);
+    CREATE INDEX IF NOT EXISTS idx_request_log_model_started_at
+      ON request_log(upstream_model, started_at_ms DESC);
+    CREATE INDEX IF NOT EXISTS idx_request_log_endpoint_started_at
+      ON request_log(upstream_endpoint, started_at_ms DESC);
+    CREATE INDEX IF NOT EXISTS idx_request_log_status_started_at
+      ON request_log(http_status, started_at_ms DESC);
+
+    PRAGMA user_version = 1;
+  `)
+}

--- a/src/lib/handler-utils.ts
+++ b/src/lib/handler-utils.ts
@@ -1,0 +1,51 @@
+import type { AccountContext, AccountRuntime } from "~/lib/types/account"
+
+import { HTTPError } from "~/lib/error"
+
+export type ErrorDetails = {
+  httpStatus: number
+  errorName: string
+  errorStatus: number | undefined
+  errorMessage: string
+  unauthorized: boolean
+}
+
+export function truncate(value: string, max: number = 2000): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}…`
+}
+
+export function computeDiff(
+  before?: number,
+  after?: number,
+): number | undefined {
+  if (typeof before !== "number" || typeof after !== "number") return undefined
+  return after - before
+}
+
+export function toAccountContext(account: AccountRuntime): AccountContext {
+  return {
+    githubToken: account.githubToken,
+    copilotToken: account.copilotToken,
+    accountType: account.accountType,
+    vsCodeVersion: account.vsCodeVersion,
+  }
+}
+
+export function extractErrorDetails(error: unknown): ErrorDetails {
+  const errorName = error instanceof Error ? error.name : "Error"
+  const errorMessage =
+    error instanceof Error ? truncate(error.message) : truncate(String(error))
+
+  const errorStatus =
+    error instanceof HTTPError ? error.response.status : undefined
+  const httpStatus = errorStatus ?? 500
+
+  return {
+    httpStatus,
+    errorName,
+    errorStatus,
+    errorMessage,
+    unauthorized: errorStatus === 401,
+  }
+}

--- a/src/lib/request-history.test.ts
+++ b/src/lib/request-history.test.ts
@@ -1,0 +1,363 @@
+import type { Context } from "hono"
+
+import { Database } from "bun:sqlite"
+import { describe, expect, test } from "bun:test"
+
+import type {
+  ChatCompletionChunk,
+  ChatCompletionResponse,
+} from "~/services/copilot/create-chat-completions"
+import type { EmbeddingResponse } from "~/services/copilot/create-embeddings"
+import type {
+  ResponseStreamEvent,
+  ResponseUsage,
+  ResponsesResult,
+} from "~/services/copilot/create-responses"
+
+import { initAdminDb } from "~/lib/admin-db"
+import {
+  RequestHistoryStore,
+  extractResponsesUsageFromResult,
+  extractResponsesUsageFromStreamEvent,
+  getClientIpInfo,
+  normalizeChatCompletionsUsage,
+  normalizeEmbeddingsUsage,
+  normalizeResponsesUsage,
+} from "~/lib/request-history"
+
+describe("normalizeChatCompletionsUsage", () => {
+  test("subtracts cached prompt tokens", () => {
+    const usage: ChatCompletionResponse["usage"] = {
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+      prompt_tokens_details: {
+        cached_tokens: 30,
+      },
+    }
+
+    expect(normalizeChatCompletionsUsage(usage)).toEqual({
+      tokensCachedInput: 30,
+      tokensInput: 70,
+      tokensOutput: 20,
+      tokensTotal: 120,
+      usageJson: JSON.stringify(usage),
+    })
+  })
+
+  test("works with streaming chunk usage", () => {
+    const usage: ChatCompletionChunk["usage"] = {
+      prompt_tokens: 10,
+      completion_tokens: 2,
+      total_tokens: 12,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+      },
+    }
+
+    expect(normalizeChatCompletionsUsage(usage).tokensTotal).toBe(12)
+  })
+})
+
+describe("normalizeResponsesUsage", () => {
+  test("subtracts cached input tokens", () => {
+    const usage: ResponseUsage = {
+      input_tokens: 50,
+      output_tokens: 10,
+      total_tokens: 60,
+      input_tokens_details: {
+        cached_tokens: 20,
+      },
+    }
+
+    expect(normalizeResponsesUsage(usage)).toEqual({
+      tokensCachedInput: 20,
+      tokensInput: 30,
+      tokensOutput: 10,
+      tokensTotal: 60,
+      usageJson: JSON.stringify(usage),
+    })
+  })
+})
+
+describe("normalizeEmbeddingsUsage", () => {
+  test("maps embedding usage", () => {
+    const usage: EmbeddingResponse["usage"] = {
+      prompt_tokens: 7,
+      total_tokens: 7,
+    }
+
+    expect(normalizeEmbeddingsUsage(usage)).toEqual({
+      tokensCachedInput: 0,
+      tokensInput: 7,
+      tokensOutput: 0,
+      tokensTotal: 7,
+      usageJson: JSON.stringify(usage),
+    })
+  })
+})
+
+describe("extractResponsesUsageFromStreamEvent", () => {
+  test("reads usage from response.completed", () => {
+    const usage: ResponseUsage = {
+      input_tokens: 5,
+      output_tokens: 1,
+      total_tokens: 6,
+      input_tokens_details: { cached_tokens: 2 },
+    }
+
+    const event = {
+      type: "response.completed",
+      sequence_number: 1,
+      response: {
+        usage,
+      },
+    } as ResponseStreamEvent
+
+    expect(extractResponsesUsageFromStreamEvent(event).tokensTotal).toBe(6)
+    expect(extractResponsesUsageFromStreamEvent(event).tokensInput).toBe(3)
+  })
+})
+
+describe("extractResponsesUsageFromResult", () => {
+  test("reads usage from result", () => {
+    const usage: ResponseUsage = {
+      input_tokens: 10,
+      output_tokens: 4,
+      total_tokens: 14,
+      input_tokens_details: { cached_tokens: 0 },
+    }
+
+    const result = {
+      usage,
+    } as ResponsesResult
+
+    expect(extractResponsesUsageFromResult(result).tokensOutput).toBe(4)
+  })
+})
+
+describe("getClientIpInfo", () => {
+  test("prefers cf-connecting-ip", () => {
+    const c = {
+      req: {
+        header: (name: string) => {
+          if (name.toLowerCase() === "cf-connecting-ip") return "203.0.113.1"
+          return undefined
+        },
+      },
+    } as unknown as Context
+
+    expect(getClientIpInfo(c)).toEqual({
+      ip: "203.0.113.1",
+      source: "cf-connecting-ip",
+    })
+  })
+
+  test("uses first x-forwarded-for", () => {
+    const c = {
+      req: {
+        header: (name: string) => {
+          if (name.toLowerCase() === "x-forwarded-for") {
+            return "198.51.100.10, 198.51.100.11"
+          }
+          return undefined
+        },
+      },
+    } as unknown as Context
+
+    expect(getClientIpInfo(c)).toEqual({
+      ip: "198.51.100.10",
+      source: "x-forwarded-for",
+    })
+  })
+
+  test("falls back to x-real-ip", () => {
+    const c = {
+      req: {
+        header: (name: string) => {
+          if (name.toLowerCase() === "x-real-ip") return "192.0.2.9"
+          return undefined
+        },
+      },
+    } as unknown as Context
+
+    expect(getClientIpInfo(c)).toEqual({ ip: "192.0.2.9", source: "x-real-ip" })
+  })
+})
+
+describe("RequestHistoryStore", () => {
+  test("insert + getByRequestId", () => {
+    const db = new Database(":memory:")
+    initAdminDb(db)
+
+    const store = new RequestHistoryStore(db)
+
+    store.insert({
+      requestId: "r1",
+      startedAtMs: 1000,
+      finishedAtMs: 1100,
+      durationMs: 100,
+      method: "POST",
+      path: "/v1/messages",
+      upstreamEndpoint: "/responses",
+      stream: false,
+      accountId: "acct-1",
+      accountType: "premium",
+      costUnits: 1,
+      clientModel: "claude-3.5",
+      upstreamModel: "gpt-5",
+      clientIp: "203.0.113.9",
+      clientIpSource: "x-forwarded-for",
+      userAgent: "ua",
+      tokensInput: 10,
+      tokensOutput: 20,
+      tokensTotal: 30,
+      tokensCachedInput: 0,
+      usageJson: "{}",
+      premiumRemainingBefore: 100,
+      premiumRemainingAfter: 90,
+      premiumRemainingDiff: -10,
+      premiumUnlimitedBefore: false,
+      premiumUnlimitedAfter: false,
+      httpStatus: 200,
+    })
+
+    const row = store.getByRequestId("r1")
+    expect(row?.request_id).toBe("r1")
+    expect(row?.path).toBe("/v1/messages")
+    expect(row?.account_id).toBe("acct-1")
+    expect(row?.stream).toBe(0)
+    expect(row?.premium_unlimited_before).toBe(0)
+  })
+
+  test("query orders by id DESC and supports cursor paging", () => {
+    const db = new Database(":memory:")
+    initAdminDb(db)
+
+    const store = new RequestHistoryStore(db)
+
+    for (const id of ["r1", "r2", "r3"]) {
+      store.insert({
+        requestId: id,
+        startedAtMs: 1000,
+        method: "POST",
+        path: "/v1/messages",
+        stream: false,
+        httpStatus: 200,
+      })
+    }
+
+    const page1 = store.query({ limit: 2 })
+    expect(page1.items.map((r) => r.request_id)).toEqual(["r3", "r2"])
+    expect(page1.hasMore).toBe(true)
+    expect(page1.nextCursorId).toBeDefined()
+
+    const page2 = store.query({ limit: 10, cursorId: page1.nextCursorId })
+    expect(page2.items.map((r) => r.request_id)).toEqual(["r1"])
+    expect(page2.hasMore).toBe(false)
+  })
+
+  test("filters by account_id and status", () => {
+    const db = new Database(":memory:")
+    initAdminDb(db)
+
+    const store = new RequestHistoryStore(db)
+
+    store.insert({
+      requestId: "ok",
+      startedAtMs: 1,
+      method: "POST",
+      path: "/v1/messages",
+      stream: false,
+      accountId: "a1",
+      httpStatus: 200,
+    })
+
+    store.insert({
+      requestId: "bad",
+      startedAtMs: 2,
+      method: "POST",
+      path: "/v1/messages",
+      stream: false,
+      accountId: "a1",
+      httpStatus: 500,
+    })
+
+    store.insert({
+      requestId: "other",
+      startedAtMs: 3,
+      method: "POST",
+      path: "/v1/messages",
+      stream: false,
+      accountId: "a2",
+      httpStatus: 200,
+    })
+
+    const q1 = store.query({ limit: 50, accountId: "a1" })
+    expect(q1.items.map((r) => r.request_id).sort()).toEqual(["bad", "ok"])
+
+    const q2 = store.query({ limit: 50, accountId: "a1", status: 500 })
+    expect(q2.items.map((r) => r.request_id)).toEqual(["bad"])
+  })
+
+  test("getAccountStatsSince aggregates counts and tokens", () => {
+    const db = new Database(":memory:")
+    initAdminDb(db)
+
+    const store = new RequestHistoryStore(db)
+
+    store.insert({
+      requestId: "r1",
+      startedAtMs: Date.now(),
+      finishedAtMs: Date.now(),
+      durationMs: 100,
+      method: "POST",
+      path: "/v1/messages",
+      stream: false,
+      accountId: "a1",
+      tokensTotal: 10,
+      httpStatus: 200,
+    })
+
+    store.insert({
+      requestId: "r2",
+      startedAtMs: Date.now(),
+      finishedAtMs: Date.now(),
+      durationMs: 200,
+      method: "POST",
+      path: "/v1/messages",
+      stream: false,
+      accountId: "a1",
+      tokensTotal: 5,
+      httpStatus: 500,
+    })
+
+    const stats = store.getAccountStatsSince(Date.now() - 60_000)
+    expect(stats.a1?.request_count).toBe(2)
+    expect(stats.a1?.error_count).toBe(1)
+    expect(stats.a1?.tokens_total).toBe(15)
+  })
+
+  test("cleanupRetention enforces maxRows", () => {
+    const db = new Database(":memory:")
+    initAdminDb(db)
+
+    const store = new RequestHistoryStore(db)
+
+    for (let i = 0; i < 5; i++) {
+      store.insert({
+        requestId: `r${i}`,
+        startedAtMs: 1,
+        method: "POST",
+        path: "/v1/messages",
+        stream: false,
+        httpStatus: 200,
+      })
+    }
+
+    store.cleanupRetention(99999, 2)
+
+    const after = store.query({ limit: 50 })
+    expect(after.items.length).toBe(2)
+  })
+})

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -19,6 +19,28 @@ import { getAdminDb, getAdminDbPath, getAdminDbUserVersion } from "./admin-db"
 const DEFAULT_RETENTION_DAYS = 14
 const DEFAULT_MAX_ROWS = 200_000
 
+const INSERT_WARN_THROTTLE_MS = 30_000
+
+let lastInsertWarnAtMs = 0
+let suppressedInsertWarnCount = 0
+
+function warnInsertFailure(error: unknown): void {
+  const now = Date.now()
+
+  if (now - lastInsertWarnAtMs < INSERT_WARN_THROTTLE_MS) {
+    suppressedInsertWarnCount++
+    return
+  }
+
+  const suppressed = suppressedInsertWarnCount
+  suppressedInsertWarnCount = 0
+  lastInsertWarnAtMs = now
+
+  const suffix =
+    suppressed > 0 ? ` (suppressed ${suppressed} similar errors)` : ""
+  consola.warn(`Failed to insert request log${suffix}`, error)
+}
+
 function toDbNull<T>(value: T | null | undefined): T | null {
   return value === undefined ? null : value
 }
@@ -324,7 +346,7 @@ export class RequestHistoryStore {
 
       this.insertStmt.run(...args)
     } catch (error) {
-      consola.debug("Failed to insert request log", error)
+      warnInsertFailure(error)
     }
   }
 
@@ -503,28 +525,97 @@ export class RequestHistoryStore {
   }
 }
 
-let sharedStore: RequestHistoryStore | null = null
-let maintenanceStarted = false
+export type RequestHistoryStoreApi = {
+  insert(record: RequestLogInsert): void
+  getByRequestId(requestId: string): RequestLogRow | null
+  query(params: RequestLogQuery): RequestLogQueryResult
+  getAccountStatsSince(
+    sinceMs: number,
+  ): Record<string, AccountStatsRow | undefined>
+  cleanupRetention(retentionDays?: number, maxRows?: number): void
+  meta(): {
+    dbPath: string
+    userVersion: number
+    retentionDays: number
+    maxRows: number
+  }
+}
 
-export function getRequestHistoryStore(): RequestHistoryStore {
-  sharedStore ??= new RequestHistoryStore(getAdminDb())
+const STORE_INIT_WARN_THROTTLE_MS = 30_000
+const STORE_INIT_RETRY_DELAY_MS = 30_000
 
-  if (!maintenanceStarted) {
-    maintenanceStarted = true
+let lastStoreInitWarnAtMs = 0
+let suppressedStoreInitWarnCount = 0
+let nextStoreRetryAtMs = 0
 
-    // Run once at startup.
-    sharedStore.cleanupRetention()
+function warnStoreInitFailure(error: unknown): void {
+  const now = Date.now()
 
-    // Then daily.
-    setInterval(
-      () => {
-        sharedStore?.cleanupRetention()
-      },
-      24 * 60 * 60 * 1000,
-    )
+  if (now - lastStoreInitWarnAtMs < STORE_INIT_WARN_THROTTLE_MS) {
+    suppressedStoreInitWarnCount++
+    return
   }
 
-  return sharedStore
+  const suppressed = suppressedStoreInitWarnCount
+  suppressedStoreInitWarnCount = 0
+  lastStoreInitWarnAtMs = now
+
+  const suffix =
+    suppressed > 0 ? ` (suppressed ${suppressed} similar errors)` : ""
+  consola.warn(`Request history store is disabled${suffix}`, error)
+}
+
+const disabledStore: RequestHistoryStoreApi = {
+  insert: () => {},
+  getByRequestId: () => null,
+  query: () => ({ items: [], hasMore: false }),
+  getAccountStatsSince: () => ({}),
+  cleanupRetention: () => {},
+  meta: () => ({
+    dbPath: getAdminDbPath(),
+    userVersion: 0,
+    retentionDays: DEFAULT_RETENTION_DAYS,
+    maxRows: DEFAULT_MAX_ROWS,
+  }),
+}
+
+let sharedStore: RequestHistoryStoreApi | null = null
+let maintenanceStarted = false
+
+export function getRequestHistoryStore(): RequestHistoryStoreApi {
+  if (sharedStore) {
+    return sharedStore
+  }
+
+  const now = Date.now()
+  if (now < nextStoreRetryAtMs) {
+    return disabledStore
+  }
+
+  try {
+    sharedStore = new RequestHistoryStore(getAdminDb())
+
+    if (!maintenanceStarted) {
+      maintenanceStarted = true
+
+      // Run once at startup.
+      sharedStore.cleanupRetention()
+
+      // Then daily.
+      setInterval(
+        () => {
+          sharedStore?.cleanupRetention()
+        },
+        24 * 60 * 60 * 1000,
+      )
+    }
+
+    return sharedStore
+  } catch (error) {
+    nextStoreRetryAtMs = now + STORE_INIT_RETRY_DELAY_MS
+    warnStoreInitFailure(error)
+    return disabledStore
+  }
 }
 
 export function extractResponsesUsageFromStreamEvent(

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -1,0 +1,551 @@
+import type { Database, SQLQueryBindings } from "bun:sqlite"
+import type { Context } from "hono"
+
+import consola from "consola"
+
+import type {
+  ChatCompletionChunk,
+  ChatCompletionResponse,
+} from "~/services/copilot/create-chat-completions"
+import type { EmbeddingResponse } from "~/services/copilot/create-embeddings"
+import type {
+  ResponseStreamEvent,
+  ResponsesResult,
+  ResponseUsage,
+} from "~/services/copilot/create-responses"
+
+import { getAdminDb, getAdminDbPath, getAdminDbUserVersion } from "./admin-db"
+
+const DEFAULT_RETENTION_DAYS = 14
+const DEFAULT_MAX_ROWS = 200_000
+
+function toDbNull<T>(value: T | null | undefined): T | null {
+  return value === undefined ? null : value
+}
+
+function toDbBool(value: boolean | undefined): 0 | 1 | null {
+  if (value === true) return 1
+  if (value === false) return 0
+  return null
+}
+
+export type ClientIpInfo = {
+  ip?: string
+  source?: string
+}
+
+export function getClientIpInfo(c: Context): ClientIpInfo {
+  const cf = c.req.header("cf-connecting-ip")
+  if (cf) return { ip: cf.trim(), source: "cf-connecting-ip" }
+
+  const xff = c.req.header("x-forwarded-for")
+  if (xff) {
+    const first = xff.split(",")[0]?.trim()
+    if (first) return { ip: first, source: "x-forwarded-for" }
+  }
+
+  const xri = c.req.header("x-real-ip")
+  if (xri) return { ip: xri.trim(), source: "x-real-ip" }
+
+  return {}
+}
+
+export type NormalizedUsage = {
+  tokensInput?: number
+  tokensOutput?: number
+  tokensTotal?: number
+  tokensCachedInput?: number
+  usageJson?: string
+}
+
+export function normalizeChatCompletionsUsage(
+  usage?: ChatCompletionResponse["usage"] | ChatCompletionChunk["usage"],
+): NormalizedUsage {
+  if (!usage) return {}
+
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? 0
+  const prompt = usage.prompt_tokens
+  const completion = usage.completion_tokens
+  const total = usage.total_tokens
+
+  return {
+    tokensCachedInput: cached,
+    tokensInput: Math.max(0, prompt - cached),
+    tokensOutput: completion,
+    tokensTotal: total,
+    usageJson: JSON.stringify(usage),
+  }
+}
+
+export function normalizeResponsesUsage(
+  usage?: ResponseUsage | null,
+): NormalizedUsage {
+  if (!usage) return {}
+
+  const cached = usage.input_tokens_details?.cached_tokens ?? 0
+  const input = usage.input_tokens
+  const output = usage.output_tokens ?? 0
+  const total = usage.total_tokens
+
+  return {
+    tokensCachedInput: cached,
+    tokensInput: Math.max(0, input - cached),
+    tokensOutput: output,
+    tokensTotal: total,
+    usageJson: JSON.stringify(usage),
+  }
+}
+
+export function normalizeEmbeddingsUsage(
+  usage?: EmbeddingResponse["usage"],
+): NormalizedUsage {
+  if (!usage) return {}
+
+  return {
+    tokensCachedInput: 0,
+    tokensInput: usage.prompt_tokens,
+    tokensOutput: 0,
+    tokensTotal: usage.total_tokens,
+    usageJson: JSON.stringify(usage),
+  }
+}
+
+export type RequestLogInsert = {
+  requestId: string
+  startedAtMs: number
+  finishedAtMs?: number
+  durationMs?: number
+  ttfbMs?: number
+
+  method: string
+  path: string
+  upstreamEndpoint?: string
+  stream: boolean
+
+  accountId?: string
+  accountType?: string
+  costUnits?: number
+  clientModel?: string
+  upstreamModel?: string
+
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+
+  tokensInput?: number
+  tokensOutput?: number
+  tokensTotal?: number
+  tokensCachedInput?: number
+  usageJson?: string
+
+  premiumRemainingBefore?: number
+  premiumRemainingAfter?: number
+  premiumRemainingDiff?: number
+  premiumUnlimitedBefore?: boolean
+  premiumUnlimitedAfter?: boolean
+
+  httpStatus?: number
+  errorName?: string
+  errorStatus?: number
+  errorMessage?: string
+  selectionFailureReason?: string
+}
+
+export type RequestLogRow = {
+  id: number
+  request_id: string
+  started_at_ms: number
+  finished_at_ms: number | null
+  duration_ms: number | null
+  ttfb_ms: number | null
+
+  method: string
+  path: string
+  upstream_endpoint: string | null
+  stream: number
+
+  account_id: string | null
+  account_type: string | null
+  cost_units: number | null
+  client_model: string | null
+  upstream_model: string | null
+
+  client_ip: string | null
+  client_ip_source: string | null
+  user_agent: string | null
+
+  tokens_input: number | null
+  tokens_output: number | null
+  tokens_total: number | null
+  tokens_cached_input: number | null
+  usage_json: string | null
+
+  premium_remaining_before: number | null
+  premium_remaining_after: number | null
+  premium_remaining_diff: number | null
+  premium_unlimited_before: number | null
+  premium_unlimited_after: number | null
+
+  http_status: number | null
+  error_name: string | null
+  error_status: number | null
+  error_message: string | null
+  selection_failure_reason: string | null
+}
+
+export type RequestLogQuery = {
+  limit: number
+  cursorId?: number
+
+  accountId?: string
+  upstreamModel?: string
+  clientModel?: string
+  upstreamEndpoint?: string
+  path?: string
+  status?: number
+  hasError?: boolean
+  fromMs?: number
+  toMs?: number
+}
+
+export type RequestLogQueryResult = {
+  items: Array<RequestLogRow>
+  nextCursorId?: number
+  hasMore: boolean
+}
+
+export type AccountStatsRow = {
+  account_id: string
+  request_count: number
+  error_count: number
+  tokens_total: number
+  avg_duration_ms: number
+  last_request_at_ms: number
+}
+
+export class RequestHistoryStore {
+  private readonly db: Database
+  private readonly insertStmt: ReturnType<Database["query"]>
+
+  private readonly getByRequestIdStmt: ReturnType<Database["query"]>
+
+  constructor(db: Database) {
+    this.db = db
+
+    this.insertStmt = db.query(`
+      INSERT INTO request_log (
+        request_id,
+        started_at_ms,
+        finished_at_ms,
+        duration_ms,
+        ttfb_ms,
+        method,
+        path,
+        upstream_endpoint,
+        stream,
+        account_id,
+        account_type,
+        cost_units,
+        client_model,
+        upstream_model,
+        client_ip,
+        client_ip_source,
+        user_agent,
+        tokens_input,
+        tokens_output,
+        tokens_total,
+        tokens_cached_input,
+        usage_json,
+        premium_remaining_before,
+        premium_remaining_after,
+        premium_remaining_diff,
+        premium_unlimited_before,
+        premium_unlimited_after,
+        http_status,
+        error_name,
+        error_status,
+        error_message,
+        selection_failure_reason
+      ) VALUES (
+        ?,?,?,?,?,?,?,?,
+        ?,?,?,?,?,?,?,?,
+        ?,?,?,?,?,?,?,?,
+        ?,?,?,?,?,?,?,?
+      );
+    `)
+
+    this.getByRequestIdStmt = db.query(
+      "SELECT * FROM request_log WHERE request_id = ? LIMIT 1;",
+    )
+  }
+
+  insert(record: RequestLogInsert): void {
+    try {
+      const args = [
+        record.requestId,
+        record.startedAtMs,
+        toDbNull(record.finishedAtMs),
+        toDbNull(record.durationMs),
+        toDbNull(record.ttfbMs),
+
+        record.method,
+        record.path,
+        toDbNull(record.upstreamEndpoint),
+        record.stream ? 1 : 0,
+
+        toDbNull(record.accountId),
+        toDbNull(record.accountType),
+        toDbNull(record.costUnits),
+        toDbNull(record.clientModel),
+        toDbNull(record.upstreamModel),
+
+        toDbNull(record.clientIp),
+        toDbNull(record.clientIpSource),
+        toDbNull(record.userAgent),
+
+        toDbNull(record.tokensInput),
+        toDbNull(record.tokensOutput),
+        toDbNull(record.tokensTotal),
+        toDbNull(record.tokensCachedInput),
+        toDbNull(record.usageJson),
+
+        toDbNull(record.premiumRemainingBefore),
+        toDbNull(record.premiumRemainingAfter),
+        toDbNull(record.premiumRemainingDiff),
+        toDbBool(record.premiumUnlimitedBefore),
+        toDbBool(record.premiumUnlimitedAfter),
+
+        toDbNull(record.httpStatus),
+        toDbNull(record.errorName),
+        toDbNull(record.errorStatus),
+        toDbNull(record.errorMessage),
+        toDbNull(record.selectionFailureReason),
+      ] as const
+
+      this.insertStmt.run(...args)
+    } catch (error) {
+      consola.debug("Failed to insert request log", error)
+    }
+  }
+
+  getByRequestId(requestId: string): RequestLogRow | null {
+    try {
+      const row = this.getByRequestIdStmt.get(requestId) as
+        | RequestLogRow
+        | null
+        | undefined
+      return row ?? null
+    } catch (error) {
+      consola.debug("Failed to fetch request log by request_id", error)
+      return null
+    }
+  }
+
+  query(params: RequestLogQuery): RequestLogQueryResult {
+    const limit = Math.max(1, Math.min(params.limit, 200))
+
+    const where: Array<string> = []
+    const values: Array<SQLQueryBindings> = []
+
+    if (params.cursorId !== undefined) {
+      where.push("id < ?")
+      values.push(params.cursorId)
+    }
+
+    if (params.accountId) {
+      where.push("account_id = ?")
+      values.push(params.accountId)
+    }
+
+    if (params.upstreamModel) {
+      where.push("upstream_model = ?")
+      values.push(params.upstreamModel)
+    }
+
+    if (params.clientModel) {
+      where.push("client_model = ?")
+      values.push(params.clientModel)
+    }
+
+    if (params.upstreamEndpoint) {
+      where.push("upstream_endpoint = ?")
+      values.push(params.upstreamEndpoint)
+    }
+
+    if (params.path) {
+      where.push("path = ?")
+      values.push(params.path)
+    }
+
+    if (params.status !== undefined) {
+      where.push("http_status = ?")
+      values.push(params.status)
+    }
+
+    if (params.hasError === true) {
+      where.push("http_status >= 400")
+    }
+    if (params.hasError === false) {
+      where.push("http_status < 400")
+    }
+
+    if (params.fromMs !== undefined) {
+      where.push("started_at_ms >= ?")
+      values.push(params.fromMs)
+    }
+
+    if (params.toMs !== undefined) {
+      where.push("started_at_ms <= ?")
+      values.push(params.toMs)
+    }
+
+    const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""
+
+    const sql = `
+      SELECT *
+      FROM request_log
+      ${whereSql}
+      ORDER BY id DESC
+      LIMIT ?;
+    `
+
+    const rows = this.db
+      .query(sql)
+      .all(...values, limit + 1) as Array<RequestLogRow>
+
+    const items = rows.slice(0, limit)
+    const hasMore = rows.length > limit
+    const nextCursorId = hasMore ? items.at(-1)?.id : undefined
+
+    return {
+      items,
+      nextCursorId,
+      hasMore,
+    }
+  }
+
+  getAccountStatsSince(
+    sinceMs: number,
+  ): Record<string, AccountStatsRow | undefined> {
+    try {
+      const sql = `
+        SELECT
+          account_id,
+          COUNT(*) AS request_count,
+          SUM(CASE WHEN http_status >= 400 THEN 1 ELSE 0 END) AS error_count,
+          COALESCE(SUM(tokens_total), 0) AS tokens_total,
+          COALESCE(AVG(duration_ms), 0) AS avg_duration_ms,
+          COALESCE(MAX(started_at_ms), 0) AS last_request_at_ms
+        FROM request_log
+        WHERE started_at_ms >= ? AND account_id IS NOT NULL
+        GROUP BY account_id;
+      `
+
+      const rows = this.db.query(sql).all(sinceMs) as Array<AccountStatsRow>
+      const map: Record<string, AccountStatsRow | undefined> = {}
+      for (const row of rows) {
+        map[row.account_id] = row
+      }
+      return map
+    } catch (error) {
+      consola.debug("Failed to fetch account stats", error)
+      return {}
+    }
+  }
+
+  cleanupRetention(
+    retentionDays: number = DEFAULT_RETENTION_DAYS,
+    maxRows: number = DEFAULT_MAX_ROWS,
+  ): void {
+    try {
+      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000
+      this.db
+        .query("DELETE FROM request_log WHERE started_at_ms < ?;")
+        .run(cutoffMs)
+
+      const countRow = this.db
+        .query("SELECT COUNT(*) AS c FROM request_log;")
+        .get() as { c: number }
+
+      const count = countRow.c
+      if (count <= maxRows) {
+        return
+      }
+
+      const offset = maxRows - 1
+      const threshold = this.db
+        .query("SELECT id FROM request_log ORDER BY id DESC LIMIT 1 OFFSET ?;")
+        .get(offset) as { id?: number } | null
+
+      const thresholdId = threshold?.id
+      if (!thresholdId) {
+        return
+      }
+
+      this.db.query("DELETE FROM request_log WHERE id < ?;").run(thresholdId)
+    } catch (error) {
+      consola.debug("Failed to cleanup request_log retention", error)
+    }
+  }
+
+  meta(): {
+    dbPath: string
+    userVersion: number
+    retentionDays: number
+    maxRows: number
+  } {
+    return {
+      dbPath: getAdminDbPath(),
+      userVersion: getAdminDbUserVersion(this.db),
+      retentionDays: DEFAULT_RETENTION_DAYS,
+      maxRows: DEFAULT_MAX_ROWS,
+    }
+  }
+}
+
+let sharedStore: RequestHistoryStore | null = null
+let maintenanceStarted = false
+
+export function getRequestHistoryStore(): RequestHistoryStore {
+  sharedStore ??= new RequestHistoryStore(getAdminDb())
+
+  if (!maintenanceStarted) {
+    maintenanceStarted = true
+
+    // Run once at startup.
+    sharedStore.cleanupRetention()
+
+    // Then daily.
+    setInterval(
+      () => {
+        sharedStore?.cleanupRetention()
+      },
+      24 * 60 * 60 * 1000,
+    )
+  }
+
+  return sharedStore
+}
+
+export function extractResponsesUsageFromStreamEvent(
+  event: ResponseStreamEvent,
+): NormalizedUsage {
+  if (
+    event.type === "response.completed"
+    || event.type === "response.incomplete"
+  ) {
+    return normalizeResponsesUsage(event.response.usage)
+  }
+
+  if (event.type === "response.failed") {
+    return normalizeResponsesUsage(event.response.usage)
+  }
+
+  return {}
+}
+
+export function extractResponsesUsageFromResult(
+  result: ResponsesResult,
+): NormalizedUsage {
+  return normalizeResponsesUsage(result.usage)
+}

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -20,10 +20,7 @@ type AdminAccessDecision =
 
 function isLoopbackHostname(hostname: string): boolean {
   return (
-    hostname === "localhost"
-    || hostname === "127.0.0.1"
-    || hostname === "::1"
-    || hostname === "0.0.0.0"
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
   )
 }
 
@@ -43,9 +40,7 @@ function getRequestAdminToken(c: Context): string | undefined {
     if (token) return token
   }
 
-  const url = new URL(c.req.url, "http://local")
-  const queryToken = url.searchParams.get("admin_token")?.trim()
-  return queryToken || undefined
+  return undefined
 }
 
 function isSameOrigin(requestUrl: URL, originHeader: string): boolean {

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono"
+import { Hono, type Context } from "hono"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { listAccountsFromRegistry } from "~/lib/accounts-registry"
@@ -6,6 +6,95 @@ import {
   getRequestHistoryStore,
   type AccountStatsRow,
 } from "~/lib/request-history"
+
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN?.trim() || undefined
+
+type AdminAccessDecision =
+  | { ok: true }
+  | {
+      ok: false
+      status: 401 | 403
+      message: string
+      errorType: "unauthorized" | "forbidden"
+    }
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost"
+    || hostname === "127.0.0.1"
+    || hostname === "::1"
+    || hostname === "0.0.0.0"
+  )
+}
+
+function getBearerToken(value: string): string | undefined {
+  const trimmed = value.trim()
+  if (!trimmed.toLowerCase().startsWith("bearer ")) return undefined
+  return trimmed.slice("bearer ".length).trim() || undefined
+}
+
+function getRequestAdminToken(c: Context): string | undefined {
+  const headerToken = c.req.header("x-admin-token")?.trim()
+  if (headerToken) return headerToken
+
+  const bearer = c.req.header("authorization")
+  if (bearer) {
+    const token = getBearerToken(bearer)
+    if (token) return token
+  }
+
+  const url = new URL(c.req.url, "http://local")
+  const queryToken = url.searchParams.get("admin_token")?.trim()
+  return queryToken || undefined
+}
+
+function isSameOrigin(requestUrl: URL, originHeader: string): boolean {
+  try {
+    return new URL(originHeader).origin === requestUrl.origin
+  } catch {
+    return false
+  }
+}
+
+function decideAdminAccess(c: Context): AdminAccessDecision {
+  const url = new URL(c.req.url, "http://local")
+
+  const token = getRequestAdminToken(c)
+  const tokenOk = Boolean(ADMIN_TOKEN) && token === ADMIN_TOKEN
+
+  const origin = c.req.header("origin")
+  if (origin && !tokenOk && !isSameOrigin(url, origin)) {
+    return {
+      ok: false,
+      status: 403,
+      message: "Cross-origin access to admin API is forbidden.",
+      errorType: "forbidden",
+    }
+  }
+
+  const loopback = isLoopbackHostname(url.hostname)
+  if (loopback || tokenOk) {
+    return { ok: true }
+  }
+
+  if (ADMIN_TOKEN) {
+    return {
+      ok: false,
+      status: 401,
+      message:
+        "Admin API requires x-admin-token or Authorization: Bearer <token>.",
+      errorType: "unauthorized",
+    }
+  }
+
+  return {
+    ok: false,
+    status: 403,
+    message:
+      "Admin API is only available on localhost. Set ADMIN_TOKEN to enable remote access.",
+    errorType: "forbidden",
+  }
+}
 
 type AccountItem = {
   account_id: string
@@ -39,6 +128,23 @@ function parseTriStateBool(value: string | null): boolean | undefined {
 }
 
 export const adminApiRoutes = new Hono()
+
+adminApiRoutes.use("*", async (c, next) => {
+  const decision = decideAdminAccess(c)
+  if (!decision.ok) {
+    return c.json(
+      {
+        error: {
+          message: decision.message,
+          type: decision.errorType,
+        },
+      },
+      decision.status,
+    )
+  }
+
+  await next()
+})
 
 adminApiRoutes.get("/meta", (c) => {
   const store = getRequestHistoryStore()

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,0 +1,141 @@
+import { Hono } from "hono"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { listAccountsFromRegistry } from "~/lib/accounts-registry"
+import {
+  getRequestHistoryStore,
+  type AccountStatsRow,
+} from "~/lib/request-history"
+
+type AccountItem = {
+  account_id: string
+  account_type?: string
+  runtime: {
+    remaining?: number
+    unlimited?: boolean
+    failed?: boolean
+    failureReason?: string
+  }
+  stats?: {
+    since_ms: number
+    request_count?: number
+    error_count?: number
+    tokens_total?: number
+    avg_duration_ms?: number
+    last_request_at_ms?: number
+  }
+}
+
+function parseFiniteNumber(value: string | null): number | undefined {
+  if (!value) return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function parseTriStateBool(value: string | null): boolean | undefined {
+  if (value === "1") return true
+  if (value === "0") return false
+  return undefined
+}
+
+export const adminApiRoutes = new Hono()
+
+adminApiRoutes.get("/meta", (c) => {
+  const store = getRequestHistoryStore()
+  return c.json(store.meta())
+})
+
+adminApiRoutes.get("/accounts", async (c) => {
+  const url = new URL(c.req.url, "http://local")
+  const sinceMs = Number(url.searchParams.get("since_ms") ?? "")
+  const includeStats = url.searchParams.get("include_stats") !== "0"
+
+  const since =
+    Number.isFinite(sinceMs) && sinceMs > 0 ?
+      sinceMs
+    : Date.now() - 24 * 60 * 60 * 1000
+
+  const registry = await listAccountsFromRegistry().catch(() => [])
+  const registryTypeById = new Map(registry.map((a) => [a.id, a.accountType]))
+
+  const statuses = accountsManager.getAccountStatus()
+
+  const store = getRequestHistoryStore()
+  const statsByAccount: Record<string, AccountStatsRow | undefined> =
+    includeStats ? store.getAccountStatsSince(since) : {}
+
+  const items: Array<AccountItem> = statuses.map((s) => {
+    const accountType = registryTypeById.get(s.id)
+    const statsRow = includeStats ? statsByAccount[s.id] : undefined
+
+    const stats =
+      includeStats ?
+        {
+          since_ms: since,
+          request_count: statsRow?.request_count,
+          error_count: statsRow?.error_count,
+          tokens_total: statsRow?.tokens_total,
+          avg_duration_ms: statsRow?.avg_duration_ms,
+          last_request_at_ms: statsRow?.last_request_at_ms,
+        }
+      : undefined
+
+    return {
+      account_id: s.id,
+      account_type: accountType,
+      runtime: {
+        remaining: s.remaining,
+        unlimited: s.unlimited,
+        failed: s.failed,
+        failureReason: s.failureReason,
+      },
+      stats,
+    }
+  })
+
+  return c.json({ items })
+})
+
+adminApiRoutes.get("/requests", (c) => {
+  const url = new URL(c.req.url, "http://local")
+  const p = url.searchParams
+
+  const limit = parseFiniteNumber(p.get("limit")) ?? 50
+  const cursorId = parseFiniteNumber(p.get("cursor_id"))
+
+  const status = parseFiniteNumber(p.get("status"))
+  const hasError = parseTriStateBool(p.get("has_error"))
+
+  const fromMs = parseFiniteNumber(p.get("from_ms"))
+  const toMs = parseFiniteNumber(p.get("to_ms"))
+
+  const store = getRequestHistoryStore()
+  const result = store.query({
+    limit,
+    cursorId,
+
+    accountId: p.get("account_id") || undefined,
+    upstreamModel: p.get("upstream_model") || undefined,
+    clientModel: p.get("client_model") || undefined,
+    upstreamEndpoint: p.get("upstream_endpoint") || undefined,
+    path: p.get("path") || undefined,
+
+    status,
+    hasError,
+    fromMs,
+    toMs,
+  })
+
+  return c.json({
+    items: result.items,
+    next_cursor_id: result.nextCursorId,
+    has_more: result.hasMore,
+  })
+})
+
+adminApiRoutes.get("/requests/:requestId", (c) => {
+  const requestId = c.req.param("requestId")
+  const store = getRequestHistoryStore()
+  const item = store.getByRequestId(requestId)
+  return c.json({ item })
+})

--- a/src/routes/admin/route.ts
+++ b/src/routes/admin/route.ts
@@ -63,6 +63,19 @@ const html = `<!doctype html>
         border-color: #3a4a7e;
         background: rgba(255,255,255,.04);
       }
+      .header-right {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .token-controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .token-controls input {
+        min-width: 160px;
+      }
       main {
         padding: 16px;
         max-width: 1200px;
@@ -157,10 +170,18 @@ const html = `<!doctype html>
   <body>
     <header>
       <h1>copilot-api / admin</h1>
-      <nav>
-        <a href="#/accounts" data-nav="accounts">Accounts</a>
-        <a href="#/requests" data-nav="requests">Requests</a>
-      </nav>
+      <div class="header-right">
+        <nav>
+          <a href="#/accounts" data-nav="accounts">Accounts</a>
+          <a href="#/requests" data-nav="requests">Requests</a>
+        </nav>
+        <div class="token-controls">
+          <input id="adminToken" type="password" placeholder="x-admin-token" />
+          <button id="adminTokenSave">Set</button>
+          <button id="adminTokenClear">Clear</button>
+          <span id="adminTokenStatus" class="muted"></span>
+        </div>
+      </div>
     </header>
 
     <main id="app"></main>
@@ -168,6 +189,50 @@ const html = `<!doctype html>
     <script type="module">
       const app = document.getElementById('app')
       const navLinks = [...document.querySelectorAll('a[data-nav]')]
+
+      const ADMIN_TOKEN_STORAGE_KEY = 'adminToken'
+
+      function getAdminToken() {
+        return sessionStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ''
+      }
+
+      function setAdminToken(value) {
+        const token = (value || '').trim()
+        if (!token) sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+        else sessionStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, token)
+      }
+
+      function refreshAdminTokenUi() {
+        const el = document.getElementById('adminTokenStatus')
+        if (!el) return
+        el.textContent = getAdminToken() ? 'token set' : ''
+      }
+
+      function initAdminTokenControls() {
+        const input = document.getElementById('adminToken')
+        const saveBtn = document.getElementById('adminTokenSave')
+        const clearBtn = document.getElementById('adminTokenClear')
+
+        if (saveBtn && input) {
+          saveBtn.addEventListener('click', () => {
+            setAdminToken(input.value)
+            input.value = ''
+            refreshAdminTokenUi()
+          })
+        }
+
+        if (clearBtn && input) {
+          clearBtn.addEventListener('click', () => {
+            setAdminToken('')
+            input.value = ''
+            refreshAdminTokenUi()
+          })
+        }
+
+        refreshAdminTokenUi()
+      }
+
+      initAdminTokenControls()
 
       function setActiveNav(key) {
         for (const a of navLinks) {
@@ -194,7 +259,9 @@ const html = `<!doctype html>
       }
 
       async function api(path) {
-        const res = await fetch(path)
+        const token = getAdminToken()
+        const headers = token ? { 'x-admin-token': token } : {}
+        const res = await fetch(path, { headers })
         if (!res.ok) {
           const txt = await res.text().catch(() => '')
           throw new Error('HTTP ' + res.status + ': ' + txt)

--- a/src/routes/admin/route.ts
+++ b/src/routes/admin/route.ts
@@ -1,0 +1,507 @@
+import { Hono } from "hono"
+
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>copilot-api admin</title>
+    <style>
+      :root {
+        --bg: #0b1020;
+        --panel: #121a33;
+        --text: #e6e9f2;
+        --muted: #aab3d0;
+        --border: #243055;
+        --good: #28c37b;
+        --bad: #ff5b5b;
+        --warn: #ffb020;
+        --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        --sans: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto,
+          Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: var(--sans);
+      }
+      a { color: inherit; }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 16px;
+        border-bottom: 1px solid var(--border);
+        background: linear-gradient(180deg, rgba(18,26,51,.9), rgba(11,16,32,.9));
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        backdrop-filter: blur(6px);
+      }
+      header h1 {
+        margin: 0;
+        font-size: 14px;
+        letter-spacing: .2px;
+        font-weight: 650;
+      }
+      header nav {
+        display: flex;
+        gap: 10px;
+      }
+      header nav a {
+        padding: 6px 10px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        text-decoration: none;
+        color: var(--muted);
+      }
+      header nav a.active {
+        color: var(--text);
+        border-color: #3a4a7e;
+        background: rgba(255,255,255,.04);
+      }
+      main {
+        padding: 16px;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      .panel {
+        border: 1px solid var(--border);
+        background: rgba(18,26,51,.65);
+        border-radius: 12px;
+        padding: 12px;
+        margin-bottom: 16px;
+      }
+      .row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: end;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      input, select {
+        background: rgba(0,0,0,.18);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 8px 10px;
+        min-width: 180px;
+        outline: none;
+      }
+      button {
+        background: rgba(255,255,255,.06);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 8px 10px;
+        cursor: pointer;
+      }
+      button:hover { border-color: #3a4a7e; }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th, td {
+        border-bottom: 1px solid rgba(36,48,85,.7);
+        padding: 8px 8px;
+        vertical-align: top;
+      }
+      th {
+        text-align: left;
+        color: var(--muted);
+        font-weight: 600;
+      }
+      .mono { font-family: var(--mono); }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        color: var(--muted);
+      }
+      .pill.good { color: var(--good); border-color: rgba(40,195,123,.35); }
+      .pill.bad { color: var(--bad); border-color: rgba(255,91,91,.35); }
+      .pill.warn { color: var(--warn); border-color: rgba(255,176,32,.35); }
+      .muted { color: var(--muted); }
+      pre {
+        margin: 0;
+        padding: 10px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: rgba(0,0,0,.25);
+        overflow: auto;
+        font-size: 12px;
+      }
+      .split {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 12px;
+      }
+      @media (min-width: 960px) {
+        .split { grid-template-columns: 1fr 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>copilot-api / admin</h1>
+      <nav>
+        <a href="#/accounts" data-nav="accounts">Accounts</a>
+        <a href="#/requests" data-nav="requests">Requests</a>
+      </nav>
+    </header>
+
+    <main id="app"></main>
+
+    <script type="module">
+      const app = document.getElementById('app')
+      const navLinks = [...document.querySelectorAll('a[data-nav]')]
+
+      function setActiveNav(key) {
+        for (const a of navLinks) {
+          a.classList.toggle('active', a.dataset.nav === key)
+        }
+      }
+
+      function fmtMs(ms) {
+        if (ms == null) return ''
+        return new Date(ms).toISOString()
+      }
+
+      function fmtNum(x) {
+        if (x == null || Number.isNaN(Number(x))) return ''
+        return String(x)
+      }
+
+      function pill(text, kind) {
+        return '<span class="pill ' + (kind || '') + '">' + text + '</span>'
+      }
+
+      function qs() {
+        return new URLSearchParams(location.hash.includes('?') ? location.hash.split('?')[1] : '')
+      }
+
+      async function api(path) {
+        const res = await fetch(path)
+        if (!res.ok) {
+          const txt = await res.text().catch(() => '')
+          throw new Error('HTTP ' + res.status + ': ' + txt)
+        }
+        return await res.json()
+      }
+
+      async function renderAccounts() {
+        setActiveNav('accounts')
+        app.innerHTML = [
+          '<div class="panel">',
+          '  <div class="row">',
+          '    <label>Stats window',
+          '      <select id="since">',
+          '        <option value="86400000">Last 24h</option>',
+          '        <option value="604800000">Last 7d</option>',
+          '      </select>',
+          '    </label>',
+          '    <button id="refresh">Refresh</button>',
+          '    <span class="muted" id="meta"></span>',
+          '  </div>',
+          '</div>',
+          '<div class="panel">',
+          '  <table>',
+          '    <thead>',
+          '      <tr>',
+          '        <th>Account</th>',
+          '        <th>Status</th>',
+          '        <th>Remaining</th>',
+          '        <th>Requests</th>',
+          '        <th>Errors</th>',
+          '        <th>Tokens</th>',
+          '        <th>Avg ms</th>',
+          '        <th>Last req</th>',
+          '      </tr>',
+          '    </thead>',
+          '    <tbody id="rows"></tbody>',
+          '  </table>',
+          '</div>',
+        ].join('')
+
+        const sinceEl = document.getElementById('since')
+        const refresh = document.getElementById('refresh')
+        const rowsEl = document.getElementById('rows')
+        const metaEl = document.getElementById('meta')
+
+        async function load() {
+          rowsEl.innerHTML = '<tr><td colspan="8" class="muted">Loading...</td></tr>'
+          const windowMs = Number(sinceEl.value)
+          const sinceMs = Date.now() - windowMs
+          const [accounts, meta] = await Promise.all([
+            api('/api/admin/accounts?since_ms=' + sinceMs + '&include_stats=1'),
+            api('/api/admin/meta'),
+          ])
+
+          metaEl.textContent = 'DB v' + meta.userVersion + ' · ' + meta.dbPath
+
+          rowsEl.innerHTML = accounts.items.map((a) => {
+            const failed = a.runtime?.failed
+            const statusPill = failed ? pill('failed', 'bad') : pill('ok', 'good')
+            const rem = a.runtime?.unlimited ? pill('unlimited', 'good') : fmtNum(a.runtime?.remaining)
+            const stats = a.stats || {}
+            const last = stats.last_request_at_ms ? fmtMs(stats.last_request_at_ms) : ''
+            const accountId = a.account_id
+            const failureReason = failed
+              ? '<div class="muted">' + (a.runtime?.failureReason || '') + '</div>'
+              : ''
+
+            return '<tr>'
+              + '<td class="mono"><a href="#/requests?account_id='
+              + encodeURIComponent(accountId)
+              + '">' + accountId + '</a></td>'
+              + '<td>' + statusPill + failureReason + '</td>'
+              + '<td>' + rem + '</td>'
+              + '<td>' + fmtNum(stats.request_count) + '</td>'
+              + '<td>' + fmtNum(stats.error_count) + '</td>'
+              + '<td>' + fmtNum(stats.tokens_total) + '</td>'
+              + '<td>' + fmtNum(Math.round(stats.avg_duration_ms || 0)) + '</td>'
+              + '<td class="mono">' + last + '</td>'
+              + '</tr>'
+          }).join('')
+        }
+
+        refresh.addEventListener('click', () => load())
+        await load()
+      }
+
+      function buildRequestsQuery(extra = {}) {
+        const p = qs()
+        const out = new URLSearchParams()
+
+        const keys = [
+          'account_id','upstream_model','client_model','upstream_endpoint','path',
+          'status','has_error','from_ms','to_ms','limit','cursor_id'
+        ]
+        for (const k of keys) {
+          const v = p.get(k)
+          if (v != null && v !== '') out.set(k, v)
+        }
+        for (const [k, v] of Object.entries(extra)) {
+          if (v == null || v === '') out.delete(k)
+          else out.set(k, String(v))
+        }
+        return out
+      }
+
+      async function renderRequests() {
+        setActiveNav('requests')
+        app.innerHTML = [
+          '<div class="panel">',
+          '  <div class="row">',
+          '    <label>Account',
+          '      <input id="account_id" placeholder="octocat" />',
+          '    </label>',
+          '    <label>Upstream model',
+          '      <input id="upstream_model" placeholder="gpt-5" />',
+          '    </label>',
+          '    <label>Endpoint',
+          '      <input id="upstream_endpoint" placeholder="/responses" />',
+          '    </label>',
+          '    <label>Status',
+          '      <input id="status" placeholder="200" />',
+          '    </label>',
+          '    <label>Has error',
+          '      <select id="has_error">',
+          '        <option value="">(any)</option>',
+          '        <option value="1">yes</option>',
+          '        <option value="0">no</option>',
+          '      </select>',
+          '    </label>',
+          '    <label>From (ms)',
+          '      <input id="from_ms" placeholder="" />',
+          '    </label>',
+          '    <label>To (ms)',
+          '      <input id="to_ms" placeholder="" />',
+          '    </label>',
+          '    <button id="apply">Apply</button>',
+          '    <button id="more">Load more</button>',
+          '  </div>',
+          '</div>',
+          '<div class="panel">',
+          '  <table>',
+          '    <thead>',
+          '      <tr>',
+          '        <th>Time</th>',
+          '        <th>Path</th>',
+          '        <th>Endpoint</th>',
+          '        <th>Account</th>',
+          '        <th>Model</th>',
+          '        <th>Tokens</th>',
+          '        <th>Cost</th>',
+          '        <th>Quota diff</th>',
+          '        <th>Dur</th>',
+          '        <th>Status</th>',
+          '      </tr>',
+          '    </thead>',
+          '    <tbody id="rows"></tbody>',
+          '  </table>',
+          '</div>',
+        ].join('')
+
+        const rowsEl = document.getElementById('rows')
+        const applyBtn = document.getElementById('apply')
+        const moreBtn = document.getElementById('more')
+
+        const fields = ['account_id','upstream_model','upstream_endpoint','status','has_error','from_ms','to_ms']
+        for (const f of fields) {
+          const el = document.getElementById(f)
+          const v = qs().get(f) || ''
+          el.value = v
+        }
+
+        let nextCursor = qs().get('cursor_id') || ''
+        let loading = false
+
+        function setHashFromForm(cursorId) {
+          const out = new URLSearchParams()
+          for (const f of fields) {
+            const v = document.getElementById(f).value.trim()
+            if (v) out.set(f, v)
+          }
+          out.set('limit', '50')
+          if (cursorId) out.set('cursor_id', cursorId)
+          location.hash = '#/requests?' + out.toString()
+        }
+
+        async function load(reset) {
+          if (loading) return
+          loading = true
+          try {
+            const q = buildRequestsQuery({ limit: 50, cursor_id: reset ? '' : nextCursor })
+            const data = await api('/api/admin/requests?' + q.toString())
+
+            if (reset) rowsEl.innerHTML = ''
+
+            for (const r of data.items) {
+              const status = r.http_status
+              const statusP = status >= 400 ? pill(status, 'bad') : pill(status, 'good')
+              const when = fmtMs(r.started_at_ms)
+              const quotaDiff = r.premium_remaining_diff != null ? fmtNum(r.premium_remaining_diff) : ''
+              const dur = r.duration_ms != null ? fmtNum(r.duration_ms) : ''
+              const acct = r.account_id || ''
+              const model = r.upstream_model || ''
+              const tokens = r.tokens_total != null ? fmtNum(r.tokens_total) : ''
+
+              rowsEl.insertAdjacentHTML('beforeend',
+                '<tr>'
+                + '<td class="mono">' + when + '</td>'
+                + '<td class="mono"><a href="#/request/' + encodeURIComponent(r.request_id) + '">' + r.path + '</a></td>'
+                + '<td class="mono">' + (r.upstream_endpoint || '') + '</td>'
+                + '<td class="mono">' + acct + '</td>'
+                + '<td class="mono">' + model + '</td>'
+                + '<td class="mono">' + tokens + '</td>'
+                + '<td class="mono">' + (r.cost_units ?? '') + '</td>'
+                + '<td class="mono">' + quotaDiff + '</td>'
+                + '<td class="mono">' + dur + '</td>'
+                + '<td>' + statusP + '</td>'
+                + '</tr>'
+              )
+            }
+
+            nextCursor = data.next_cursor_id || ''
+            moreBtn.disabled = !data.has_more
+          } catch (e) {
+            rowsEl.innerHTML = '<tr><td colspan="10" class="muted">' + String(e) + '</td></tr>'
+          } finally {
+            loading = false
+          }
+        }
+
+        applyBtn.addEventListener('click', () => setHashFromForm(''))
+        moreBtn.addEventListener('click', () => load(false))
+
+        await load(true)
+      }
+
+      async function renderRequestDetail(requestId) {
+        setActiveNav('requests')
+        app.innerHTML = '<div class="panel"><div class="muted">Loading...</div></div>'
+        const data = await api('/api/admin/requests/' + encodeURIComponent(requestId))
+        const r = data.item
+        if (!r) {
+          app.innerHTML = '<div class="panel"><div class="muted">Not found</div></div>'
+          return
+        }
+
+        app.innerHTML = [
+          '<div class="panel">',
+          '  <div class="row">',
+          '    <div class="mono">request_id: ' + r.request_id + '</div>',
+          '    <div class="mono">status: ' + r.http_status + '</div>',
+          '    <div class="mono">dur_ms: ' + (r.duration_ms ?? '') + '</div>',
+          '    <div class="mono">ttfb_ms: ' + (r.ttfb_ms ?? '') + '</div>',
+          '  </div>',
+          '</div>',
+          '',
+          '<div class="split">',
+          '  <div class="panel">',
+          '    <h3 style="margin:0 0 8px 0; font-size: 13px;">Summary</h3>',
+          '    <table>',
+          '      <tbody>',
+          '        <tr><th>time</th><td class="mono">' + fmtMs(r.started_at_ms) + '</td></tr>',
+          '        <tr><th>path</th><td class="mono">' + r.path + '</td></tr>',
+          '        <tr><th>endpoint</th><td class="mono">' + (r.upstream_endpoint || '') + '</td></tr>',
+          '        <tr><th>account</th><td class="mono">' + (r.account_id || '') + '</td></tr>',
+          '        <tr><th>model</th><td class="mono">' + (r.upstream_model || '') + '</td></tr>',
+          '        <tr><th>client</th><td class="mono">' + (r.client_ip || '') + ' ' + (r.user_agent ? '(' + r.user_agent + ')' : '') + '</td></tr>',
+          '        <tr><th>tokens</th><td class="mono">in=' + (r.tokens_input ?? '') + ' out=' + (r.tokens_output ?? '') + ' total=' + (r.tokens_total ?? '') + ' cached=' + (r.tokens_cached_input ?? '') + '</td></tr>',
+          '        <tr><th>quota</th><td class="mono">before=' + (r.premium_remaining_before ?? '') + ' after=' + (r.premium_remaining_after ?? '') + ' diff=' + (r.premium_remaining_diff ?? '') + '</td></tr>',
+          '      </tbody>',
+          '    </table>',
+          '  </div>',
+          '',
+          '  <div class="panel">',
+          '    <h3 style="margin:0 0 8px 0; font-size: 13px;">Raw</h3>',
+          '    <pre class="mono">' + escapeHtml(JSON.stringify(r, null, 2)) + '</pre>',
+          '  </div>',
+          '</div>',
+        ].join('')
+      }
+
+      function escapeHtml(s) {
+        return String(s)
+          .replaceAll('&', '&amp;')
+          .replaceAll('<', '&lt;')
+          .replaceAll('>', '&gt;')
+      }
+
+      function route() {
+        const h = location.hash || '#/accounts'
+        const [path] = h.slice(1).split('?')
+        if (path === '/accounts') return renderAccounts()
+        if (path === '/requests') return renderRequests()
+        if (path.startsWith('/request/')) {
+          const requestId = decodeURIComponent(path.slice('/request/'.length))
+          return renderRequestDetail(requestId)
+        }
+        location.hash = '#/accounts'
+      }
+
+      window.addEventListener('hashchange', route)
+      route()
+    </script>
+  </body>
+</html>
+`
+
+export const adminRoutes = new Hono()
+
+adminRoutes.get("/", (c) => c.html(html))

--- a/src/routes/admin/route.ts
+++ b/src/routes/admin/route.ts
@@ -186,7 +186,7 @@ const html = `<!doctype html>
       }
 
       function pill(text, kind) {
-        return '<span class="pill ' + (kind || '') + '">' + text + '</span>'
+        return '<span class="pill ' + (kind || '') + '">' + escapeHtml(text) + '</span>'
       }
 
       function qs() {
@@ -260,13 +260,13 @@ const html = `<!doctype html>
             const last = stats.last_request_at_ms ? fmtMs(stats.last_request_at_ms) : ''
             const accountId = a.account_id
             const failureReason = failed
-              ? '<div class="muted">' + (a.runtime?.failureReason || '') + '</div>'
+              ? '<div class="muted">' + escapeHtml(a.runtime?.failureReason || '') + '</div>'
               : ''
 
             return '<tr>'
               + '<td class="mono"><a href="#/requests?account_id='
               + encodeURIComponent(accountId)
-              + '">' + accountId + '</a></td>'
+              + '">' + escapeHtml(accountId) + '</a></td>'
               + '<td>' + statusPill + failureReason + '</td>'
               + '<td>' + rem + '</td>'
               + '<td>' + fmtNum(stats.request_count) + '</td>'
@@ -403,10 +403,10 @@ const html = `<!doctype html>
               rowsEl.insertAdjacentHTML('beforeend',
                 '<tr>'
                 + '<td class="mono">' + when + '</td>'
-                + '<td class="mono"><a href="#/request/' + encodeURIComponent(r.request_id) + '">' + r.path + '</a></td>'
-                + '<td class="mono">' + (r.upstream_endpoint || '') + '</td>'
-                + '<td class="mono">' + acct + '</td>'
-                + '<td class="mono">' + model + '</td>'
+                + '<td class="mono"><a href="#/request/' + encodeURIComponent(r.request_id) + '">' + escapeHtml(r.path) + '</a></td>'
+                + '<td class="mono">' + escapeHtml(r.upstream_endpoint || '') + '</td>'
+                + '<td class="mono">' + escapeHtml(acct) + '</td>'
+                + '<td class="mono">' + escapeHtml(model) + '</td>'
                 + '<td class="mono">' + tokens + '</td>'
                 + '<td class="mono">' + (r.cost_units ?? '') + '</td>'
                 + '<td class="mono">' + quotaDiff + '</td>'
@@ -419,7 +419,7 @@ const html = `<!doctype html>
             nextCursor = data.next_cursor_id || ''
             moreBtn.disabled = !data.has_more
           } catch (e) {
-            rowsEl.innerHTML = '<tr><td colspan="10" class="muted">' + String(e) + '</td></tr>'
+            rowsEl.innerHTML = '<tr><td colspan="10" class="muted">' + escapeHtml(String(e)) + '</td></tr>'
           } finally {
             loading = false
           }
@@ -444,7 +444,7 @@ const html = `<!doctype html>
         app.innerHTML = [
           '<div class="panel">',
           '  <div class="row">',
-          '    <div class="mono">request_id: ' + r.request_id + '</div>',
+          '    <div class="mono">request_id: ' + escapeHtml(r.request_id) + '</div>',
           '    <div class="mono">status: ' + r.http_status + '</div>',
           '    <div class="mono">dur_ms: ' + (r.duration_ms ?? '') + '</div>',
           '    <div class="mono">ttfb_ms: ' + (r.ttfb_ms ?? '') + '</div>',
@@ -457,11 +457,11 @@ const html = `<!doctype html>
           '    <table>',
           '      <tbody>',
           '        <tr><th>time</th><td class="mono">' + fmtMs(r.started_at_ms) + '</td></tr>',
-          '        <tr><th>path</th><td class="mono">' + r.path + '</td></tr>',
-          '        <tr><th>endpoint</th><td class="mono">' + (r.upstream_endpoint || '') + '</td></tr>',
-          '        <tr><th>account</th><td class="mono">' + (r.account_id || '') + '</td></tr>',
-          '        <tr><th>model</th><td class="mono">' + (r.upstream_model || '') + '</td></tr>',
-          '        <tr><th>client</th><td class="mono">' + (r.client_ip || '') + ' ' + (r.user_agent ? '(' + r.user_agent + ')' : '') + '</td></tr>',
+          '        <tr><th>path</th><td class="mono">' + escapeHtml(r.path) + '</td></tr>',
+          '        <tr><th>endpoint</th><td class="mono">' + escapeHtml(r.upstream_endpoint || '') + '</td></tr>',
+          '        <tr><th>account</th><td class="mono">' + escapeHtml(r.account_id || '') + '</td></tr>',
+          '        <tr><th>model</th><td class="mono">' + escapeHtml(r.upstream_model || '') + '</td></tr>',
+          '        <tr><th>client</th><td class="mono">' + escapeHtml(r.client_ip || '') + ' ' + (r.user_agent ? '(' + escapeHtml(r.user_agent) + ')' : '') + '</td></tr>',
           '        <tr><th>tokens</th><td class="mono">in=' + (r.tokens_input ?? '') + ' out=' + (r.tokens_output ?? '') + ' total=' + (r.tokens_total ?? '') + ' cached=' + (r.tokens_cached_input ?? '') + '</td></tr>',
           '        <tr><th>quota</th><td class="mono">before=' + (r.premium_remaining_before ?? '') + ' after=' + (r.premium_remaining_after ?? '') + ' diff=' + (r.premium_remaining_diff ?? '') + '</td></tr>',
           '      </tbody>',
@@ -481,6 +481,8 @@ const html = `<!doctype html>
           .replaceAll('&', '&amp;')
           .replaceAll('<', '&lt;')
           .replaceAll('>', '&gt;')
+          .replaceAll('"', '&quot;')
+          .replaceAll("'", '&#39;')
       }
 
       function route() {

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -5,7 +5,11 @@ import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import { HTTPError } from "~/lib/error"
+import {
+  computeDiff,
+  extractErrorDetails,
+  toAccountContext,
+} from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
@@ -71,7 +75,7 @@ export async function handleCompletion(c: Context) {
 
   const payloadWithMaxTokens = applyDefaultMaxTokens(payload, selectedModel)
 
-  const accountCtx = buildAccountCtx(account)
+  const accountCtx = toAccountContext(account)
 
   if (streamRequested) {
     return handleStreamingRequest({
@@ -131,14 +135,6 @@ type ChatCompletionsStream = Exclude<
 
 type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
 
-type ErrorDetails = {
-  httpStatus: number
-  errorName: string
-  errorStatus: number | undefined
-  errorMessage: string
-  unauthorized: boolean
-}
-
 function buildRequestContext(c: Context): RequestContext {
   const requestId = randomUUID()
   const startedAtMs = Date.now()
@@ -157,35 +153,6 @@ function buildRequestContext(c: Context): RequestContext {
     clientIp,
     clientIpSource,
     userAgent,
-  }
-}
-
-function buildAccountCtx(
-  account: AccountSelectionOk["account"],
-): Parameters<typeof createChatCompletions>[1] {
-  return {
-    githubToken: account.githubToken,
-    copilotToken: account.copilotToken,
-    accountType: account.accountType,
-    vsCodeVersion: account.vsCodeVersion,
-  }
-}
-
-function extractErrorDetails(error: unknown): ErrorDetails {
-  const errorName = error instanceof Error ? error.name : "Error"
-  const errorMessage =
-    error instanceof Error ? truncate(error.message) : truncate(String(error))
-
-  const errorStatus =
-    error instanceof HTTPError ? error.response.status : undefined
-  const httpStatus = errorStatus ?? 500
-
-  return {
-    httpStatus,
-    errorName,
-    errorStatus,
-    errorMessage,
-    unauthorized: errorStatus === 401,
   }
 }
 
@@ -713,13 +680,3 @@ async function handleNonStreamingRequest(params: {
 const isNonStreaming = (
   response: Awaited<ReturnType<typeof createChatCompletions>>,
 ): response is ChatCompletionResponse => Object.hasOwn(response, "choices")
-
-function truncate(value: string, max: number = 2000): string {
-  if (value.length <= max) return value
-  return `${value.slice(0, max)}…`
-}
-
-function computeDiff(before?: number, after?: number): number | undefined {
-  if (typeof before !== "number" || typeof after !== "number") return undefined
-  return after - before
-}

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -1,17 +1,25 @@
 import type { Context } from "hono"
 
 import { streamSSE, type SSEMessage } from "hono/streaming"
+import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { HTTPError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
+import {
+  getClientIpInfo,
+  getRequestHistoryStore,
+  normalizeChatCompletionsUsage,
+  type NormalizedUsage,
+} from "~/lib/request-history"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
 import { isNullish } from "~/lib/utils"
 import {
   createChatCompletions,
+  type ChatCompletionChunk,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
@@ -23,7 +31,12 @@ const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
-  let payload = await c.req.json<ChatCompletionsPayload>()
+  const store = getRequestHistoryStore()
+  const request = buildRequestContext(c)
+
+  const payload = await c.req.json<ChatCompletionsPayload>()
+  const streamRequested = Boolean(payload.stream)
+
   logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
 
   const selection = await accountsManager.selectAccountForRequest([
@@ -34,82 +47,679 @@ export async function handleCompletion(c: Context) {
   ])
 
   if (!selection.ok) {
-    if (selection.reason === "MODEL_NOT_SUPPORTED") {
-      return c.json(
-        {
-          error: {
-            message: `Model "${payload.model}" is not available for any configured account.`,
-            type: "invalid_request_error",
-          },
-        },
-        400,
-      )
-    }
+    recordSelectionFailure(store, {
+      request,
+      clientModel: payload.model,
+      stream: streamRequested,
+      reason: selection.reason,
+    })
 
+    return selectionFailureResponse(c, {
+      clientModel: payload.model,
+      reason: selection.reason,
+    })
+  }
+
+  const { account, selectedModel } = selection
+
+  const premiumRemainingBefore = account.premiumRemaining
+  const premiumUnlimitedBefore = account.unlimited
+
+  await logTokenCountForRequest({ payload, selectedModel })
+
+  if (state.manualApprove) await awaitApproval()
+
+  const payloadWithMaxTokens = applyDefaultMaxTokens(payload, selectedModel)
+
+  const accountCtx = buildAccountCtx(account)
+
+  if (streamRequested) {
+    return handleStreamingRequest({
+      c,
+      store,
+      request,
+      payload: payloadWithMaxTokens,
+      selection,
+      accountCtx,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+    })
+  }
+
+  return handleNonStreamingRequest({
+    c,
+    store,
+    request,
+    payload: payloadWithMaxTokens,
+    selection,
+    accountCtx,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  })
+}
+
+type AccountSelection = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+
+type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
+
+type AccountSelectionErr = Extract<AccountSelection, { ok: false }>
+
+type RequestContext = {
+  requestId: string
+  startedAtMs: number
+
+  method: string
+  path: string
+
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+}
+
+type Store = ReturnType<typeof getRequestHistoryStore>
+
+type RequestLogInsert = Parameters<Store["insert"]>[0]
+
+type ChatCompletionsResult = Awaited<ReturnType<typeof createChatCompletions>>
+
+type ChatCompletionsStream = Exclude<
+  ChatCompletionsResult,
+  ChatCompletionResponse
+>
+
+type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
+
+type ErrorDetails = {
+  httpStatus: number
+  errorName: string
+  errorStatus: number | undefined
+  errorMessage: string
+  unauthorized: boolean
+}
+
+function buildRequestContext(c: Context): RequestContext {
+  const requestId = randomUUID()
+  const startedAtMs = Date.now()
+
+  const method = c.req.raw.method
+  const path = new URL(c.req.url, "http://local").pathname
+
+  const { ip: clientIp, source: clientIpSource } = getClientIpInfo(c)
+  const userAgent = c.req.header("user-agent") ?? undefined
+
+  return {
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    clientIp,
+    clientIpSource,
+    userAgent,
+  }
+}
+
+function buildAccountCtx(
+  account: AccountSelectionOk["account"],
+): Parameters<typeof createChatCompletions>[1] {
+  return {
+    githubToken: account.githubToken,
+    copilotToken: account.copilotToken,
+    accountType: account.accountType,
+    vsCodeVersion: account.vsCodeVersion,
+  }
+}
+
+function extractErrorDetails(error: unknown): ErrorDetails {
+  const errorName = error instanceof Error ? error.name : "Error"
+  const errorMessage =
+    error instanceof Error ? truncate(error.message) : truncate(String(error))
+
+  const errorStatus =
+    error instanceof HTTPError ? error.response.status : undefined
+  const httpStatus = errorStatus ?? 500
+
+  return {
+    httpStatus,
+    errorName,
+    errorStatus,
+    errorMessage,
+    unauthorized: errorStatus === 401,
+  }
+}
+
+function insertRequestLog(
+  store: Store,
+  request: RequestContext,
+  record: Omit<
+    RequestLogInsert,
+    | "requestId"
+    | "startedAtMs"
+    | "method"
+    | "path"
+    | "clientIp"
+    | "clientIpSource"
+    | "userAgent"
+  >,
+): void {
+  store.insert({
+    requestId: request.requestId,
+    startedAtMs: request.startedAtMs,
+    method: request.method,
+    path: request.path,
+    clientIp: request.clientIp,
+    clientIpSource: request.clientIpSource,
+    userAgent: request.userAgent,
+    ...record,
+  })
+}
+
+function recordSelectionFailure(
+  store: Store,
+  params: {
+    request: RequestContext
+    stream: boolean
+    clientModel: string
+    reason: AccountSelectionErr["reason"]
+  },
+): void {
+  const { request, stream, clientModel, reason } = params
+
+  const finishedAtMs = Date.now()
+
+  insertRequestLog(store, request, {
+    finishedAtMs,
+    durationMs: finishedAtMs - request.startedAtMs,
+    upstreamEndpoint: CHAT_COMPLETIONS_ENDPOINT,
+    stream,
+    clientModel,
+    httpStatus: reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
+    selectionFailureReason: reason,
+  })
+}
+
+function selectionFailureResponse(
+  c: Context,
+  params: {
+    clientModel: string
+    reason: AccountSelectionErr["reason"]
+  },
+) {
+  const { clientModel, reason } = params
+
+  if (reason === "MODEL_NOT_SUPPORTED") {
     return c.json(
       {
         error: {
-          message:
-            "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
-          type: "rate_limit_error",
+          message: `Model "${clientModel}" is not available for any configured account.`,
+          type: "invalid_request_error",
         },
       },
-      429,
+      400,
     )
   }
 
-  const { account, reservation, selectedModel } = selection
+  return c.json(
+    {
+      error: {
+        message:
+          "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
+        type: "rate_limit_error",
+      },
+    },
+    429,
+  )
+}
 
-  // Calculate and display token count
+async function logTokenCountForRequest(params: {
+  payload: ChatCompletionsPayload
+  selectedModel: AccountSelectionOk["selectedModel"]
+}) {
   try {
-    const tokenCount = await getTokenCount(payload, selectedModel)
+    const tokenCount = await getTokenCount(params.payload, params.selectedModel)
     logger.info("Current token count:", tokenCount)
   } catch (error) {
     logger.warn("Failed to calculate token count:", error)
   }
+}
 
-  if (state.manualApprove) await awaitApproval()
+function applyDefaultMaxTokens(
+  payload: ChatCompletionsPayload,
+  selectedModel: AccountSelectionOk["selectedModel"],
+): ChatCompletionsPayload {
+  if (!isNullish(payload.max_tokens)) {
+    return payload
+  }
 
-  if (isNullish(payload.max_tokens)) {
-    payload = {
-      ...payload,
-      max_tokens: selectedModel.capabilities.limits.max_output_tokens,
+  const updated = {
+    ...payload,
+    max_tokens: selectedModel.capabilities.limits.max_output_tokens,
+  }
+
+  logger.debug("Set max_tokens to:", JSON.stringify(updated.max_tokens))
+
+  return updated
+}
+
+async function handleStreamingRequest(params: {
+  c: Context
+  store: Store
+  request: RequestContext
+  payload: ChatCompletionsPayload
+  selection: AccountSelectionOk
+  accountCtx: Parameters<typeof createChatCompletions>[1]
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+}): Promise<Response> {
+  const {
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    accountCtx,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = params
+
+  let response: ChatCompletionsResult
+
+  try {
+    response = await createChatCompletions(payload, accountCtx)
+  } catch (error) {
+    return handleUpstreamCreateError({
+      store,
+      request,
+      payload,
+      selection,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+      error,
+    })
+  }
+
+  // A defensive guard: stream requested, but upstream returned a non-stream response.
+  if (isNonStreaming(response)) {
+    return handleNonStreamingUpstreamResponse({
+      c,
+      store,
+      request,
+      payload,
+      selection,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+      response,
+    })
+  }
+
+  logger.debug("Streaming response")
+
+  return streamSSE(c, (stream) =>
+    streamChatCompletionsAndLog({
+      stream,
+      response,
+      store,
+      request,
+      payload,
+      selection,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+    }),
+  )
+}
+
+async function handleUpstreamCreateError(params: {
+  store: Store
+  request: RequestContext
+  payload: ChatCompletionsPayload
+  selection: AccountSelectionOk
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+  error: unknown
+}): Promise<never> {
+  const {
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+    error,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  const finishedAtMs = Date.now()
+  const details = extractErrorDetails(error)
+
+  if (details.unauthorized) {
+    accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+  }
+
+  await accountsManager.finalizeQuota(account, reservation)
+
+  const premiumRemainingAfter = account.premiumRemaining
+  const premiumUnlimitedAfter = account.unlimited
+
+  insertRequestLog(store, request, {
+    finishedAtMs,
+    durationMs: finishedAtMs - request.startedAtMs,
+    upstreamEndpoint: endpoint,
+    stream: true,
+    accountId: account.id,
+    accountType: account.accountType,
+    costUnits,
+    clientModel: payload.model,
+    upstreamModel: selectedModel.id,
+    premiumRemainingBefore,
+    premiumRemainingAfter,
+    premiumRemainingDiff: computeDiff(
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+    ),
+    premiumUnlimitedBefore,
+    premiumUnlimitedAfter,
+    httpStatus: details.httpStatus,
+    errorName: details.errorName,
+    errorStatus: details.errorStatus,
+    errorMessage: details.errorMessage,
+  })
+
+  throw error
+}
+
+async function handleNonStreamingUpstreamResponse(params: {
+  c: Context
+  store: Store
+  request: RequestContext
+  payload: ChatCompletionsPayload
+  selection: AccountSelectionOk
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+  response: ChatCompletionResponse
+}): Promise<Response> {
+  const {
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+    response,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  let httpStatus = 200
+  const usage: NormalizedUsage = normalizeChatCompletionsUsage(response.usage)
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const finishedAtMs = Date.now()
+
+  try {
+    logger.debug("Non-streaming response:", JSON.stringify(response))
+    return c.json(response)
+  } catch (error) {
+    const details = extractErrorDetails(error)
+    httpStatus = details.httpStatus
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    throw error
+  } finally {
+    await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    insertRequestLog(store, request, {
+      finishedAtMs,
+      durationMs: finishedAtMs - request.startedAtMs,
+      upstreamEndpoint: endpoint,
+      stream: false,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      ...usage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function streamChatCompletionsAndLog(params: {
+  stream: StreamSseStream
+  response: ChatCompletionsStream
+  store: Store
+  request: RequestContext
+  payload: ChatCompletionsPayload
+  selection: AccountSelectionOk
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+}): Promise<void> {
+  const {
+    stream,
+    response,
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  try {
+    for await (const rawChunk of response) {
+      const chunk = rawChunk as SSEMessage
+
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - request.startedAtMs
+      }
+
+      const usage = await extractUsageFromChunk(chunk)
+      if (usage) {
+        lastUsage = usage
+      }
+
+      logger.debug("Streaming chunk:", JSON.stringify(chunk))
+      await stream.writeSSE(chunk)
     }
-    logger.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
+  } catch (error) {
+    const details = extractErrorDetails(error)
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Streaming error:", error)
+  } finally {
+    const finishedAtMs = Date.now()
+
+    await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    insertRequestLog(store, request, {
+      finishedAtMs,
+      durationMs: finishedAtMs - request.startedAtMs,
+      ttfbMs,
+      upstreamEndpoint: endpoint,
+      stream: true,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      ...lastUsage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus: errorStatus ?? (errorName ? 500 : 200),
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function extractUsageFromChunk(
+  chunk: SSEMessage,
+): Promise<NormalizedUsage | undefined> {
+  const data = typeof chunk.data === "string" ? chunk.data : await chunk.data
+
+  if (!data || data === "[DONE]") {
+    return undefined
   }
 
   try {
-    const ctx = {
-      githubToken: account.githubToken,
-      copilotToken: account.copilotToken,
-      accountType: account.accountType,
-      vsCodeVersion: account.vsCodeVersion,
-    }
-    const response = await createChatCompletions(payload, ctx)
+    const parsed = JSON.parse(data) as ChatCompletionChunk
+    if (!parsed.usage) return undefined
+    return normalizeChatCompletionsUsage(parsed.usage)
+  } catch {
+    return undefined
+  }
+}
 
-    if (isNonStreaming(response)) {
-      logger.debug("Non-streaming response:", JSON.stringify(response))
-      return c.json(response)
+async function handleNonStreamingRequest(params: {
+  c: Context
+  store: Store
+  request: RequestContext
+  payload: ChatCompletionsPayload
+  selection: AccountSelectionOk
+  accountCtx: Parameters<typeof createChatCompletions>[1]
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+}): Promise<Response> {
+  const {
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    accountCtx,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  let httpStatus = 200
+  let usage: NormalizedUsage = {}
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  let finishedAtMs: number | undefined
+
+  try {
+    const response = await createChatCompletions(payload, accountCtx)
+    finishedAtMs = Date.now()
+
+    if (!isNonStreaming(response)) {
+      logger.debug("Unexpected streaming response")
+      // If upstream returns streaming unexpectedly, we just forward it.
+      // Note: This will not have "true completion" accounting.
+      return streamSSE(c, async (stream) => {
+        for await (const chunk of response) {
+          await stream.writeSSE(chunk as SSEMessage)
+        }
+      })
     }
 
-    logger.debug("Streaming response")
-    return streamSSE(c, async (stream) => {
-      for await (const chunk of response) {
-        logger.debug("Streaming chunk:", JSON.stringify(chunk))
-        await stream.writeSSE(chunk as SSEMessage)
-      }
-    })
+    usage = normalizeChatCompletionsUsage(response.usage)
+
+    logger.debug("Non-streaming response:", JSON.stringify(response))
+    return c.json(response)
   } catch (error) {
-    if (error instanceof HTTPError && error.response.status === 401) {
+    finishedAtMs = Date.now()
+
+    const details = extractErrorDetails(error)
+    httpStatus = details.httpStatus
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    if (details.unauthorized) {
       accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
     }
+
     throw error
   } finally {
-    // Refresh quota after request completes
+    const finishedAtMsFinal = finishedAtMs ?? Date.now()
+
     await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    insertRequestLog(store, request, {
+      finishedAtMs: finishedAtMsFinal,
+      durationMs: finishedAtMsFinal - request.startedAtMs,
+      upstreamEndpoint: endpoint,
+      stream: false,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      ...usage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
   }
 }
 
 const isNonStreaming = (
   response: Awaited<ReturnType<typeof createChatCompletions>>,
 ): response is ChatCompletionResponse => Object.hasOwn(response, "choices")
+
+function truncate(value: string, max: number = 2000): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}…`
+}
+
+function computeDiff(before?: number, after?: number): number | undefined {
+  if (typeof before !== "number" || typeof after !== "number") return undefined
+  return after - before
+}

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -2,7 +2,12 @@ import { Hono, type Context } from "hono"
 import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
-import { forwardError, HTTPError } from "~/lib/error"
+import { forwardError } from "~/lib/error"
+import {
+  computeDiff,
+  extractErrorDetails,
+  toAccountContext,
+} from "~/lib/handler-utils"
 import {
   getClientIpInfo,
   getRequestHistoryStore,
@@ -177,12 +182,7 @@ async function runEmbeddingsWithAccount({
   let finishedAtMs: number | undefined
 
   try {
-    const accountCtx = {
-      githubToken: account.githubToken,
-      copilotToken: account.copilotToken,
-      accountType: account.accountType,
-      vsCodeVersion: account.vsCodeVersion,
-    }
+    const accountCtx = toAccountContext(account)
 
     const response = await createEmbeddings(payload, accountCtx)
 
@@ -192,14 +192,15 @@ async function runEmbeddingsWithAccount({
     return c.json(response)
   } catch (error) {
     finishedAtMs = Date.now()
-    httpStatus = error instanceof HTTPError ? error.response.status : 500
 
-    errorName = error instanceof Error ? error.name : "Error"
-    errorStatus = error instanceof HTTPError ? error.response.status : undefined
-    errorMessage =
-      error instanceof Error ? truncate(error.message) : truncate(String(error))
+    const details = extractErrorDetails(error)
 
-    if (error instanceof HTTPError && error.response.status === 401) {
+    httpStatus = details.httpStatus
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    if (details.unauthorized) {
       accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
     }
 
@@ -244,14 +245,4 @@ async function runEmbeddingsWithAccount({
       errorMessage,
     })
   }
-}
-
-function truncate(value: string, max: number = 2000): string {
-  if (value.length <= max) return value
-  return `${value.slice(0, max)}…`
-}
-
-function computeDiff(before?: number, after?: number): number | undefined {
-  if (typeof before !== "number" || typeof after !== "number") return undefined
-  return after - before
 }

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -1,7 +1,14 @@
-import { Hono } from "hono"
+import { Hono, type Context } from "hono"
+import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { forwardError, HTTPError } from "~/lib/error"
+import {
+  getClientIpInfo,
+  getRequestHistoryStore,
+  normalizeEmbeddingsUsage,
+  type NormalizedUsage,
+} from "~/lib/request-history"
 import {
   createEmbeddings,
   type EmbeddingRequest,
@@ -11,8 +18,49 @@ export const embeddingRoutes = new Hono()
 
 const EMBEDDINGS_ENDPOINT = "/embeddings"
 
+type AccountSelection = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+
+type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
+
+type AccountSelectionErr = Extract<AccountSelection, { ok: false }>
+
+type RequestContext = {
+  requestId: string
+  startedAtMs: number
+
+  method: string
+  path: string
+
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+}
+
 embeddingRoutes.post("/", async (c) => {
   try {
+    const store = getRequestHistoryStore()
+
+    const requestId = randomUUID()
+    const startedAtMs = Date.now()
+
+    const method = c.req.raw.method
+    const path = new URL(c.req.url, "http://local").pathname
+
+    const { ip: clientIp, source: clientIpSource } = getClientIpInfo(c)
+    const userAgent = c.req.header("user-agent") ?? undefined
+
+    const ctx: RequestContext = {
+      requestId,
+      startedAtMs,
+      method,
+      path,
+      clientIp,
+      clientIpSource,
+      userAgent,
+    }
+
     const payload = await c.req.json<EmbeddingRequest>()
 
     const selection = await accountsManager.selectAccountForRequest([
@@ -23,52 +71,187 @@ embeddingRoutes.post("/", async (c) => {
     ])
 
     if (!selection.ok) {
-      if (selection.reason === "MODEL_NOT_SUPPORTED") {
-        return c.json(
-          {
-            error: {
-              message: `Model "${payload.model}" is not available for any configured account.`,
-              type: "invalid_request_error",
-            },
-          },
-          400,
-        )
-      }
-
-      return c.json(
-        {
-          error: {
-            message:
-              "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
-            type: "rate_limit_error",
-          },
-        },
-        429,
-      )
+      recordSelectionFailure(store, {
+        ctx,
+        clientModel: payload.model,
+        reason: selection.reason,
+      })
+      return selectionFailureResponse(c, payload.model, selection.reason)
     }
 
-    const { account, reservation } = selection
-
-    try {
-      const ctx = {
-        githubToken: account.githubToken,
-        copilotToken: account.copilotToken,
-        accountType: account.accountType,
-        vsCodeVersion: account.vsCodeVersion,
-      }
-      const response = await createEmbeddings(payload, ctx)
-
-      return c.json(response)
-    } catch (error) {
-      if (error instanceof HTTPError && error.response.status === 401) {
-        accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
-      }
-      throw error
-    } finally {
-      // Refresh quota after request completes
-      await accountsManager.finalizeQuota(account, reservation)
-    }
+    return await runEmbeddingsWithAccount({
+      c,
+      store,
+      ctx,
+      payload,
+      selection,
+    })
   } catch (error) {
     return await forwardError(c, error)
   }
 })
+
+function recordSelectionFailure(
+  store: ReturnType<typeof getRequestHistoryStore>,
+  params: {
+    ctx: RequestContext
+    clientModel: string
+    reason: AccountSelectionErr["reason"]
+  },
+): void {
+  const { ctx, clientModel, reason } = params
+
+  const finishedAtMs = Date.now()
+
+  store.insert({
+    requestId: ctx.requestId,
+    startedAtMs: ctx.startedAtMs,
+    finishedAtMs,
+    durationMs: finishedAtMs - ctx.startedAtMs,
+    method: ctx.method,
+    path: ctx.path,
+    upstreamEndpoint: EMBEDDINGS_ENDPOINT,
+    stream: false,
+    clientModel,
+    clientIp: ctx.clientIp,
+    clientIpSource: ctx.clientIpSource,
+    userAgent: ctx.userAgent,
+    httpStatus: reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
+    selectionFailureReason: reason,
+  })
+}
+
+function selectionFailureResponse(
+  c: Context,
+  clientModel: string,
+  reason: AccountSelectionErr["reason"],
+) {
+  if (reason === "MODEL_NOT_SUPPORTED") {
+    return c.json(
+      {
+        error: {
+          message: `Model "${clientModel}" is not available for any configured account.`,
+          type: "invalid_request_error",
+        },
+      },
+      400,
+    )
+  }
+
+  return c.json(
+    {
+      error: {
+        message:
+          "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
+        type: "rate_limit_error",
+      },
+    },
+    429,
+  )
+}
+
+async function runEmbeddingsWithAccount({
+  c,
+  store,
+  ctx,
+  payload,
+  selection,
+}: {
+  c: Context
+  store: ReturnType<typeof getRequestHistoryStore>
+  ctx: RequestContext
+  payload: EmbeddingRequest
+  selection: AccountSelectionOk
+}) {
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  const premiumRemainingBefore = account.premiumRemaining
+  const premiumUnlimitedBefore = account.unlimited
+
+  let httpStatus = 200
+  let usage: NormalizedUsage = {}
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  let finishedAtMs: number | undefined
+
+  try {
+    const accountCtx = {
+      githubToken: account.githubToken,
+      copilotToken: account.copilotToken,
+      accountType: account.accountType,
+      vsCodeVersion: account.vsCodeVersion,
+    }
+
+    const response = await createEmbeddings(payload, accountCtx)
+
+    usage = normalizeEmbeddingsUsage(response.usage)
+
+    finishedAtMs = Date.now()
+    return c.json(response)
+  } catch (error) {
+    finishedAtMs = Date.now()
+    httpStatus = error instanceof HTTPError ? error.response.status : 500
+
+    errorName = error instanceof Error ? error.name : "Error"
+    errorStatus = error instanceof HTTPError ? error.response.status : undefined
+    errorMessage =
+      error instanceof Error ? truncate(error.message) : truncate(String(error))
+
+    if (error instanceof HTTPError && error.response.status === 401) {
+      accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+    }
+
+    throw error
+  } finally {
+    const finishedAtMsFinal = finishedAtMs ?? Date.now()
+
+    await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    store.insert({
+      requestId: ctx.requestId,
+      startedAtMs: ctx.startedAtMs,
+      finishedAtMs: finishedAtMsFinal,
+      durationMs: finishedAtMsFinal - ctx.startedAtMs,
+      method: ctx.method,
+      path: ctx.path,
+      upstreamEndpoint: endpoint,
+      stream: false,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      clientIp: ctx.clientIp,
+      clientIpSource: ctx.clientIpSource,
+      userAgent: ctx.userAgent,
+      ...usage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+function truncate(value: string, max: number = 2000): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}…`
+}
+
+function computeDiff(before?: number, after?: number): number | undefined {
+  if (typeof before !== "number" || typeof after !== "number") return undefined
+  return after - before
+}

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono"
 
 import { streamSSE } from "hono/streaming"
+import { randomUUID } from "node:crypto"
 
 import type { AccountContext, AccountRuntime } from "~/lib/types/account"
 
@@ -10,6 +11,14 @@ import { getSmallModel } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
+import {
+  extractResponsesUsageFromResult,
+  extractResponsesUsageFromStreamEvent,
+  getClientIpInfo,
+  getRequestHistoryStore,
+  normalizeChatCompletionsUsage,
+  type NormalizedUsage,
+} from "~/lib/request-history"
 import { state } from "~/lib/state"
 import {
   buildErrorEvent,
@@ -33,10 +42,11 @@ import {
   type ResponseStreamEvent,
 } from "~/services/copilot/create-responses"
 
-import {
-  type AnthropicMessagesPayload,
-  type AnthropicStreamState,
+import type {
+  AnthropicMessagesPayload,
+  AnthropicStreamState,
 } from "./anthropic-types"
+
 import {
   translateToAnthropic,
   translateToOpenAI,
@@ -45,8 +55,52 @@ import { translateChunkToAnthropicEvents } from "./stream-translation"
 
 const logger = createHandlerLogger("messages-handler")
 
+const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
+const RESPONSES_ENDPOINT = "/responses"
+
+type AccountSelection = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+
+type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
+
+type InstrumentationContext = {
+  store: ReturnType<typeof getRequestHistoryStore>
+  requestId: string
+  startedAtMs: number
+
+  method: string
+  path: string
+
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+
+  clientModel: string
+
+  account: AccountRuntime
+  reservation: AccountSelectionOk["reservation"]
+  upstreamModel: string
+  upstreamEndpoint: string
+  costUnits: number
+
+  premiumRemainingBefore?: number
+  premiumUnlimitedBefore?: boolean
+}
+
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
+
+  const store = getRequestHistoryStore()
+
+  const requestId = randomUUID()
+  const startedAtMs = Date.now()
+
+  const method = c.req.raw.method
+  const path = new URL(c.req.url, "http://local").pathname
+
+  const { ip: clientIp, source: clientIpSource } = getClientIpInfo(c)
+  const userAgent = c.req.header("user-agent") ?? undefined
 
   const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
   logger.debug("Anthropic request payload:", JSON.stringify(anthropicPayload))
@@ -60,6 +114,7 @@ export async function handleCompletion(c: Context) {
   }
 
   const openAIPayload = translateToOpenAI(anthropicPayload)
+  const streamRequested = Boolean(anthropicPayload.stream)
 
   const selection = await accountsManager.selectAccountForRequest([
     {
@@ -73,6 +128,24 @@ export async function handleCompletion(c: Context) {
   ])
 
   if (!selection.ok) {
+    const finishedAtMs = Date.now()
+
+    store.insert({
+      requestId,
+      startedAtMs,
+      finishedAtMs,
+      durationMs: finishedAtMs - startedAtMs,
+      method,
+      path,
+      stream: streamRequested,
+      clientModel: anthropicPayload.model,
+      clientIp,
+      clientIpSource,
+      userAgent,
+      httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
+      selectionFailureReason: selection.reason,
+    })
+
     if (selection.reason === "MODEL_NOT_SUPPORTED") {
       return c.json(
         {
@@ -97,31 +170,45 @@ export async function handleCompletion(c: Context) {
     )
   }
 
-  const { account, reservation, endpoint } = selection
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  const premiumRemainingBefore = account.premiumRemaining
+  const premiumUnlimitedBefore = account.unlimited
 
   if (state.manualApprove) {
     await awaitApproval()
   }
 
-  try {
-    if (endpoint === RESPONSES_ENDPOINT) {
-      return await handleWithResponsesApi(c, anthropicPayload, account)
-    }
+  const instr: InstrumentationContext = {
+    store,
+    requestId,
+    startedAtMs,
 
-    return await handleWithChatCompletions(c, openAIPayload, account)
-  } catch (error) {
-    if (error instanceof HTTPError && error.response.status === 401) {
-      accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
-    }
-    throw error
-  } finally {
-    // Refresh quota after request completes
-    await accountsManager.finalizeQuota(account, reservation)
+    method,
+    path,
+
+    clientIp,
+    clientIpSource,
+    userAgent,
+
+    clientModel: anthropicPayload.model,
+
+    account,
+    reservation,
+    upstreamEndpoint: endpoint,
+    upstreamModel: selectedModel.id,
+    costUnits,
+
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
   }
-}
 
-const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
-const RESPONSES_ENDPOINT = "/responses"
+  if (endpoint === RESPONSES_ENDPOINT) {
+    return await handleWithResponsesApi(c, anthropicPayload, instr)
+  }
+
+  return await handleWithChatCompletions(c, openAIPayload, instr)
+}
 
 const toAccountContext = (account: AccountRuntime): AccountContext => ({
   githubToken: account.githubToken,
@@ -133,68 +220,51 @@ const toAccountContext = (account: AccountRuntime): AccountContext => ({
 const handleWithChatCompletions = async (
   c: Context,
   openAIPayload: ChatCompletionsPayload,
-  account: AccountRuntime,
-) => {
+  instr: InstrumentationContext,
+): Promise<Response> => {
   logger.debug(
     "Translated OpenAI request payload:",
     JSON.stringify(openAIPayload),
   )
 
-  const ctx = toAccountContext(account)
-  const response = await createChatCompletions(openAIPayload, ctx)
+  const ctx = toAccountContext(instr.account)
+
+  let response: ChatCompletionsResult
+
+  try {
+    response = await createChatCompletions(openAIPayload, ctx)
+  } catch (error) {
+    return await handleChatCompletionsCreateError({
+      error,
+      instr,
+      stream: Boolean(openAIPayload.stream),
+    })
+  }
 
   if (isNonStreaming(response)) {
-    logger.debug(
-      "Non-streaming response from Copilot:",
-      JSON.stringify(response),
-    )
-    const anthropicResponse = translateToAnthropic(response)
-    logger.debug(
-      "Translated Anthropic response:",
-      JSON.stringify(anthropicResponse),
-    )
-    return c.json(anthropicResponse)
+    return handleChatCompletionsNonStreaming({
+      c,
+      response,
+      instr,
+    })
   }
 
   logger.debug("Streaming response from Copilot")
-  return streamSSE(c, async (stream) => {
-    const streamState: AnthropicStreamState = {
-      messageStartSent: false,
-      contentBlockIndex: 0,
-      contentBlockOpen: false,
-      toolCalls: {},
-      thinkingBlockOpen: false,
-    }
 
-    for await (const rawEvent of response) {
-      logger.debug("Copilot raw stream event:", JSON.stringify(rawEvent))
-      if (rawEvent.data === "[DONE]") {
-        break
-      }
-
-      if (!rawEvent.data) {
-        continue
-      }
-
-      const chunk = JSON.parse(rawEvent.data) as ChatCompletionChunk
-      const events = translateChunkToAnthropicEvents(chunk, streamState)
-
-      for (const event of events) {
-        logger.debug("Translated Anthropic event:", JSON.stringify(event))
-        await stream.writeSSE({
-          event: event.type,
-          data: JSON.stringify(event),
-        })
-      }
-    }
-  })
+  return streamSSE(c, (stream) =>
+    streamChatCompletionsAndLog({
+      stream,
+      response,
+      instr,
+    }),
+  )
 }
 
 const handleWithResponsesApi = async (
   c: Context,
   anthropicPayload: AnthropicMessagesPayload,
-  account: AccountRuntime,
-) => {
+  instr: InstrumentationContext,
+): Promise<Response> => {
   const responsesPayload =
     translateAnthropicMessagesToResponsesPayload(anthropicPayload)
   logger.debug(
@@ -203,81 +273,587 @@ const handleWithResponsesApi = async (
   )
 
   const { vision, initiator } = getResponsesRequestOptions(responsesPayload)
-  const ctx = toAccountContext(account)
-  const response = await createResponses(
-    responsesPayload,
-    {
-      vision,
-      initiator,
-    },
-    ctx,
-  )
+  const ctx = toAccountContext(instr.account)
 
-  if (responsesPayload.stream && isAsyncIterable(response)) {
-    logger.debug("Streaming response from Copilot (Responses API)")
-    return streamSSE(c, async (stream) => {
-      const streamState = createResponsesStreamState()
+  let response: Awaited<ReturnType<typeof createResponses>>
 
-      for await (const chunk of response) {
-        const eventName = chunk.event
-        if (eventName === "ping") {
-          await stream.writeSSE({ event: "ping", data: "" })
-          continue
-        }
-
-        const data = chunk.data
-        if (!data) {
-          continue
-        }
-
-        logger.debug("Responses raw stream event:", data)
-
-        const events = translateResponsesStreamEvent(
-          JSON.parse(data) as ResponseStreamEvent,
-          streamState,
-        )
-        for (const event of events) {
-          const eventData = JSON.stringify(event)
-          logger.debug("Translated Anthropic event:", eventData)
-          await stream.writeSSE({
-            event: event.type,
-            data: eventData,
-          })
-        }
-
-        if (streamState.messageCompleted) {
-          logger.debug("Message completed, ending stream")
-          break
-        }
-      }
-
-      if (!streamState.messageCompleted) {
-        logger.warn(
-          "Responses stream ended without completion; sending error event",
-        )
-        const errorEvent = buildErrorEvent(
-          "Responses stream ended without completion",
-        )
-        await stream.writeSSE({
-          event: errorEvent.type,
-          data: JSON.stringify(errorEvent),
-        })
-      }
+  try {
+    response = await createResponses(
+      responsesPayload,
+      {
+        vision,
+        initiator,
+      },
+      ctx,
+    )
+  } catch (error) {
+    return await handleResponsesCreateError({
+      error,
+      instr,
+      stream: Boolean(responsesPayload.stream),
     })
   }
 
-  logger.debug(
-    "Non-streaming Responses result:",
-    JSON.stringify(response).slice(-400),
-  )
-  const anthropicResponse = translateResponsesResultToAnthropic(
-    response as ResponsesResult,
-  )
-  logger.debug(
-    "Translated Anthropic response:",
-    JSON.stringify(anthropicResponse),
-  )
-  return c.json(anthropicResponse)
+  if (responsesPayload.stream && isAsyncIterable(response)) {
+    logger.debug("Streaming response from Copilot (Responses API)")
+
+    return streamSSE(c, (stream) =>
+      streamResponsesAndLog({
+        stream,
+        response,
+        instr,
+      }),
+    )
+  }
+
+  return handleResponsesNonStreaming({
+    c,
+    result: response as ResponsesResult,
+    instr,
+  })
+}
+
+type Store = ReturnType<typeof getRequestHistoryStore>
+
+type RequestLogInsert = Parameters<Store["insert"]>[0]
+
+type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
+
+type ChatCompletionsResult = Awaited<ReturnType<typeof createChatCompletions>>
+
+type ChatCompletionsStream = Exclude<
+  ChatCompletionsResult,
+  ChatCompletionResponse
+>
+
+type ErrorDetails = {
+  httpStatus: number
+  errorName: string
+  errorStatus: number | undefined
+  errorMessage: string
+  unauthorized: boolean
+}
+
+function extractErrorDetails(error: unknown): ErrorDetails {
+  const errorName = error instanceof Error ? error.name : "Error"
+  const errorMessage =
+    error instanceof Error ? truncate(error.message) : truncate(String(error))
+
+  const errorStatus =
+    error instanceof HTTPError ? error.response.status : undefined
+  const httpStatus = errorStatus ?? 500
+
+  return {
+    httpStatus,
+    errorName,
+    errorStatus,
+    errorMessage,
+    unauthorized: errorStatus === 401,
+  }
+}
+
+function insertRequestLog(
+  instr: InstrumentationContext,
+  record: Omit<
+    RequestLogInsert,
+    | "requestId"
+    | "startedAtMs"
+    | "method"
+    | "path"
+    | "clientIp"
+    | "clientIpSource"
+    | "userAgent"
+    | "clientModel"
+    | "upstreamEndpoint"
+    | "accountId"
+    | "accountType"
+    | "costUnits"
+    | "upstreamModel"
+    | "premiumRemainingBefore"
+    | "premiumUnlimitedBefore"
+  >,
+): void {
+  const {
+    store,
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    clientIp,
+    clientIpSource,
+    userAgent,
+    clientModel,
+    account,
+    upstreamEndpoint,
+    upstreamModel,
+    costUnits,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = instr
+
+  store.insert({
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    clientIp,
+    clientIpSource,
+    userAgent,
+    clientModel,
+    upstreamEndpoint,
+    accountId: account.id,
+    accountType: account.accountType,
+    costUnits,
+    upstreamModel,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+    ...record,
+  })
+}
+
+async function finalizeQuotaAndGetPremiumSnapshot(
+  instr: InstrumentationContext,
+): Promise<{
+  premiumRemainingAfter: number | undefined
+  premiumUnlimitedAfter: boolean | undefined
+  premiumRemainingDiff: number | undefined
+}> {
+  await accountsManager.finalizeQuota(instr.account, instr.reservation)
+
+  const premiumRemainingAfter = instr.account.premiumRemaining
+  const premiumUnlimitedAfter = instr.account.unlimited
+
+  return {
+    premiumRemainingAfter,
+    premiumUnlimitedAfter,
+    premiumRemainingDiff: computeDiff(
+      instr.premiumRemainingBefore,
+      premiumRemainingAfter,
+    ),
+  }
+}
+
+async function handleChatCompletionsCreateError(params: {
+  error: unknown
+  instr: InstrumentationContext
+  stream: boolean
+}): Promise<never> {
+  const { error, instr, stream } = params
+
+  const finishedAtMs = Date.now()
+  const details = extractErrorDetails(error)
+
+  if (details.unauthorized) {
+    accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+  }
+
+  const { premiumRemainingAfter, premiumUnlimitedAfter, premiumRemainingDiff } =
+    await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+  insertRequestLog(instr, {
+    finishedAtMs,
+    durationMs: finishedAtMs - instr.startedAtMs,
+    stream,
+    premiumRemainingAfter,
+    premiumUnlimitedAfter,
+    premiumRemainingDiff,
+    httpStatus: details.httpStatus,
+    errorName: details.errorName,
+    errorStatus: details.errorStatus,
+    errorMessage: details.errorMessage,
+  })
+
+  throw error
+}
+
+async function handleChatCompletionsNonStreaming(params: {
+  c: Context
+  response: ChatCompletionResponse
+  instr: InstrumentationContext
+}): Promise<Response> {
+  const { c, response, instr } = params
+
+  let httpStatus = 200
+  const usage: NormalizedUsage = normalizeChatCompletionsUsage(response.usage)
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const finishedAtMs = Date.now()
+
+  try {
+    logger.debug(
+      "Non-streaming response from Copilot:",
+      JSON.stringify(response),
+    )
+
+    const anthropicResponse = translateToAnthropic(response)
+    logger.debug(
+      "Translated Anthropic response:",
+      JSON.stringify(anthropicResponse),
+    )
+
+    return c.json(anthropicResponse)
+  } catch (error) {
+    const details = extractErrorDetails(error)
+
+    httpStatus = details.httpStatus
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+
+    throw error
+  } finally {
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      stream: false,
+      ...usage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function streamChatCompletionsAndLog(params: {
+  stream: StreamSseStream
+  response: ChatCompletionsStream
+  instr: InstrumentationContext
+}): Promise<void> {
+  const { stream, response, instr } = params
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const streamState: AnthropicStreamState = {
+    messageStartSent: false,
+    contentBlockIndex: 0,
+    contentBlockOpen: false,
+    toolCalls: {},
+    thinkingBlockOpen: false,
+  }
+
+  try {
+    for await (const rawEvent of response) {
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - instr.startedAtMs
+      }
+
+      logger.debug("Copilot raw stream event:", JSON.stringify(rawEvent))
+
+      const { data: rawData } = rawEvent as {
+        data?: string | Promise<string>
+      }
+      const data = typeof rawData === "string" ? rawData : await rawData
+
+      if (data === "[DONE]") {
+        break
+      }
+
+      if (!data) {
+        continue
+      }
+
+      const chunk = JSON.parse(data) as ChatCompletionChunk
+      if (chunk.usage) {
+        lastUsage = normalizeChatCompletionsUsage(chunk.usage)
+      }
+
+      const events = translateChunkToAnthropicEvents(chunk, streamState)
+      for (const event of events) {
+        logger.debug("Translated Anthropic event:", JSON.stringify(event))
+
+        await stream.writeSSE({
+          event: event.type,
+          data: JSON.stringify(event),
+        })
+      }
+    }
+  } catch (error) {
+    const details = extractErrorDetails(error)
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Streaming error:", error)
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+  } finally {
+    const finishedAtMs = Date.now()
+
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      ttfbMs,
+      stream: true,
+      ...lastUsage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus: errorStatus ?? (errorName ? 500 : 200),
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function handleResponsesCreateError(params: {
+  error: unknown
+  instr: InstrumentationContext
+  stream: boolean
+}): Promise<never> {
+  const { error, instr, stream } = params
+
+  const finishedAtMs = Date.now()
+  const details = extractErrorDetails(error)
+
+  if (details.unauthorized) {
+    accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+  }
+
+  const { premiumRemainingAfter, premiumUnlimitedAfter, premiumRemainingDiff } =
+    await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+  insertRequestLog(instr, {
+    finishedAtMs,
+    durationMs: finishedAtMs - instr.startedAtMs,
+    stream,
+    premiumRemainingAfter,
+    premiumUnlimitedAfter,
+    premiumRemainingDiff,
+    httpStatus: details.httpStatus,
+    errorName: details.errorName,
+    errorStatus: details.errorStatus,
+    errorMessage: details.errorMessage,
+  })
+
+  throw error
+}
+
+async function handleResponsesNonStreaming(params: {
+  c: Context
+  result: ResponsesResult
+  instr: InstrumentationContext
+}): Promise<Response> {
+  const { c, result, instr } = params
+
+  let httpStatus = 200
+  let usage: NormalizedUsage = {}
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const finishedAtMs = Date.now()
+
+  try {
+    usage = extractResponsesUsageFromResult(result)
+
+    logger.debug(
+      "Non-streaming Responses result:",
+      JSON.stringify(result).slice(-400),
+    )
+
+    const anthropicResponse = translateResponsesResultToAnthropic(result)
+    logger.debug(
+      "Translated Anthropic response:",
+      JSON.stringify(anthropicResponse),
+    )
+
+    return c.json(anthropicResponse)
+  } catch (error) {
+    const details = extractErrorDetails(error)
+
+    httpStatus = details.httpStatus
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+
+    throw error
+  } finally {
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      stream: false,
+      ...usage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function ensureResponsesStreamCompleted(params: {
+  stream: StreamSseStream
+  streamState: ReturnType<typeof createResponsesStreamState>
+  setStreamError: (name: string, message: string) => void
+}): Promise<void> {
+  const { stream, streamState, setStreamError } = params
+
+  if (streamState.messageCompleted) {
+    return
+  }
+
+  logger.warn("Responses stream ended without completion; sending error event")
+
+  const msg = "Responses stream ended without completion"
+  const errorEvent = buildErrorEvent(msg)
+
+  setStreamError("StreamIncomplete", msg)
+
+  await stream.writeSSE({
+    event: errorEvent.type,
+    data: JSON.stringify(errorEvent),
+  })
+}
+
+async function streamResponsesAndLog(params: {
+  stream: StreamSseStream
+  response: AsyncIterable<unknown>
+  instr: InstrumentationContext
+}): Promise<void> {
+  const { stream, response, instr } = params
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const streamState = createResponsesStreamState()
+
+  try {
+    for await (const chunk of response) {
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - instr.startedAtMs
+      }
+
+      const eventName = (chunk as { event?: string }).event
+      if (eventName === "ping") {
+        await stream.writeSSE({ event: "ping", data: "" })
+        continue
+      }
+
+      const data = (chunk as { data?: string }).data
+      if (!data) {
+        continue
+      }
+
+      logger.debug("Responses raw stream event:", data)
+
+      const parsed = JSON.parse(data) as ResponseStreamEvent
+      const u = extractResponsesUsageFromStreamEvent(parsed)
+      if (u.usageJson) {
+        lastUsage = u
+      }
+
+      const events = translateResponsesStreamEvent(parsed, streamState)
+      for (const event of events) {
+        const eventData = JSON.stringify(event)
+        logger.debug("Translated Anthropic event:", eventData)
+        await stream.writeSSE({
+          event: event.type,
+          data: eventData,
+        })
+      }
+
+      if (streamState.messageCompleted) {
+        logger.debug("Message completed, ending stream")
+        break
+      }
+    }
+
+    await ensureResponsesStreamCompleted({
+      stream,
+      streamState,
+      setStreamError: (name, message) => {
+        errorName = name
+        errorMessage = message
+      },
+    })
+  } catch (error) {
+    const details = extractErrorDetails(error)
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Streaming error:", error)
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+  } finally {
+    const finishedAtMs = Date.now()
+
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      ttfbMs,
+      stream: true,
+      ...lastUsage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus: errorStatus ?? (errorName ? 500 : 200),
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
 }
 
 const isNonStreaming = (
@@ -287,3 +863,13 @@ const isNonStreaming = (
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
   Boolean(value)
   && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
+
+function truncate(value: string, max: number = 2000): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}…`
+}
+
+function computeDiff(before?: number, after?: number): number | undefined {
+  if (typeof before !== "number" || typeof after !== "number") return undefined
+  return after - before
+}

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -3,12 +3,16 @@ import type { Context } from "hono"
 import { streamSSE } from "hono/streaming"
 import { randomUUID } from "node:crypto"
 
-import type { AccountContext, AccountRuntime } from "~/lib/types/account"
+import type { AccountRuntime } from "~/lib/types/account"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { getSmallModel } from "~/lib/config"
-import { HTTPError } from "~/lib/error"
+import {
+  computeDiff,
+  extractErrorDetails,
+  toAccountContext,
+} from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
@@ -210,13 +214,6 @@ export async function handleCompletion(c: Context) {
   return await handleWithChatCompletions(c, openAIPayload, instr)
 }
 
-const toAccountContext = (account: AccountRuntime): AccountContext => ({
-  githubToken: account.githubToken,
-  copilotToken: account.copilotToken,
-  accountType: account.accountType,
-  vsCodeVersion: account.vsCodeVersion,
-})
-
 const handleWithChatCompletions = async (
   c: Context,
   openAIPayload: ChatCompletionsPayload,
@@ -325,32 +322,6 @@ type ChatCompletionsStream = Exclude<
   ChatCompletionsResult,
   ChatCompletionResponse
 >
-
-type ErrorDetails = {
-  httpStatus: number
-  errorName: string
-  errorStatus: number | undefined
-  errorMessage: string
-  unauthorized: boolean
-}
-
-function extractErrorDetails(error: unknown): ErrorDetails {
-  const errorName = error instanceof Error ? error.name : "Error"
-  const errorMessage =
-    error instanceof Error ? truncate(error.message) : truncate(String(error))
-
-  const errorStatus =
-    error instanceof HTTPError ? error.response.status : undefined
-  const httpStatus = errorStatus ?? 500
-
-  return {
-    httpStatus,
-    errorName,
-    errorStatus,
-    errorMessage,
-    unauthorized: errorStatus === 401,
-  }
-}
 
 function insertRequestLog(
   instr: InstrumentationContext,
@@ -863,13 +834,3 @@ const isNonStreaming = (
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
   Boolean(value)
   && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
-
-function truncate(value: string, max: number = 2000): string {
-  if (value.length <= max) return value
-  return `${value.slice(0, max)}…`
-}
-
-function computeDiff(before?: number, after?: number): number | undefined {
-  if (typeof before !== "number" || typeof after !== "number") return undefined
-  return after - before
-}

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1,17 +1,26 @@
 import type { Context } from "hono"
 
 import { streamSSE } from "hono/streaming"
+import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import { HTTPError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
+import {
+  extractResponsesUsageFromResult,
+  extractResponsesUsageFromStreamEvent,
+  getClientIpInfo,
+  getRequestHistoryStore,
+  type NormalizedUsage,
+} from "~/lib/request-history"
 import { state } from "~/lib/state"
 import {
   createResponses,
   type ResponsesPayload,
   type ResponsesResult,
+  type ResponseStreamEvent,
 } from "~/services/copilot/create-responses"
 
 import { getResponsesRequestOptions } from "./utils"
@@ -23,8 +32,13 @@ const RESPONSES_ENDPOINT = "/responses"
 export const handleResponses = async (c: Context) => {
   await checkRateLimit(state)
 
+  const store = getRequestHistoryStore()
+  const request = buildRequestContext(c)
+
   const payload = await c.req.json<ResponsesPayload>()
   logger.debug("Responses request payload:", JSON.stringify(payload))
+
+  const streamRequested = Boolean(payload.stream)
 
   const selection = await accountsManager.selectAccountForRequest([
     {
@@ -34,75 +48,669 @@ export const handleResponses = async (c: Context) => {
   ])
 
   if (!selection.ok) {
-    if (selection.reason === "MODEL_NOT_SUPPORTED") {
-      return c.json(
-        {
-          error: {
-            message:
-              "This model does not support the responses endpoint. Please choose a different model.",
-            type: "invalid_request_error",
-          },
-        },
-        400,
-      )
-    }
+    recordSelectionFailure(store, {
+      request,
+      stream: streamRequested,
+      clientModel: payload.model,
+      reason: selection.reason,
+    })
 
+    return selectionFailureResponse(c, {
+      reason: selection.reason,
+    })
+  }
+
+  const { account } = selection
+
+  const premiumRemainingBefore = account.premiumRemaining
+  const premiumUnlimitedBefore = account.unlimited
+
+  const { vision, initiator } = getResponsesRequestOptions(payload)
+
+  if (state.manualApprove) await awaitApproval()
+
+  const accountCtx = buildAccountCtx(account)
+
+  if (streamRequested) {
+    return handleStreamingResponses({
+      c,
+      store,
+      request,
+      payload,
+      selection,
+      accountCtx,
+      vision,
+      initiator,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+    })
+  }
+
+  return handleNonStreamingResponses({
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    accountCtx,
+    vision,
+    initiator,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  })
+}
+
+type AccountSelection = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+
+type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
+
+type AccountSelectionErr = Extract<AccountSelection, { ok: false }>
+
+type RequestContext = {
+  requestId: string
+  startedAtMs: number
+
+  method: string
+  path: string
+
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+}
+
+type Store = ReturnType<typeof getRequestHistoryStore>
+
+type RequestLogInsert = Parameters<Store["insert"]>[0]
+
+type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
+
+type ErrorDetails = {
+  httpStatus: number
+  errorName: string
+  errorStatus: number | undefined
+  errorMessage: string
+  unauthorized: boolean
+}
+
+function buildRequestContext(c: Context): RequestContext {
+  const requestId = randomUUID()
+  const startedAtMs = Date.now()
+
+  const method = c.req.raw.method
+  const path = new URL(c.req.url, "http://local").pathname
+
+  const { ip: clientIp, source: clientIpSource } = getClientIpInfo(c)
+  const userAgent = c.req.header("user-agent") ?? undefined
+
+  return {
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    clientIp,
+    clientIpSource,
+    userAgent,
+  }
+}
+
+function buildAccountCtx(
+  account: AccountSelectionOk["account"],
+): Parameters<typeof createResponses>[2] {
+  return {
+    githubToken: account.githubToken,
+    copilotToken: account.copilotToken,
+    accountType: account.accountType,
+    vsCodeVersion: account.vsCodeVersion,
+  }
+}
+
+function extractErrorDetails(error: unknown): ErrorDetails {
+  const errorName = error instanceof Error ? error.name : "Error"
+  const errorMessage =
+    error instanceof Error ? truncate(error.message) : truncate(String(error))
+
+  const errorStatus =
+    error instanceof HTTPError ? error.response.status : undefined
+  const httpStatus = errorStatus ?? 500
+
+  return {
+    httpStatus,
+    errorName,
+    errorStatus,
+    errorMessage,
+    unauthorized: errorStatus === 401,
+  }
+}
+
+function insertRequestLog(
+  store: Store,
+  request: RequestContext,
+  record: Omit<
+    RequestLogInsert,
+    | "requestId"
+    | "startedAtMs"
+    | "method"
+    | "path"
+    | "clientIp"
+    | "clientIpSource"
+    | "userAgent"
+  >,
+): void {
+  store.insert({
+    requestId: request.requestId,
+    startedAtMs: request.startedAtMs,
+    method: request.method,
+    path: request.path,
+    clientIp: request.clientIp,
+    clientIpSource: request.clientIpSource,
+    userAgent: request.userAgent,
+    ...record,
+  })
+}
+
+function recordSelectionFailure(
+  store: Store,
+  params: {
+    request: RequestContext
+    stream: boolean
+    clientModel: string
+    reason: AccountSelectionErr["reason"]
+  },
+): void {
+  const { request, stream, clientModel, reason } = params
+
+  const finishedAtMs = Date.now()
+
+  insertRequestLog(store, request, {
+    finishedAtMs,
+    durationMs: finishedAtMs - request.startedAtMs,
+    upstreamEndpoint: RESPONSES_ENDPOINT,
+    stream,
+    clientModel,
+    httpStatus: reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
+    selectionFailureReason: reason,
+  })
+}
+
+function selectionFailureResponse(
+  c: Context,
+  params: {
+    reason: AccountSelectionErr["reason"]
+  },
+) {
+  const { reason } = params
+
+  if (reason === "MODEL_NOT_SUPPORTED") {
     return c.json(
       {
         error: {
           message:
-            "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
-          type: "rate_limit_error",
+            "This model does not support the responses endpoint. Please choose a different model.",
+          type: "invalid_request_error",
         },
       },
-      429,
+      400,
     )
   }
 
-  const { account, reservation } = selection
+  return c.json(
+    {
+      error: {
+        message:
+          "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
+        type: "rate_limit_error",
+      },
+    },
+    429,
+  )
+}
 
-  const { vision, initiator } = getResponsesRequestOptions(payload)
-
-  if (state.manualApprove) {
-    await awaitApproval()
-  }
+function extractUsageFromChunkData(
+  data: string | undefined,
+): NormalizedUsage | undefined {
+  if (!data) return undefined
 
   try {
-    const ctx = {
-      githubToken: account.githubToken,
-      copilotToken: account.copilotToken,
-      accountType: account.accountType,
-      vsCodeVersion: account.vsCodeVersion,
-    }
-    const response = await createResponses(payload, { vision, initiator }, ctx)
+    const event = JSON.parse(data) as ResponseStreamEvent
+    const usage = extractResponsesUsageFromStreamEvent(event)
+    return usage.usageJson ? usage : undefined
+  } catch {
+    return undefined
+  }
+}
 
-    if (isStreamingRequested(payload) && isAsyncIterable(response)) {
-      logger.debug("Forwarding native Responses stream")
+type StreamChunk = {
+  id?: string
+  event?: string
+  data?: string
+}
+
+function getStreamChunkFields(chunk: unknown): StreamChunk {
+  const c = chunk as StreamChunk
+  return {
+    id: c.id,
+    event: c.event,
+    data: c.data,
+  }
+}
+
+async function handleStreamingResponses(params: {
+  c: Context
+  store: Store
+  request: RequestContext
+  payload: ResponsesPayload
+  selection: AccountSelectionOk
+  accountCtx: Parameters<typeof createResponses>[2]
+  vision: boolean
+  initiator: "agent" | "user"
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+}): Promise<Response> {
+  const {
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    accountCtx,
+    vision,
+    initiator,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = params
+
+  let response: Awaited<ReturnType<typeof createResponses>>
+
+  try {
+    response = await createResponses(payload, { vision, initiator }, accountCtx)
+  } catch (error) {
+    return handleUpstreamCreateError({
+      store,
+      request,
+      payload,
+      selection,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+      error,
+    })
+  }
+
+  if (isAsyncIterable(response)) {
+    logger.debug("Forwarding native Responses stream")
+
+    return streamSSE(c, (stream) =>
+      streamResponsesAndLog({
+        stream,
+        response,
+        store,
+        request,
+        payload,
+        selection,
+        premiumRemainingBefore,
+        premiumUnlimitedBefore,
+      }),
+    )
+  }
+
+  return handleNonStreamingUpstreamResult({
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+    result: response,
+  })
+}
+
+async function handleUpstreamCreateError(params: {
+  store: Store
+  request: RequestContext
+  payload: ResponsesPayload
+  selection: AccountSelectionOk
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+  error: unknown
+}): Promise<never> {
+  const {
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+    error,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  const finishedAtMs = Date.now()
+  const details = extractErrorDetails(error)
+
+  if (details.unauthorized) {
+    accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
+  }
+
+  await accountsManager.finalizeQuota(account, reservation)
+
+  const premiumRemainingAfter = account.premiumRemaining
+  const premiumUnlimitedAfter = account.unlimited
+
+  insertRequestLog(store, request, {
+    finishedAtMs,
+    durationMs: finishedAtMs - request.startedAtMs,
+    upstreamEndpoint: endpoint,
+    stream: true,
+    accountId: account.id,
+    accountType: account.accountType,
+    costUnits,
+    clientModel: payload.model,
+    upstreamModel: selectedModel.id,
+    premiumRemainingBefore,
+    premiumRemainingAfter,
+    premiumRemainingDiff: computeDiff(
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+    ),
+    premiumUnlimitedBefore,
+    premiumUnlimitedAfter,
+    httpStatus: details.httpStatus,
+    errorName: details.errorName,
+    errorStatus: details.errorStatus,
+    errorMessage: details.errorMessage,
+  })
+
+  throw error
+}
+
+async function handleNonStreamingUpstreamResult(params: {
+  c: Context
+  store: Store
+  request: RequestContext
+  payload: ResponsesPayload
+  selection: AccountSelectionOk
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+  result: ResponsesResult
+}): Promise<Response> {
+  const {
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+    result,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  let httpStatus = 200
+  const usage: NormalizedUsage = extractResponsesUsageFromResult(result)
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const finishedAtMs = Date.now()
+
+  try {
+    logger.debug(
+      "Forwarding native Responses result:",
+      JSON.stringify(result).slice(-400),
+    )
+    return c.json(result)
+  } catch (error) {
+    const details = extractErrorDetails(error)
+    httpStatus = details.httpStatus
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    throw error
+  } finally {
+    await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    insertRequestLog(store, request, {
+      finishedAtMs,
+      durationMs: finishedAtMs - request.startedAtMs,
+      upstreamEndpoint: endpoint,
+      stream: false,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      ...usage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function streamResponsesAndLog(params: {
+  stream: StreamSseStream
+  response: AsyncIterable<unknown>
+  store: Store
+  request: RequestContext
+  payload: ResponsesPayload
+  selection: AccountSelectionOk
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+}): Promise<void> {
+  const {
+    stream,
+    response,
+    store,
+    request,
+    payload,
+    selection,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  try {
+    for await (const chunk of response) {
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - request.startedAtMs
+      }
+
+      const { id, event, data } = getStreamChunkFields(chunk)
+
+      const usage = extractUsageFromChunkData(data)
+      if (usage) {
+        lastUsage = usage
+      }
+
+      logger.debug("Responses stream chunk:", JSON.stringify(chunk))
+
+      await stream.writeSSE({
+        id,
+        event,
+        data: data ?? "",
+      })
+    }
+  } catch (error) {
+    const details = extractErrorDetails(error)
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Responses streaming error:", error)
+  } finally {
+    const finishedAtMs = Date.now()
+
+    await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    insertRequestLog(store, request, {
+      finishedAtMs,
+      durationMs: finishedAtMs - request.startedAtMs,
+      ttfbMs,
+      upstreamEndpoint: endpoint,
+      stream: true,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      ...lastUsage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus: errorStatus ?? (errorName ? 500 : 200),
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+async function handleNonStreamingResponses(params: {
+  c: Context
+  store: Store
+  request: RequestContext
+  payload: ResponsesPayload
+  selection: AccountSelectionOk
+  accountCtx: Parameters<typeof createResponses>[2]
+  vision: boolean
+  initiator: "agent" | "user"
+  premiumRemainingBefore: number | undefined
+  premiumUnlimitedBefore: boolean | undefined
+}): Promise<Response> {
+  const {
+    c,
+    store,
+    request,
+    payload,
+    selection,
+    accountCtx,
+    vision,
+    initiator,
+    premiumRemainingBefore,
+    premiumUnlimitedBefore,
+  } = params
+
+  const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  let httpStatus = 200
+  let usage: NormalizedUsage = {}
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  let finishedAtMs: number | undefined
+
+  try {
+    const response = await createResponses(
+      payload,
+      { vision, initiator },
+      accountCtx,
+    )
+    finishedAtMs = Date.now()
+
+    if (isAsyncIterable(response)) {
+      // Defensive guard: upstream returned stream unexpectedly.
+      logger.debug("Forwarding native Responses stream (unexpected)")
+
       return streamSSE(c, async (stream) => {
         for await (const chunk of response) {
-          logger.debug("Responses stream chunk:", JSON.stringify(chunk))
+          const { id, event, data } = getStreamChunkFields(chunk)
           await stream.writeSSE({
-            id: (chunk as { id?: string }).id,
-            event: (chunk as { event?: string }).event,
-            data: (chunk as { data?: string }).data ?? "",
+            id,
+            event,
+            data: data ?? "",
           })
         }
       })
     }
 
+    usage = extractResponsesUsageFromResult(response)
+
     logger.debug(
       "Forwarding native Responses result:",
       JSON.stringify(response).slice(-400),
     )
-    return c.json(response as ResponsesResult)
+    return c.json(response)
   } catch (error) {
-    if (error instanceof HTTPError && error.response.status === 401) {
+    finishedAtMs = Date.now()
+
+    const details = extractErrorDetails(error)
+    httpStatus = details.httpStatus
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    if (details.unauthorized) {
       accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
     }
+
     throw error
   } finally {
-    // Refresh quota after request completes
+    const finishedAtMsFinal = finishedAtMs ?? Date.now()
+
     await accountsManager.finalizeQuota(account, reservation)
+
+    const premiumRemainingAfter = account.premiumRemaining
+    const premiumUnlimitedAfter = account.unlimited
+
+    insertRequestLog(store, request, {
+      finishedAtMs: finishedAtMsFinal,
+      durationMs: finishedAtMsFinal - request.startedAtMs,
+      upstreamEndpoint: endpoint,
+      stream: false,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      clientModel: payload.model,
+      upstreamModel: selectedModel.id,
+      ...usage,
+      premiumRemainingBefore,
+      premiumRemainingAfter,
+      premiumRemainingDiff: computeDiff(
+        premiumRemainingBefore,
+        premiumRemainingAfter,
+      ),
+      premiumUnlimitedBefore,
+      premiumUnlimitedAfter,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
   }
 }
 
@@ -110,5 +718,12 @@ const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
   Boolean(value)
   && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
 
-const isStreamingRequested = (payload: ResponsesPayload): boolean =>
-  Boolean(payload.stream)
+function truncate(value: string, max: number = 2000): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}…`
+}
+
+function computeDiff(before?: number, after?: number): number | undefined {
+  if (typeof before !== "number" || typeof after !== "number") return undefined
+  return after - before
+}

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -5,7 +5,11 @@ import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import { HTTPError } from "~/lib/error"
+import {
+  computeDiff,
+  extractErrorDetails,
+  toAccountContext,
+} from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
@@ -69,7 +73,7 @@ export const handleResponses = async (c: Context) => {
 
   if (state.manualApprove) await awaitApproval()
 
-  const accountCtx = buildAccountCtx(account)
+  const accountCtx = toAccountContext(account)
 
   if (streamRequested) {
     return handleStreamingResponses({
@@ -126,14 +130,6 @@ type RequestLogInsert = Parameters<Store["insert"]>[0]
 
 type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
 
-type ErrorDetails = {
-  httpStatus: number
-  errorName: string
-  errorStatus: number | undefined
-  errorMessage: string
-  unauthorized: boolean
-}
-
 function buildRequestContext(c: Context): RequestContext {
   const requestId = randomUUID()
   const startedAtMs = Date.now()
@@ -152,35 +148,6 @@ function buildRequestContext(c: Context): RequestContext {
     clientIp,
     clientIpSource,
     userAgent,
-  }
-}
-
-function buildAccountCtx(
-  account: AccountSelectionOk["account"],
-): Parameters<typeof createResponses>[2] {
-  return {
-    githubToken: account.githubToken,
-    copilotToken: account.copilotToken,
-    accountType: account.accountType,
-    vsCodeVersion: account.vsCodeVersion,
-  }
-}
-
-function extractErrorDetails(error: unknown): ErrorDetails {
-  const errorName = error instanceof Error ? error.name : "Error"
-  const errorMessage =
-    error instanceof Error ? truncate(error.message) : truncate(String(error))
-
-  const errorStatus =
-    error instanceof HTTPError ? error.response.status : undefined
-  const httpStatus = errorStatus ?? 500
-
-  return {
-    httpStatus,
-    errorName,
-    errorStatus,
-    errorMessage,
-    unauthorized: errorStatus === 401,
   }
 }
 
@@ -717,13 +684,3 @@ async function handleNonStreamingResponses(params: {
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
   Boolean(value)
   && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
-
-function truncate(value: string, max: number = 2000): string {
-  if (value.length <= max) return value
-  return `${value.slice(0, max)}…`
-}
-
-function computeDiff(before?: number, after?: number): number | undefined {
-  if (typeof before !== "number" || typeof after !== "number") return undefined
-  return after - before
-}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 
+import { adminApiRoutes } from "./routes/admin-api/route"
+import { adminRoutes } from "./routes/admin/route"
 import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
@@ -23,6 +25,10 @@ server.route("/embeddings", embeddingRoutes)
 server.route("/usage", usageRoute)
 server.route("/token", tokenRoute)
 server.route("/responses", responsesRoutes)
+
+// Admin UI / APIs (no auth; intended for localhost/intranet)
+server.route("/admin", adminRoutes)
+server.route("/api/admin", adminApiRoutes)
 
 // Compatibility with tools that expect v1/ prefix
 server.route("/v1/chat/completions", completionRoutes)

--- a/tests/handler-utils.test.ts
+++ b/tests/handler-utils.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+
+import type { AccountRuntime } from "../src/lib/types/account"
+
+import { HTTPError } from "../src/lib/error"
+import {
+  computeDiff,
+  extractErrorDetails,
+  toAccountContext,
+  truncate,
+} from "../src/lib/handler-utils"
+
+test("truncate returns original when within limit", () => {
+  expect(truncate("abc", 3)).toBe("abc")
+  expect(truncate("abc", 10)).toBe("abc")
+})
+
+test("truncate appends ellipsis when exceeding limit", () => {
+  expect(truncate("abcd", 3)).toBe("abc…")
+})
+
+test("computeDiff returns after-before for numbers", () => {
+  expect(computeDiff(5, 8)).toBe(3)
+})
+
+test("computeDiff returns undefined if inputs are missing", () => {
+  expect(computeDiff(undefined, 8)).toBeUndefined()
+  expect(computeDiff(5, undefined)).toBeUndefined()
+})
+
+test("toAccountContext projects AccountRuntime to AccountContext", () => {
+  const runtime: AccountRuntime = {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: 0,
+    githubToken: "ghp_test",
+    copilotToken: "copilot_test",
+    vsCodeVersion: "1.0.0",
+  }
+
+  expect(toAccountContext(runtime)).toEqual({
+    githubToken: "ghp_test",
+    copilotToken: "copilot_test",
+    accountType: "individual",
+    vsCodeVersion: "1.0.0",
+  })
+})
+
+test("extractErrorDetails handles non-HTTP errors", () => {
+  const error = new Error("boom")
+  const details = extractErrorDetails(error)
+
+  expect(details.httpStatus).toBe(500)
+  expect(details.errorStatus).toBeUndefined()
+  expect(details.errorMessage).toBe("boom")
+  expect(details.unauthorized).toBe(false)
+})
+
+test("extractErrorDetails handles HTTPError and detects unauthorized", () => {
+  const error = new HTTPError(
+    "nope",
+    new Response("unauthorized", { status: 401 }),
+  )
+
+  const details = extractErrorDetails(error)
+
+  expect(details.httpStatus).toBe(401)
+  expect(details.errorStatus).toBe(401)
+  expect(details.errorMessage).toBe("nope")
+  expect(details.unauthorized).toBe(true)
+})


### PR DESCRIPTION
## Summary
- Persist per-request usage, account selection, and quota snapshots/diffs in SQLite
- Add /api/admin endpoints and a no-build /admin UI for inspection/debugging
- Instrument chat-completions, responses, messages, and embeddings (including streaming finalization)
- Harden admin surfaces:
  - /api/admin: localhost-only by default; optional ADMIN_TOKEN for remote access; same-origin check to prevent cross-origin reads
  - /admin UI: escape dynamic fields to mitigate XSS
- Improve resilience:
  - Throttled warn on request-log insert failures
  - Retryable admin DB/request-history initialization (no-op store when unavailable)

## Test plan
- [x] bun run lint
- [x] bun run typecheck
- [x] bun test