### PR TITLE
feat: queue-based rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ node_modules/
 # aider
 .aider*
 
-# claude
-.claude/
-
 # eslint cache
 .eslintcache
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules/
 # aider
 .aider*
 
+# claude
+.claude/
+
 # eslint cache
 .eslintcache
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A reverse-engineered proxy for the GitHub Copilot API that exposes it as an Open
 - **Claude Code Integration**: Easily configure and launch [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) to use Copilot as its backend with a simple command-line flag (`--claude-code`).
 - **Usage Dashboard**: A web-based dashboard to monitor your Copilot API usage, view quotas, and see detailed statistics.
 - **Admin UI**: Modern admin console (`/admin`) to inspect account runtime status and request history, with rich filtering and a request-detail JSON viewer (search/copy/download). Includes theme (system/light/dark) and motion (magic/subtle/off) toggles.
-- **Rate Limit Control**: Manage API usage with rate-limiting options (`--rate-limit`) and a waiting mechanism (`--wait`) to prevent errors from rapid requests.
+- **Rate Limit Control**: Optional queue-based rate limiting (`--rate-limit`) that queues requests and processes them sequentially to avoid rate limit errors from rapid requests.
 - **Manual Request Approval**: Manually approve or deny each API request for fine-grained control over usage (`--manual`).
 - **Token Visibility**: Option to display GitHub and Copilot tokens during authentication and refresh for debugging (`--show-token`).
 - **Flexible Authentication**: Authenticate interactively or provide a GitHub token directly, suitable for CI/CD environments.
@@ -194,7 +194,7 @@ The following command line options are available for the `start` command:
 | --account-type | Account type to use (individual, business, enterprise)                        | individual | -a    |
 | --manual       | Enable manual request approval                                                | false      | none  |
 | --rate-limit   | Rate limit in seconds between requests                                        | none       | -r    |
-| --wait         | Wait instead of error when rate limit is hit                                  | false      | -w    |
+| --wait         | Deprecated (no-op): kept for backward compatibility (queue-based rate limiting always waits) | false      | -w    |
 | --github-token | Provide GitHub token directly (must be generated using the `auth` subcommand) | none       | -g    |
 | --claude-code  | Generate a command to launch Claude Code with Copilot API config              | false      | -c    |
 | --show-token   | Show GitHub and Copilot tokens on fetch and refresh                           | false      | none  |
@@ -364,11 +364,8 @@ npx copilot-api@latest start --account-type enterprise
 # Enable manual approval for each request
 npx copilot-api@latest start --manual
 
-# Set rate limit to 30 seconds between requests
+# Enable queue-based rate limiting (requests are queued and processed sequentially)
 npx copilot-api@latest start --rate-limit 30
-
-# Wait instead of error when rate limit is hit
-npx copilot-api@latest start --rate-limit 30 --wait
 
 # Provide GitHub token directly
 npx copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
@@ -567,8 +564,8 @@ bun run start
 
 - To avoid hitting GitHub Copilot's rate limits, you can use the following flags:
   - `--manual`: Enables manual approval for each request, giving you full control over when requests are sent.
