### PR TITLE
feat(chat-completions): support reasoning_effort for gpt-5-mini

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -36,8 +36,13 @@ let cachedConfig: AppConfig | null = null
 
 function ensureConfigFile(): void {
   try {
-    fs.accessSync(PATHS.CONFIG_PATH, fs.constants.R_OK | fs.constants.W_OK)
+    fs.accessSync(PATHS.CONFIG_PATH, fs.constants.R_OK)
+    return
   } catch {
+    // Fall through to try creating the default config file.
+  }
+
+  try {
     fs.mkdirSync(PATHS.APP_DIR, { recursive: true })
     fs.writeFileSync(
       PATHS.CONFIG_PATH,
@@ -47,8 +52,10 @@ function ensureConfigFile(): void {
     try {
       fs.chmodSync(PATHS.CONFIG_PATH, 0o600)
     } catch {
-      return
+      // Ignore chmod errors (e.g. unsupported filesystem).
     }
+  } catch {
+    // Best-effort only: if we can't create the file, reads will fall back to defaults.
   }
 }
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -4,8 +4,31 @@ import { events } from "fetch-event-stream"
 import type { AccountContext } from "~/lib/types/account"
 
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
+import { getReasoningEffortForModel } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { accountFromState } from "~/lib/state"
+
+function isGpt5MiniFamily(modelId: string): boolean {
+  return modelId === "gpt-5-mini" || modelId.startsWith("gpt-5-mini-")
+}
+
+function applyDefaultReasoningEffort(
+  payload: ChatCompletionsPayload,
+): ChatCompletionsPayload {
+  if (!isGpt5MiniFamily(payload.model)) return payload
+
+  // Only inject when omitted/null; allow callers to explicitly override.
+  if (
+    payload.reasoning_effort !== null
+    && payload.reasoning_effort !== undefined
+  )
+    return payload
+
+  return {
+    ...payload,
+    reasoning_effort: getReasoningEffortForModel("gpt-5-mini"),
+  }
+}
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
@@ -32,10 +55,12 @@ export const createChatCompletions = async (
     "X-Initiator": isAgentCall ? "agent" : "user",
   }
 
+  const upstreamPayload = applyDefaultReasoningEffort(payload)
+
   const response = await fetch(`${copilotBaseUrl(ctx)}/chat/completions`, {
     method: "POST",
     headers,
-    body: JSON.stringify(payload),
+    body: JSON.stringify(upstreamPayload),
   })
 
   if (!response.ok) {
@@ -156,6 +181,14 @@ export interface ChatCompletionsPayload {
     | { type: "function"; function: { name: string } }
     | null
   user?: string | null
+  reasoning_effort?:
+    | "none"
+    | "minimal"
+    | "low"
+    | "medium"
+    | "high"
+    | "xhigh"
+    | null
   thinking_budget?: number
 }
 

--- a/tests/create-chat-completions.test.ts
+++ b/tests/create-chat-completions.test.ts
@@ -1,9 +1,16 @@
 import { test, expect, mock } from "bun:test"
 
-import type { ChatCompletionsPayload } from "../src/services/copilot/create-chat-completions"
-
+import { getReasoningEffortForModel } from "../src/lib/config"
 import { state } from "../src/lib/state"
-import { createChatCompletions } from "../src/services/copilot/create-chat-completions"
+import {
+  createChatCompletions,
+  type ChatCompletionsPayload,
+} from "../src/services/copilot/create-chat-completions"
+
+type FetchOpts = {
+  headers: Record<string, string>
+  body?: string
+}
 
 // Mock state
 state.githubToken = "test-github-token"
@@ -12,19 +19,32 @@ state.vsCodeVersion = "1.0.0"
 state.accountType = "individual"
 
 // Helper to mock fetch
-const fetchMock = mock(
-  (_url: string, opts: { headers: Record<string, string> }) => {
-    return {
-      ok: true,
-      json: () => ({ id: "123", object: "chat.completion", choices: [] }),
-      headers: opts.headers,
-    }
-  },
-)
+const fetchMock = mock((_url: string, opts: FetchOpts) => {
+  return {
+    ok: true,
+    json: () => ({ id: "123", object: "chat.completion", choices: [] }),
+    headers: opts.headers,
+  }
+})
 // @ts-expect-error - Mock fetch doesn't implement all fetch properties
 ;(globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock
 
+function getLastFetchCall(): FetchOpts {
+  const last = fetchMock.mock.calls.at(-1)?.[1]
+
+  expect(last).toBeTruthy()
+  return last as FetchOpts
+}
+
+function getLastUpstreamPayload(): Record<string, unknown> {
+  const { body } = getLastFetchCall()
+  expect(body).toBeTruthy()
+  return JSON.parse(body as string) as Record<string, unknown>
+}
+
 test("sets X-Initiator to agent if tool/assistant present", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
   const payload: ChatCompletionsPayload = {
     messages: [
       { role: "user", content: "hi" },
@@ -32,15 +52,17 @@ test("sets X-Initiator to agent if tool/assistant present", async () => {
     ],
     model: "gpt-test",
   }
+
   await createChatCompletions(payload)
-  expect(fetchMock).toHaveBeenCalled()
-  const headers = (
-    fetchMock.mock.calls[0][1] as { headers: Record<string, string> }
-  ).headers
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const { headers } = getLastFetchCall()
   expect(headers["X-Initiator"]).toBe("agent")
 })
 
 test("sets X-Initiator to user if only user present", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
   const payload: ChatCompletionsPayload = {
     messages: [
       { role: "user", content: "hi" },
@@ -48,10 +70,91 @@ test("sets X-Initiator to user if only user present", async () => {
     ],
     model: "gpt-test",
   }
+
   await createChatCompletions(payload)
-  expect(fetchMock).toHaveBeenCalled()
-  const headers = (
-    fetchMock.mock.calls[1][1] as { headers: Record<string, string> }
-  ).headers
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const { headers } = getLastFetchCall()
   expect(headers["X-Initiator"]).toBe("user")
+})
+
+test("injects reasoning_effort from config for gpt-5-mini when omitted", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
+  const payload: ChatCompletionsPayload = {
+    messages: [{ role: "user", content: "hi" }],
+    model: "gpt-5-mini",
+  }
+
+  await createChatCompletions(payload)
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const upstreamPayload = getLastUpstreamPayload()
+  expect(upstreamPayload["reasoning_effort"]).toBe(
+    getReasoningEffortForModel("gpt-5-mini"),
+  )
+})
+
+test("does not override explicit reasoning_effort for gpt-5-mini", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
+  const payload: ChatCompletionsPayload = {
+    messages: [{ role: "user", content: "hi" }],
+    model: "gpt-5-mini",
+    reasoning_effort: "high",
+  }
+
+  await createChatCompletions(payload)
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const upstreamPayload = getLastUpstreamPayload()
+  expect(upstreamPayload["reasoning_effort"]).toBe("high")
+})
+
+test("passes through reasoning_effort for non-gpt-5-mini models", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
+  const payload: ChatCompletionsPayload = {
+    messages: [{ role: "user", content: "hi" }],
+    model: "gpt-test",
+    reasoning_effort: "low",
+  }
+
+  await createChatCompletions(payload)
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const upstreamPayload = getLastUpstreamPayload()
+  expect(upstreamPayload["reasoning_effort"]).toBe("low")
+})
+
+test("does not inject reasoning_effort for non-gpt-5-mini models when omitted", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
+  const payload: ChatCompletionsPayload = {
+    messages: [{ role: "user", content: "hi" }],
+    model: "gpt-test",
+  }
+
+  await createChatCompletions(payload)
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const upstreamPayload = getLastUpstreamPayload()
+  expect(Object.hasOwn(upstreamPayload, "reasoning_effort")).toBe(false)
+})
+
+test("injects reasoning_effort for gpt-5-mini variant models when omitted", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
+  const payload: ChatCompletionsPayload = {
+    messages: [{ role: "user", content: "hi" }],
+    model: "gpt-5-mini-2026-01-01",
+  }
+
+  await createChatCompletions(payload)
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const upstreamPayload = getLastUpstreamPayload()
+  expect(upstreamPayload["reasoning_effort"]).toBe(
+    getReasoningEffortForModel("gpt-5-mini"),
+  )
 })


### PR DESCRIPTION
## Summary
- Add `reasoning_effort` support for `/chat/completions` and inject default from config for `gpt-5-mini` when omitted
- Keep non-`gpt-5-mini` requests pass-through for `reasoning_effort`
- Harden config file creation to be best-effort and add regression tests

## Test plan
- [x] bun test
- [x] bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进配置文件访问机制，增强容错性，降低权限检查严格度。

* **New Features**
  * 为特定模型自动注入推理参数，优化API请求处理流程。

* **Tests**
  * 新增推理参数处理相关的测试覆盖。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->