### PR TITLE
feat(admin): show quota remaining in requests table

### DIFF
--- a/src/routes/admin/route.ts
+++ b/src/routes/admin/route.ts
@@ -413,7 +413,7 @@ const html = `<!doctype html>
           '        <th>Model</th>',
           '        <th>Tokens</th>',
           '        <th>Cost</th>',
-          '        <th>Quota diff</th>',
+          '        <th>Quota</th>',
           '        <th>Dur</th>',
           '        <th>Status</th>',
           '      </tr>',
@@ -461,7 +461,9 @@ const html = `<!doctype html>
               const status = r.http_status
               const statusP = status >= 400 ? pill(status, 'bad') : pill(status, 'good')
               const when = fmtMs(r.started_at_ms)
-              const quotaDiff = r.premium_remaining_diff != null ? fmtNum(r.premium_remaining_diff) : ''
+              const quota = Number(r.premium_unlimited_after) > 0
+                ? '∞'
+                : (r.premium_remaining_after != null ? fmtNum(r.premium_remaining_after) : '')
               const dur = r.duration_ms != null ? fmtNum(r.duration_ms) : ''
               const acct = r.account_id || ''
               const model = r.upstream_model || ''
@@ -476,7 +478,7 @@ const html = `<!doctype html>
                 + '<td class="mono">' + escapeHtml(model) + '</td>'
                 + '<td class="mono">' + tokens + '</td>'
                 + '<td class="mono">' + (r.cost_units ?? '') + '</td>'
-                + '<td class="mono">' + quotaDiff + '</td>'
+                + '<td class="mono">' + quota + '</td>'
                 + '<td class="mono">' + dur + '</td>'
                 + '<td>' + statusP + '</td>'
                 + '</tr>'

--- a/src/routes/admin/route.ts
+++ b/src/routes/admin/route.ts
@@ -461,7 +461,7 @@ const html = `<!doctype html>
               const status = r.http_status
               const statusP = status >= 400 ? pill(status, 'bad') : pill(status, 'good')
               const when = fmtMs(r.started_at_ms)
-              const quota = Number(r.premium_unlimited_after) > 0
+              const quota = r.premium_unlimited_after
                 ? '∞'
                 : (r.premium_remaining_after != null ? fmtNum(r.premium_remaining_after) : '')
               const dur = r.duration_ms != null ? fmtNum(r.duration_ms) : ''


### PR DESCRIPTION
## Summary
- Replace **Quota diff** with **Quota** on `/admin#/requests`.
- Display request post-run remaining quota via `premium_remaining_after` (shows `∞` when `premium_unlimited_after`).

## Test plan
- [x] bun test
- [x] bun run lint
- [x] bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 请求视图中将列标题从“Quota diff”更新为“Quota”。
  * 请求表格中改进了配额展示：当为无限配额时显示“∞”，否则显示格式化后的剩余配额，缺失时留空。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->