-  - `--rate-limit <seconds>`: Enforces a minimum time interval between requests. For example, `copilot-api start --rate-limit 30` will ensure there's at least a 30-second gap between requests.
-  - `--wait`: Use this with `--rate-limit`. It makes the server wait for the cooldown period to end instead of rejecting the request with an error. This is useful for clients that don't automatically retry on rate limit errors.
+  - `--rate-limit <seconds>`: Enables queue-based rate limiting. Requests are queued and processed sequentially, with at least `<seconds>` between request starts.
+  - `--wait`: Deprecated (no-op). Kept for backward compatibility; when `--rate-limit` is set, requests are queued (no 429 rejection).
 - If you have a GitHub business or enterprise plan account with Copilot, use the `--account-type` flag (e.g., `--account-type business`). See the [official documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network#configuring-copilot-subscription-based-network-routing-for-your-enterprise-or-organization) for more details.
 - **Multi-account request routing**: Add multiple GitHub Copilot accounts using `auth add`.
   - **Premium models**: Accounts are tried in the order they were added. When an account's premium request quota (`remaining=0`) is exhausted (or insufficient for the selected model), the proxy automatically switches to the next eligible account.

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -72,14 +72,13 @@ export class RequestQueue {
         consola.debug(
           `Processing request (${this.queue.length} remaining in queue)`,
         )
+        this.lastProcessedTime = Date.now()
         const result = await item.execute()
         item.resolve(result)
       } catch (error) {
         consola.error("Error processing queued request:", error)
         item.reject(error)
       }
-
-      this.lastProcessedTime = Date.now()
     }
 
     this.processing = false

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,0 +1,101 @@
+import consola from "consola"
+
+interface QueueItem<T> {
+  execute: () => Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+  timestamp: number
+}
+
+export class RequestQueue {
+  private queue: Array<QueueItem<unknown>> = []
+  private processing = false
+  private rateLimitMs: number
+  private lastProcessedTime = 0
+
+  constructor(rateLimitSeconds?: number) {
+    this.rateLimitMs = rateLimitSeconds ? rateLimitSeconds * 1000 : 0
+  }
+
+  async enqueue<T>(execute: () => Promise<T>): Promise<T> {
+    // If no rate limit is set, execute immediately
+    if (this.rateLimitMs === 0) {
+      return execute()
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        execute: execute as () => Promise<unknown>,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timestamp: Date.now(),
+      })
+
+      consola.debug(`Request queued. Queue size: ${this.queue.length}`)
+
+      // Start processing if not already processing
+      if (!this.processing) {
+        void this.processQueue()
+      }
+    })
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing) return
+    this.processing = true
+
+    while (this.queue.length > 0) {
+      const now = Date.now()
+      const timeSinceLastRequest = now - this.lastProcessedTime
+
+      // Wait if we need to respect rate limit
+      if (
+        this.lastProcessedTime > 0
+        && timeSinceLastRequest < this.rateLimitMs
+      ) {
+        const waitTime = this.rateLimitMs - timeSinceLastRequest
+        consola.info(
+          `Rate limit: waiting ${Math.ceil(waitTime / 1000)}s before processing next request (${this.queue.length} in queue)`,
+        )
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
+      }
+
+      const item = this.queue.shift()
+      if (!item) break
+
+      const queueTime = Date.now() - item.timestamp
+      if (queueTime > 1000) {
+        consola.debug(`Request waited ${Math.ceil(queueTime / 1000)}s in queue`)
+      }
+
+      try {
+        consola.debug(
+          `Processing request (${this.queue.length} remaining in queue)`,
+        )
+        const result = await item.execute()
+        item.resolve(result)
+      } catch (error) {
+        consola.error("Error processing queued request:", error)
+        item.reject(error)
+      }
+
+      this.lastProcessedTime = Date.now()
+    }
+
+    this.processing = false
+    consola.debug("Queue processing completed")
+  }
+
+  getQueueSize(): number {
+    return this.queue.length
+  }
+
+  updateRateLimit(rateLimitSeconds?: number): void {
+    this.rateLimitMs = rateLimitSeconds ? rateLimitSeconds * 1000 : 0
+    consola.info(
+      rateLimitSeconds ?
+        `Rate limit updated to ${rateLimitSeconds}s`
+      : "Rate limit disabled",
+    )
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -5,6 +5,23 @@ import type { State } from "./state"
 import { HTTPError } from "./error"
 import { sleep } from "./utils"
 
+/**
+ * Execute a request with rate limiting using the request queue.
+ * Requests are automatically queued and processed at the configured rate limit.
+ * @param state - Application state containing the request queue
+ * @param execute - The async function to execute
+ * @returns The result of the executed function
+ */
+export async function executeWithRateLimit<T>(
+  state: State,
+  execute: () => Promise<T>,
+): Promise<T> {
+  return state.requestQueue.enqueue(execute)
+}
+
+/**
+ * @deprecated Use executeWithRateLimit instead for better queue-based rate limiting
+ */
 export async function checkRateLimit(state: State) {
   if (state.rateLimitSeconds === undefined) return
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -2,6 +2,8 @@ import type { ModelsResponse } from "~/services/copilot/get-models"
 
 import type { AccountContext, AccountType } from "./types/account"
 
+import { RequestQueue } from "./queue"
+
 export interface State {
   githubToken?: string
   copilotToken?: string
@@ -18,6 +20,7 @@ export interface State {
   rateLimitSeconds?: number
   lastRequestTimestamp?: number
   verbose: boolean
+  requestQueue: RequestQueue
 }
 
 export const state: State = {
@@ -26,6 +29,7 @@ export const state: State = {
   rateLimitWait: false,
   showToken: false,
   verbose: false,
+  requestQueue: new RequestQueue(),
 }
 
 /**

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -11,7 +11,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
-import { checkRateLimit } from "~/lib/rate-limit"
+import { executeWithRateLimit } from "~/lib/rate-limit"
 import {
   getClientIpInfo,
   getRequestHistoryStore,
@@ -33,8 +33,10 @@ const logger = createHandlerLogger("chat-completions-handler")
 const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
 
 export async function handleCompletion(c: Context) {
-  await checkRateLimit(state)
+  return executeWithRateLimit(state, () => handleCompletionImpl(c))
+}
 
+async function handleCompletionImpl(c: Context) {
   const store = getRequestHistoryStore()
   const request = buildRequestContext(c)
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -14,7 +14,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
-import { checkRateLimit } from "~/lib/rate-limit"
+import { executeWithRateLimit } from "~/lib/rate-limit"
 import {
   extractResponsesUsageFromResult,
   extractResponsesUsageFromStreamEvent,
@@ -93,8 +93,10 @@ type InstrumentationContext = {
 }
 
 export async function handleCompletion(c: Context) {
-  await checkRateLimit(state)
+  return executeWithRateLimit(state, () => handleCompletionImpl(c))
+}
 
+async function handleCompletionImpl(c: Context) {
   const store = getRequestHistoryStore()
 
   const requestId = randomUUID()

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -11,7 +11,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
-import { checkRateLimit } from "~/lib/rate-limit"
+import { executeWithRateLimit } from "~/lib/rate-limit"
 import {
   extractResponsesUsageFromResult,
   extractResponsesUsageFromStreamEvent,
@@ -33,9 +33,10 @@ const logger = createHandlerLogger("responses-handler")
 
 const RESPONSES_ENDPOINT = "/responses"
 
-export const handleResponses = async (c: Context) => {
-  await checkRateLimit(state)
+export const handleResponses = (c: Context) =>
+  executeWithRateLimit(state, () => handleResponsesImpl(c))
 
+const handleResponsesImpl = async (c: Context) => {
   const store = getRequestHistoryStore()
   const request = buildRequestContext(c)
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -239,7 +239,7 @@ export const start = defineCommand({
       type: "boolean",
       default: false,
       description:
-        "Wait instead of error when rate limit is hit. Has no effect if rate limit is not set",
+        "Deprecated (no-op): kept for backward compatibility; queue-based rate limiting always waits when enabled",
     },
     "github-token": {
       alias: "g",

--- a/src/start.ts
+++ b/src/start.ts
@@ -232,7 +232,6 @@ export const start = defineCommand({
     "rate-limit": {
       alias: "r",
       type: "string",
-      default: "3",
       description: "Rate limit in seconds between requests",
     },
     wait: {

--- a/src/start.ts
+++ b/src/start.ts
@@ -100,6 +100,9 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   state.rateLimitWait = options.rateLimitWait
   state.showToken = options.showToken
 
+  // Initialize request queue with rate limit
+  state.requestQueue.updateRateLimit(options.rateLimit)
+
   await ensurePaths()
   await cacheVSCodeVersion()
 
@@ -229,6 +232,7 @@ export const start = defineCommand({
     "rate-limit": {
       alias: "r",
       type: "string",
+      default: "3",
       description: "Rate limit in seconds between requests",
     },
     wait: {


### PR DESCRIPTION
## Summary
- Introduce a `RequestQueue`-based rate limiting mechanism via `executeWithRateLimit()`.
- Apply queue-based execution to `/chat/completions` and `/messages` handlers **while preserving** the `all` branch multi-account selection + request-history instrumentation.
- Wire the queue rate limit at startup (`state.requestQueue.updateRateLimit(options.rateLimit)`).

## Behavior
- When `--rate-limit` is set: requests are queued and processed sequentially at the configured interval (no 429 rejections).
- When `--rate-limit` is not set: the queue is effectively disabled (no waiting / no queuing).

## Test plan
- [x] `bun run typecheck`
- [x] pre-commit hook: `bun run lint --fix`
- [ ] Run server and sanity test both endpoints:
  - [ ] `POST /chat/completions`
  - [ ] `POST /messages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 实现了基于队列的速率限制系统，按顺序处理请求以避免错误
  * 支持多账户路由和自动切换功能

* **文档**
  * 更新了速率限制功能说明，标记 `--wait` 选项为已弃用
  * 补充了多账户场景下的使用指南和最佳实践

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->