### PR TITLE
feat(auth): optional API key protection for public endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ docker run -p 4141:4141 -e GH_TOKEN=your_github_token_here copilot-api
 # This requires setting ADMIN_TOKEN and sending it via request headers (x-admin-token / Authorization: Bearer)
 docker run -p 4141:4141 -e GH_TOKEN=your_github_token_here -e ADMIN_TOKEN=your_admin_token_here copilot-api
 
+# (Optional) Protect selected API endpoints with an API key
+# This protects /v1/*, /token, /usage(/usage/*), and also the non-/v1 OpenAI-style endpoints (/chat/completions, /models, /embeddings, /responses)
+# Clients must send Authorization: Bearer <key> or x-api-key: <key>
+docker run -p 4141:4141 -e GH_TOKEN=your_github_token_here -e COPILOT_API_KEY=your_api_key_here copilot-api
+
 # Run with additional options
 docker run -p 4141:4141 -e GH_TOKEN=your_token copilot-api --verbose --port 4141
 ```
@@ -131,6 +136,7 @@ services:
     environment:
       - GH_TOKEN=your_github_token_here
       - ADMIN_TOKEN=your_admin_token_here
+      - COPILOT_API_KEY=your_api_key_here
     restart: unless-stopped
 ```
 
@@ -248,6 +254,7 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Copilot. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts.
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests) to avoid spending premium requests; defaults to `gpt-5-mini`.
 - **freeModelLoadBalancing:** Enable round-robin routing for free-model requests across multiple accounts. Defaults to `true`. Set to `false` to route free-model requests sequentially (same ordering strategy as premium models).
+- **apiKey (optional):** API key used to protect selected endpoints. You can also set this via the `COPILOT_API_KEY` environment variable (takes precedence). See **API Key authentication** below.
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
 
 Edit this file to customize prompts or swap in your own fast model. Restart the server (or rerun the command) after changes so the cached config is refreshed.
@@ -290,6 +297,23 @@ Endpoints for monitoring your Copilot usage and quotas across all accounts.
 > - `/usage/:index` is **0-based**.
 > - If you start the server with `start --github-token ...`, a temporary account is included and shown as `"(temporary)"` in `GET /usage`. In that case, `index=0` refers to the temporary account and registered accounts start at `index=1`.
 > - `auth rm <index>` uses a **1-based** index (as shown by `auth ls`).
+
+### API Key authentication (optional)
+
+You can protect selected public endpoints by setting an API key:
+
+- **Environment variable (preferred):** `COPILOT_API_KEY`
+- **config.json:** `"apiKey": "<key>"` (used only when `COPILOT_API_KEY` is not set)
+
+When a key is configured, requests to the following endpoints require authentication:
+- OpenAI-compatible: `/v1/*`, `/chat/completions`, `/models`, `/embeddings`, `/responses`
+- Usage/token: `/usage`, `/usage/*`, `/token`
+
+Send the key using one of:
+- `Authorization: Bearer <key>` (common for OpenAI clients)
+- `x-api-key: <key>` (common for Anthropic clients)
+
+If no key is configured, these endpoints are publicly accessible (fail-open).
 
 ### Admin UI & Admin API
 
@@ -416,6 +440,8 @@ After starting the server, a URL to the Copilot Usage Dashboard will be displaye
     `https://ericc-ch.github.io/copilot-api?endpoint=http://localhost:4141/usage`
     - If you use the `start.bat` script on Windows, this page will open automatically.
 
+> **API Key note:** If you enable API key authentication for `/usage`, your client must send the API key header. If a client cannot set headers, use `curl` or another API client instead.
+
 The dashboard provides a user-friendly interface to view your Copilot usage data:
 
 - **API Endpoint URL**: The dashboard is pre-configured to fetch data from your local server endpoint via the URL query parameter. You can change this URL to point to any other compatible API endpoint.
@@ -486,11 +512,15 @@ You will be prompted to select a primary model and a "small, fast" model for bac
 
 Paste and run this command in a new terminal to launch Claude Code.
 
