### PR TITLE
ci(actions): publish DockerHub images on pushes

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -23,15 +23,15 @@ jobs:
 
       - name: Set up QEMU
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,amd64
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log into Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -66,7 +66,7 @@ jobs:
           echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,74 @@
+name: DockerHub Build and Push
+
+on:
+  push:
+    branches-ignore:
+      - release
+    tags:
+      - "v*"
+
+concurrency:
+  group: dockerhub-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64,amd64
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          raw="${GITHUB_REF#refs/heads/}"
+          clean=$(echo "$raw" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's#/#-#g' \
+            | sed 's/[^a-z0-9._-]/-/g' \
+            | sed 's/-\{2,\}/-/g' \
+            | sed 's/^[^a-z0-9]\+//; s/[^a-z0-9]\+$//' \
+            | cut -c1-128)
+
+          if [[ -z "$clean" ]]; then
+            clean="branch"
+          fi
+
+          echo "tag=$clean" >> "$GITHUB_OUTPUT"
+          echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/copilot-api:${{ steps.tag.outputs.tag }}
+          platforms: ${{ steps.tag.outputs.platforms }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,amd64
@@ -63,7 +62,7 @@ jobs:
           fi
 
           echo "tag=$clean" >> "$GITHUB_OUTPUT"
-          echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
+          echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -72,3 +71,5 @@ jobs:
           push: true
           tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/copilot-api:${{ steps.tag.outputs.tag }}
           platforms: ${{ steps.tag.outputs.platforms }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add DockerHub workflow to build & push images on non-`release` branch pushes (tag = sanitized branch name).
- Publish on `v*` tag pushes (tag = git tag). Tag pushes will still keep existing GHCR release workflow as-is.
- Branch builds use `linux/amd64`; tag builds use `linux/amd64,linux/arm64`.

## Notes
- Requires GitHub Actions secrets:
  - `DOCKERHUB_USERNAME`
  - `DOCKERHUB_TOKEN`

## Test plan
- [ ] Configure `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` in repo secrets
- [ ] Push a commit to a non-`release` branch and verify DockerHub image tag matches the sanitized branch name
- [ ] Push a `v*` tag and verify DockerHub publishes `:<tag>` (and GHCR still publishes for `v*.*.*`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 新增自动化工作流：构建并推送镜像到 Docker Hub。
  * 支持按分支或按标签触发构建，并为构建生成规范化的镜像标签（分支名会规范化，空分支默认为 "branch"）。
  * 支持多架构镜像（amd64、arm64）构建与推送。
  * 启用基于工作流的并发取消与缓存以提升构建效率。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->