+> **API Key note:** If you enabled API key authentication (via `COPILOT_API_KEY` or `config.json` `apiKey`), set `ANTHROPIC_AUTH_TOKEN` in the generated command to the same API key.
+
 ### Manual Configuration with `settings.json`
 
 Alternatively, you can configure Claude Code by creating a `.claude/settings.json` file in your project's root directory. This file should contain the environment variables needed by Claude Code. This way you don't need to run the interactive setup every time.
 
 Here is an example `.claude/settings.json` file:
+
+> **API Key note:** If API key authentication is enabled, set `ANTHROPIC_AUTH_TOKEN` to your API key so Claude Code can send `x-api-key`. If not enabled, any value works.
 
 ```json
 {

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -1,6 +1,8 @@
 import type { MiddlewareHandler } from "hono"
 
-import { getConfig } from "./config"
+import { timingSafeEqual } from "node:crypto"
+
+import { getConfig } from "~/lib/config"
 
 const API_KEY_ENV_VAR = "COPILOT_API_KEY"
 
@@ -72,6 +74,17 @@ export function isProtectedPath(pathnameRaw: string): boolean {
   )
 }
 
+function timingSafeKeyCompare(a: string, b: string): boolean {
+  try {
+    const aBuf = Buffer.from(a)
+    const bBuf = Buffer.from(b)
+    if (aBuf.length !== bBuf.length) return false
+    return timingSafeEqual(aBuf, bBuf)
+  } catch {
+    return false
+  }
+}
+
 export function createApiKeyAuthMiddleware(
   options: ApiKeyAuthOptions = {},
 ): MiddlewareHandler {
@@ -100,7 +113,7 @@ export function createApiKeyAuthMiddleware(
 
     const providedKey = extractRequestApiKey(c.req.raw.headers)
 
-    if (!providedKey || providedKey !== configuredKey) {
+    if (!providedKey || !timingSafeKeyCompare(providedKey, configuredKey)) {
       return c.json(
         {
           error: {

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -1,0 +1,118 @@
+import type { MiddlewareHandler } from "hono"
+
+import { getConfig } from "./config"
+
+const API_KEY_ENV_VAR = "COPILOT_API_KEY"
+
+export type ApiKeyAuthOptions = {
+  /**
+   * Injected for tests; defaults to env+config resolution.
+   */
+  getConfiguredApiKey?: () => string | undefined
+
+  /**
+   * Injected for tests; defaults to the built-in protected path matcher.
+   */
+  isProtectedPath?: (pathname: string) => boolean
+}
+
+export function resolveConfiguredApiKey(): string | undefined {
+  const envKey = process.env[API_KEY_ENV_VAR]?.trim()
+  if (envKey) return envKey
+
+  const configKey = getConfig().apiKey?.trim()
+  if (configKey) return configKey
+
+  return undefined
+}
+
+export function parseBearerToken(value: string): string | undefined {
+  const trimmed = value.trim()
+  if (!trimmed.toLowerCase().startsWith("bearer ")) return undefined
+
+  const token = trimmed.slice("bearer ".length).trim()
+  return token || undefined
+}
+
+export function extractRequestApiKey(headers: Headers): string | undefined {
+  const headerToken = headers.get("x-api-key")?.trim()
+  if (headerToken) return headerToken
+
+  const bearer = headers.get("authorization")
+  if (bearer) {
+    const token = parseBearerToken(bearer)
+    if (token) return token
+  }
+
+  return undefined
+}
+
+function normalizePathname(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1)
+  }
+  return pathname
+}
+
+function hasPrefixBoundary(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`)
+}
+
+export function isProtectedPath(pathnameRaw: string): boolean {
+  const pathname = normalizePathname(pathnameRaw)
+
+  return (
+    hasPrefixBoundary(pathname, "/v1")
+    || hasPrefixBoundary(pathname, "/token")
+    || hasPrefixBoundary(pathname, "/usage")
+    || hasPrefixBoundary(pathname, "/chat/completions")
+    || hasPrefixBoundary(pathname, "/embeddings")
+    || hasPrefixBoundary(pathname, "/models")
+    || hasPrefixBoundary(pathname, "/responses")
+  )
+}
+
+export function createApiKeyAuthMiddleware(
+  options: ApiKeyAuthOptions = {},
+): MiddlewareHandler {
+  const getConfiguredKey =
+    options.getConfiguredApiKey ?? resolveConfiguredApiKey
+  const isPathProtected = options.isProtectedPath ?? isProtectedPath
+
+  return async (c, next) => {
+    if (c.req.method === "OPTIONS") {
+      await next()
+      return
+    }
+
+    const url = new URL(c.req.url, "http://local")
+    if (!isPathProtected(url.pathname)) {
+      await next()
+      return
+    }
+
+    // User requirement: when key is not configured at all, allow all traffic.
+    const configuredKey = getConfiguredKey()
+    if (!configuredKey) {
+      await next()
+      return
+    }
+
+    const providedKey = extractRequestApiKey(c.req.raw.headers)
+
+    if (!providedKey || providedKey !== configuredKey) {
+      return c.json(
+        {
+          error: {
+            message:
+              "Unauthorized. Provide Authorization: Bearer <key> or x-api-key.",
+            type: "unauthorized",
+          },
+        },
+        401,
+      )
+    }
+
+    await next()
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ export interface AppConfig {
   extraPrompts?: Record<string, string>
   smallModel?: string
   freeModelLoadBalancing?: boolean
+  apiKey?: string
   modelReasoningEfforts?: Record<
     string,
     "none" | "minimal" | "low" | "medium" | "high" | "xhigh"

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 
+import { createApiKeyAuthMiddleware } from "./lib/api-key-auth"
 import { adminApiRoutes } from "./routes/admin-api/route"
 import { adminRoutes } from "./routes/admin/route"
 import { completionRoutes } from "./routes/chat-completions/route"
@@ -16,6 +17,7 @@ export const server = new Hono()
 
 server.use(logger())
 server.use(cors())
+server.use("*", createApiKeyAuthMiddleware())
 
 server.get("/", (c) => c.text("Server running"))
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,8 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 
-import { createApiKeyAuthMiddleware } from "./lib/api-key-auth"
+import { createApiKeyAuthMiddleware } from "~/lib/api-key-auth"
+
 import { adminApiRoutes } from "./routes/admin-api/route"
 import { adminRoutes } from "./routes/admin/route"
 import { completionRoutes } from "./routes/chat-completions/route"

--- a/tests/api-key-auth.test.ts
+++ b/tests/api-key-auth.test.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "bun:test"
+import { Hono } from "hono"
+
+import {
+  createApiKeyAuthMiddleware,
+  isProtectedPath,
+} from "../src/lib/api-key-auth"
+
+function createTestApp(getKey: () => string | undefined) {
+  const app = new Hono()
+
+  app.use(
+    "*",
+    createApiKeyAuthMiddleware({
+      getConfiguredApiKey: getKey,
+    }),
+  )
+
+  // Unprotected
+  app.get("/", (c) => c.text("ok"))
+
+  // Protected (per requirements)
+  app.get("/token", (c) => c.text("token"))
+
+  app.get("/usage", (c) => c.text("usage"))
+  app.get("/usage/:accountIndex", (c) => c.text("usage-item"))
+
+  app.get("/v1/models", (c) => c.text("v1-models"))
+  app.options("/v1/models", (c) => c.text("v1-models-preflight"))
+
+  app.post("/chat/completions", (c) => c.text("chat"))
+  app.post("/embeddings", (c) => c.text("embeddings"))
+  app.get("/models", (c) => c.text("models"))
+  app.post("/responses", (c) => c.text("responses"))
+
+  return app
+}
+
+test("isProtectedPath matches intended endpoints", () => {
+  expect(isProtectedPath("/v1/models")).toBe(true)
+  expect(isProtectedPath("/v1/models/")).toBe(true)
+  expect(isProtectedPath("/v1/messages")).toBe(true)
+
+  expect(isProtectedPath("/token")).toBe(true)
+  expect(isProtectedPath("/token/")).toBe(true)
+
+  expect(isProtectedPath("/usage")).toBe(true)
+  expect(isProtectedPath("/usage/0")).toBe(true)
+
+  expect(isProtectedPath("/chat/completions")).toBe(true)
+  expect(isProtectedPath("/embeddings")).toBe(true)
+  expect(isProtectedPath("/models")).toBe(true)
+  expect(isProtectedPath("/responses")).toBe(true)
+
+  expect(isProtectedPath("/")).toBe(false)
+  expect(isProtectedPath("/admin")).toBe(false)
+  expect(isProtectedPath("/api/admin/meta")).toBe(false)
+})
+
+test("allows protected routes when no key is configured", async () => {
+  const app = createTestApp(() => undefined)
+
+  const res = await app.fetch(new Request("http://local/v1/models"))
+  expect(res.status).toBe(200)
+})
+
+test("denies requests without key when configured", async () => {
+  const app = createTestApp(() => "k")
+
+  const res = await app.fetch(new Request("http://local/v1/models"))
+  expect(res.status).toBe(401)
+
+  const body = (await res.json()) as {
+    error: { message: string; type: string }
+  }
+
+  expect(body.error.type).toBe("unauthorized")
+  expect(typeof body.error.message).toBe("string")
+  expect(body.error.message.length).toBeGreaterThan(0)
+})
+
+test("accepts Authorization: Bearer <key>", async () => {
+  const app = createTestApp(() => "k")
+
+  const res = await app.fetch(
+    new Request("http://local/v1/models", {
+      headers: {
+        authorization: "Bearer k",
+      },
+    }),
+  )
+
+  expect(res.status).toBe(200)
+})
+
+test("accepts x-api-key: <key>", async () => {
+  const app = createTestApp(() => "k")
+
+  const res = await app.fetch(
+    new Request("http://local/v1/models", {
+      headers: {
+        "x-api-key": "k",
+      },
+    }),
+  )
+
+  expect(res.status).toBe(200)
+})
+
+test("does not protect non-listed routes", async () => {
+  const app = createTestApp(() => "k")
+
+  const res = await app.fetch(new Request("http://local/"))
+  expect(res.status).toBe(200)
+})
+
+test("bypasses auth for OPTIONS (CORS preflight)", async () => {
+  const app = createTestApp(() => "k")
+
+  const res = await app.fetch(
+    new Request("http://local/v1/models", {
+      method: "OPTIONS",
+    }),
+  )
+
+  expect(res.status).toBe(200)
+})
+
+test("server enforces API key on protected routes", async () => {
+  const envKey = process.env.COPILOT_API_KEY
+  process.env.COPILOT_API_KEY = "k"
+
+  try {
+    const { server } = await import("../src/server")
+
+    const resV1 = await server.fetch(new Request("http://local/v1/models"))
+    expect(resV1.status).toBe(401)
+
+    const resModels = await server.fetch(new Request("http://local/models"))
+    expect(resModels.status).toBe(401)
+
+    const body = (await resV1.json()) as {
+      error: { message: string; type: string }
+    }
+    expect(body.error.type).toBe("unauthorized")
+  } finally {
+    if (envKey === undefined) {
+      delete process.env.COPILOT_API_KEY
+    } else {
+      // eslint-disable-next-line require-atomic-updates
+      process.env.COPILOT_API_KEY = envKey
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- Add optional API key auth middleware (env `COPILOT_API_KEY` or `config.json` `apiKey`)
- Protect `/v1/*`, `/token`, `/usage(/usage/*)`, and non-`/v1` OpenAI-style endpoints (`/chat/completions`, `/models`, `/embeddings`, `/responses`)
- Document configuration and usage in README

## Test plan
- [x] bun test
- [x] bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  - 全局启用 API 密钥认证，可通过环境变量或配置文件配置，受保护端点需提供密钥；CORS 预检（OPTIONS）请求被跳过。
  - 支持 Bearer 令牌或 x-api-key 两种传递方式；当未配置密钥时系统为开放模式（允许访问）。

* **文档**
  - 更新 README，新增配置示例（包括 Docker/compose、管理界面与使用面板等）和使用说明。

* **测试**
  - 添加完整的认证行为测试覆盖。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->