### PR TITLE
✨ feat(rate-limit): add request queue with adaptive rate limiting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # AGENTS.md
 
+## Project Background
+
+This project is a fork of `ericc-ch/copilot-api`, created because the original repository appears to be unmaintained.
+
+- **Current Repository**: [nick3/copilot-api](https://github.com/nick3/copilot-api)
+- **Workflow**:
+  - All pushes and Pull Requests should be directed to `nick3/copilot-api`.
+  - The default active branch is `all` (not `master` or `main`).
+  - All Pull Requests should target the `all` branch.
+
 ## Build, Lint, and Test Commands
 
 - **Build:**  

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A reverse-engineered proxy for the GitHub Copilot API that exposes it as an Open
 - **Claude Code Integration**: Easily configure and launch [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) to use Copilot as its backend with a simple command-line flag (`--claude-code`).
 - **Usage Dashboard**: A web-based dashboard to monitor your Copilot API usage, view quotas, and see detailed statistics.
 - **Admin UI**: Modern admin console (`/admin`) to inspect account runtime status and request history, with rich filtering and a request-detail JSON viewer (search/copy/download). Includes theme (system/light/dark) and motion (magic/subtle/off) toggles.
-- **Rate Limit Control**: Manage API usage with rate-limiting options (`--rate-limit`) and a waiting mechanism (`--wait`) to prevent errors from rapid requests.
+- **Rate Limit Control**: Manage API usage with rate-limiting options (`--rate-limit`). When enabled, requests are automatically queued and rate-limit headers (`X-RateLimit-*`) are included in responses. The proxy also learns from upstream 429 responses to adaptively adjust intervals.
 - **Manual Request Approval**: Manually approve or deny each API request for fine-grained control over usage (`--manual`).
 - **Token Visibility**: Option to display GitHub and Copilot tokens during authentication and refresh for debugging (`--show-token`).
 - **Flexible Authentication**: Authenticate interactively or provide a GitHub token directly, suitable for CI/CD environments.
@@ -193,8 +193,8 @@ The following command line options are available for the `start` command:
 | --verbose      | Enable verbose logging                                                        | false      | -v    |
 | --account-type | Account type to use (individual, business, enterprise)                        | individual | -a    |
 | --manual       | Enable manual request approval                                                | false      | none  |
-| --rate-limit   | Rate limit in seconds between requests                                        | none       | -r    |
-| --wait         | Wait instead of error when rate limit is hit                                  | false      | -w    |
+| --rate-limit   | Rate limit in seconds between requests (requests are queued automatically)    | none       | -r    |
+| --wait         | **DEPRECATED**: No longer needed. Requests are always queued when rate limiting is enabled | false      | -w    |
 | --github-token | Provide GitHub token directly (must be generated using the `auth` subcommand) | none       | -g    |
 | --claude-code  | Generate a command to launch Claude Code with Copilot API config              | false      | -c    |
 | --show-token   | Show GitHub and Copilot tokens on fetch and refresh                           | false      | none  |
@@ -364,11 +364,8 @@ npx copilot-api@latest start --account-type enterprise
 # Enable manual approval for each request
 npx copilot-api@latest start --manual
 
-# Set rate limit to 30 seconds between requests
+# Set rate limit to 30 seconds between requests (requests are queued automatically)
 npx copilot-api@latest start --rate-limit 30
-
-# Wait instead of error when rate limit is hit
-npx copilot-api@latest start --rate-limit 30 --wait
 
 # Provide GitHub token directly
 npx copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
@@ -567,8 +564,7 @@ bun run start
 
 - To avoid hitting GitHub Copilot's rate limits, you can use the following flags:
   - `--manual`: Enables manual approval for each request, giving you full control over when requests are sent.
-  - `--rate-limit <seconds>`: Enforces a minimum time interval between requests. For example, `copilot-api start --rate-limit 30` will ensure there's at least a 30-second gap between requests.
-  - `--wait`: Use this with `--rate-limit`. It makes the server wait for the cooldown period to end instead of rejecting the request with an error. This is useful for clients that don't automatically retry on rate limit errors.
+  - `--rate-limit <seconds>`: Enforces a minimum time interval between requests. For example, `copilot-api start --rate-limit 30` will ensure there's at least a 30-second gap between requests. When enabled, requests are automatically queued (no need for `--wait`), and the proxy includes `X-RateLimit-*` headers in responses. The proxy also learns from upstream 429 responses to adaptively adjust intervals.
 - If you have a GitHub business or enterprise plan account with Copilot, use the `--account-type` flag (e.g., `--account-type business`). See the [official documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network#configuring-copilot-subscription-based-network-routing-for-your-enterprise-or-organization) for more details.
 - **Multi-account request routing**: Add multiple GitHub Copilot accounts using `auth add`.
   - **Premium models**: Accounts are tried in the order they were added. When an account's premium request quota (`remaining=0`) is exhausted (or insufficient for the selected model), the proxy automatically switches to the next eligible account.

--- a/src/lib/accounts-manager-auth.ts
+++ b/src/lib/accounts-manager-auth.ts
@@ -37,6 +37,7 @@ export const toAccountContextFromSnapshot = (
   snapshot: AuthSnapshot,
   copilotToken?: string,
 ): AccountContext => ({
+  id: account.id,
   githubToken: snapshot.githubToken,
   copilotToken,
   accountType: snapshot.accountType,

--- a/src/lib/copilot-rate-limiter.ts
+++ b/src/lib/copilot-rate-limiter.ts
@@ -1,0 +1,158 @@
+import consola from "consola"
+
+import { state } from "./state"
+import { sleep as defaultSleep } from "./utils"
+
+export type CopilotRateLimiterSnapshot = {
+  enabled: boolean
+  /** Effective interval (configured vs learned). Undefined when disabled. */
+  effectiveSeconds?: number
+  /** Number of callers currently waiting for a permit. */
+  queueDepth: number
+  /** Earliest unix ms timestamp when the next permit can be granted. */
+  nextAllowedAtMs: number
+}
+
+type Deps = {
+  nowMs?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
+export class CopilotRateLimiter {
+  readonly accountId: string
+
+  private queueDepth = 0
+  private nextAllowedAtMs = 0
+  private learnedIntervalSeconds = 0
+  private cooldownUntilMs = 0
+
+  private mutex: Promise<void> = Promise.resolve()
+
+  private readonly nowMs: () => number
+  private readonly sleep: (ms: number) => Promise<void>
+
+  constructor(accountId: string, deps: Deps = {}) {
+    this.accountId = accountId
+    this.nowMs = deps.nowMs ?? Date.now
+    this.sleep = deps.sleep ?? defaultSleep
+  }
+
+  snapshot(): CopilotRateLimiterSnapshot {
+    const configuredSeconds = state.rateLimitSeconds
+    if (configuredSeconds === undefined) {
+      return {
+        enabled: false,
+        queueDepth: 0,
+        nextAllowedAtMs: 0,
+      }
+    }
+
+    const effectiveSeconds = Math.max(
+      configuredSeconds,
+      this.learnedIntervalSeconds,
+    )
+    const nextAllowedAtMs = Math.max(this.nextAllowedAtMs, this.cooldownUntilMs)
+
+    return {
+      enabled: true,
+      effectiveSeconds,
+      queueDepth: this.queueDepth,
+      nextAllowedAtMs,
+    }
+  }
+
+  /**
+   * Wait for a permit to start a Copilot upstream request.
+   *
+   * NOTE: This limits request *start rate* only; it does not serialize the full
+   * upstream request lifecycle (important for streaming endpoints).
+   */
+  async acquire(): Promise<void> {
+    const configuredSeconds = state.rateLimitSeconds
+    if (configuredSeconds === undefined) return
+
+    this.queueDepth += 1
+
+    if (this.queueDepth > 100) {
+      consola.warn(
+        `[rate-limit] High queue depth for account ${this.accountId}: ${this.queueDepth}`,
+      )
+    }
+
+    let release!: () => void
+
+    const previous = this.mutex
+    this.mutex = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    try {
+      await previous
+
+      while (true) {
+        const now = this.nowMs()
+        const effectiveSeconds = Math.max(
+          configuredSeconds,
+          this.learnedIntervalSeconds,
+        )
+
+        const gateMs = Math.max(this.nextAllowedAtMs, this.cooldownUntilMs)
+
+        if (now >= gateMs) {
+          // Reserve the next slot based on *actual* permit time.
+          this.nextAllowedAtMs = now + effectiveSeconds * 1000
+          return
+        }
+
+        await this.sleep(gateMs - now)
+        // Loop to re-check in case cooldown/interval changed while sleeping.
+      }
+    } finally {
+      release()
+      this.queueDepth -= 1
+    }
+  }
+
+  /**
+   * Record an upstream 429 and adjust this account's limiter.
+   */
+  noteRateLimitHit(
+    baseRetryAfterSeconds: number,
+    jitteredWaitMs: number,
+  ): void {
+    if (state.rateLimitSeconds === undefined) return
+
+    this.learnedIntervalSeconds = Math.max(
+      this.learnedIntervalSeconds,
+      baseRetryAfterSeconds,
+    )
+
+    const now = this.nowMs()
+    this.cooldownUntilMs = Math.max(this.cooldownUntilMs, now + jitteredWaitMs)
+  }
+
+  /** @internal For tests */
+  resetForTest(): void {
+    this.queueDepth = 0
+    this.nextAllowedAtMs = 0
+    this.learnedIntervalSeconds = 0
+    this.cooldownUntilMs = 0
+    this.mutex = Promise.resolve()
+  }
+}
+
+const limiters = new Map<string, CopilotRateLimiter>()
+
+export function getCopilotRateLimiter(accountId: string): CopilotRateLimiter {
+  const existing = limiters.get(accountId)
+  if (existing) return existing
+
+  const limiter = new CopilotRateLimiter(accountId)
+  limiters.set(accountId, limiter)
+  return limiter
+}
+
+/** @internal For tests */
+export function resetCopilotRateLimitersForTest(): void {
+  limiters.clear()
+}

--- a/src/lib/handler-utils.ts
+++ b/src/lib/handler-utils.ts
@@ -25,6 +25,7 @@ export function computeDiff(
 
 export function toAccountContext(account: AccountRuntime): AccountContext {
   return {
+    id: account.id,
     githubToken: account.githubToken,
     copilotToken: account.copilotToken,
     accountType: account.accountType,

--- a/src/lib/rate-limit-headers.ts
+++ b/src/lib/rate-limit-headers.ts
@@ -1,0 +1,66 @@
+import type { Context, MiddlewareHandler } from "hono"
+
+import { getCopilotRateLimiter } from "./copilot-rate-limiter"
+import { state } from "./state"
+
+type ApplyOptions = {
+  accountId?: string
+}
+
+function clampLimitPerMinute(limit: number): number {
+  // Avoid confusing clients with 0 req/min when interval > 60s.
+  return Math.max(1, limit)
+}
+
+export function applyRateLimitHeaders(
+  c: Context,
+  options: ApplyOptions = {},
+): void {
+  const configuredSeconds = state.rateLimitSeconds
+
+  // Unlimited mode
+  if (configuredSeconds === undefined) {
+    c.header("X-RateLimit-Limit", "unlimited")
+    c.header("X-RateLimit-Remaining", "unlimited")
+    c.header("X-RateLimit-Reset", "unlimited")
+    c.header("X-Queue-Depth", "0")
+    return
+  }
+
+  const accountId = options.accountId?.trim()
+
+  // Best-effort fallback when we don't know which Copilot account will be used.
+  if (!accountId) {
+    const limit = clampLimitPerMinute(Math.floor(60 / configuredSeconds))
+    const reset = Math.floor((Date.now() + configuredSeconds * 1000) / 1000)
+
+    c.header("X-RateLimit-Limit", String(limit))
+    c.header("X-RateLimit-Remaining", String(limit))
+    c.header("X-RateLimit-Reset", String(reset))
+    c.header("X-Queue-Depth", "0")
+    return
+  }
+
+  const snapshot = getCopilotRateLimiter(accountId).snapshot()
+  const effectiveSeconds = snapshot.effectiveSeconds ?? configuredSeconds
+
+  const limit = clampLimitPerMinute(Math.floor(60 / effectiveSeconds))
+  const remaining = Math.max(0, limit - snapshot.queueDepth)
+  const reset = Math.floor(snapshot.nextAllowedAtMs / 1000)
+
+  c.header("X-RateLimit-Limit", String(limit))
+  c.header("X-RateLimit-Remaining", String(remaining))
+  c.header("X-RateLimit-Reset", String(reset))
+  c.header("X-Queue-Depth", String(snapshot.queueDepth))
+
+  if (snapshot.queueDepth > 50) {
+    c.header("Retry-After", String(effectiveSeconds))
+  }
+}
+
+export function rateLimitHeadersMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    applyRateLimitHeaders(c)
+    await next()
+  }
+}

--- a/src/lib/resilient-copilot-fetch.ts
+++ b/src/lib/resilient-copilot-fetch.ts
@@ -1,0 +1,542 @@
+import consola from "consola"
+import { events } from "fetch-event-stream"
+
+import { getCopilotRateLimiter } from "./copilot-rate-limiter"
+import { HTTPError } from "./error"
+import { state } from "./state"
+import { sleep as defaultSleep } from "./utils"
+
+const DEFAULT_MAX_RETRIES = 5
+const DEFAULT_TIMEOUT_MS = 60_000
+const DEFAULT_FIRST_EVENT_TIMEOUT_MS = 60_000
+
+type RetryableStatus = 429 | 500 | 502 | 503 | 504
+
+type SleepFn = (ms: number) => Promise<void>
+
+type BaseOptions = {
+  accountId: string
+  operation: string
+  url: string
+  init: RequestInit
+  maxRetries?: number
+  /** @internal For tests */
+  sleep?: SleepFn
+}
+
+type JsonOptions = BaseOptions & {
+  timeoutMs?: number
+  failureMessage: string
+}
+
+type StreamOptions = BaseOptions & {
+  connectTimeoutMs?: number
+  firstEventTimeoutMs?: number
+  failureMessage: string
+}
+
+export function addJitter(ms: number, ratio: number = 0.2): number {
+  if (ms <= 0) return 0
+  const span = ms * ratio
+  const r = (Math.random() * 2 - 1) * span
+  return Math.max(0, Math.round(ms + r))
+}
+
+export function parseRetryAfterToMs(
+  value: string | null,
+  nowMs: number,
+): number | undefined {
+  if (!value) return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  // delta-seconds
+  const asInt = Number.parseInt(trimmed, 10)
+  if (Number.isFinite(asInt) && String(asInt) === trimmed) {
+    return Math.max(0, asInt * 1000)
+  }
+
+  // HTTP-date
+  const parsed = Date.parse(trimmed)
+  if (Number.isNaN(parsed)) return undefined
+  return Math.max(0, parsed - nowMs)
+}
+
+function getRetryAfterBaseMs(response: Response, nowMs: number): number {
+  const retryAfter = response.headers.get("retry-after")
+  const parsed = parseRetryAfterToMs(retryAfter, nowMs)
+  if (parsed !== undefined) return parsed
+
+  // GitHub-specific header sometimes exposed through Copilot.
+  const ghUserRetryAfter = response.headers.get("x-ratelimit-user-retry-after")
+  const ghParsed = parseRetryAfterToMs(ghUserRetryAfter, nowMs)
+  if (ghParsed !== undefined) return ghParsed
+
+  // Fallback: be conservative.
+  return 60_000
+}
+
+function isRetryableStatus(status: number): status is RetryableStatus {
+  return (
+    status === 429
+    || status === 500
+    || status === 502
+    || status === 503
+    || status === 504
+  )
+}
+
+function getExponentialBackoffMs(retryAttempt: number): number {
+  // retryAttempt: 1..maxRetries => 1s,2s,4s,8s,16s
+  const seconds = Math.min(16, 2 ** (retryAttempt - 1))
+  return seconds * 1000
+}
+
+async function waitForRateLimitRetry(params: {
+  limiter: ReturnType<typeof getCopilotRateLimiter>
+  response: Response
+  accountId: string
+  operation: string
+  retryAttempt: number
+  maxRetries: number
+  sleep: SleepFn
+}): Promise<void> {
+  const {
+    limiter,
+    response,
+    accountId,
+    operation,
+    retryAttempt,
+    maxRetries,
+    sleep,
+  } = params
+
+  const nowMs = Date.now()
+  const baseMs = getRetryAfterBaseMs(response, nowMs)
+  const waitMs = addJitter(baseMs)
+  const baseSeconds = Math.max(1, Math.ceil(baseMs / 1000))
+
+  consola.warn(
+    `[retry] Rate limit hit for ${operation} (account=${accountId}) (attempt ${retryAttempt + 1}/${maxRetries}). Waiting ${Math.round(waitMs / 100) / 10}s before retry...`,
+  )
+
+  if (state.rateLimitSeconds !== undefined) {
+    limiter.noteRateLimitHit(baseSeconds, waitMs)
+    return
+  }
+
+  await sleep(waitMs)
+}
+
+async function waitForRetryableHttpStatus(params: {
+  status: number
+  accountId: string
+  operation: string
+  retryAttempt: number
+  maxRetries: number
+  sleep: SleepFn
+}): Promise<void> {
+  const { status, accountId, operation, retryAttempt, maxRetries, sleep } =
+    params
+
+  const backoffMs = addJitter(getExponentialBackoffMs(retryAttempt + 1))
+
+  consola.warn(
+    `[retry] Transient HTTP ${status} for ${operation} (account=${accountId}) (attempt ${retryAttempt + 1}/${maxRetries}). Waiting ${Math.round(backoffMs / 100) / 10}s before retry...`,
+  )
+
+  await sleep(backoffMs)
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ?
+      `${error.name}: ${error.message}`
+    : String(error)
+}
+
+async function waitForRetryableError(params: {
+  operation: string
+  accountId: string
+  retryAttempt: number
+  maxRetries: number
+  error: unknown
+  stream: boolean
+  sleep: SleepFn
+}): Promise<void> {
+  const {
+    operation,
+    accountId,
+    retryAttempt,
+    maxRetries,
+    error,
+    stream,
+    sleep,
+  } = params
+
+  const backoffMs = addJitter(getExponentialBackoffMs(retryAttempt + 1))
+  const details = describeError(error)
+
+  consola.warn(
+    `[retry] Transient${stream ? " stream" : ""} error for ${operation} (account=${accountId}) (attempt ${retryAttempt + 1}/${maxRetries}): ${details}. Waiting ${Math.round(backoffMs / 100) / 10}s before retry...`,
+  )
+
+  await sleep(backoffMs)
+}
+
+async function prefetchFirstEvent<T>(params: {
+  iterator: AsyncIterator<T>
+  controller: AbortController
+  firstEventTimeoutMs: number
+}): Promise<IteratorResult<T>> {
+  const { iterator, controller, firstEventTimeoutMs } = params
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race<IteratorResult<T>>([
+      iterator.next(),
+      new Promise<IteratorResult<T>>((_, reject) => {
+        timer = setTimeout(() => {
+          controller.abort()
+          reject(
+            new Error(
+              `Stream first event timeout after ${firstEventTimeoutMs}ms`,
+            ),
+          )
+        }, firstEventTimeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (typeof DOMException !== "undefined"
+      && error instanceof DOMException
+      && error.name === "AbortError")
+    || (error instanceof Error && error.name === "AbortError")
+  )
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const maybe = error as { code?: unknown }
+  return typeof maybe.code === "string" ? maybe.code : undefined
+}
+
+function isRetryableNetworkError(error: unknown): boolean {
+  const code = getErrorCode(error)
+  if (!code) return false
+  return (
+    code === "ECONNRESET"
+    || code === "ETIMEDOUT"
+    || code === "ECONNREFUSED"
+    || code === "EAI_AGAIN"
+    || code === "ENOTFOUND"
+    || code === "EPIPE"
+  )
+}
+
+function shouldRetryError(error: unknown): boolean {
+  if (isAbortError(error)) return true
+  if (isRetryableNetworkError(error)) return true
+
+  if (error instanceof Error) {
+    if (error.message.startsWith("Stream first event timeout")) return true
+    if (error.message === "Upstream stream ended before first event")
+      return true
+  }
+
+  // Bun often throws TypeError("fetch failed") on network issues.
+  if (error instanceof TypeError) return true
+
+  return false
+}
+
+function responseToHttpError(message: string, response: Response): HTTPError {
+  return new HTTPError(message, response)
+}
+
+function makeGatewayErrorResponse(
+  status: 502 | 504,
+  message: string,
+): Response {
+  return Response.json({ message }, { status })
+}
+
+function wrapFinalNonHttpError(
+  failureMessage: string,
+  error: unknown,
+): HTTPError {
+  const details =
+    error instanceof Error ?
+      `${error.name}: ${error.message}`
+    : `Unknown error: ${String(error)}`
+
+  const status: 502 | 504 = isAbortError(error) ? 504 : 502
+
+  return new HTTPError(
+    failureMessage,
+    makeGatewayErrorResponse(status, `${failureMessage}. ${details}`),
+  )
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<{
+  response: Response
+  controller: AbortController
+  clear: () => void
+}> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    })
+
+    return {
+      response,
+      controller,
+      clear: () => clearTimeout(timeout),
+    }
+  } catch (error) {
+    clearTimeout(timeout)
+    throw error
+  }
+}
+
+export async function copilotFetchJsonWithRetry<T>(
+  options: JsonOptions,
+): Promise<T> {
+  const {
+    accountId,
+    operation,
+    url,
+    init,
+    failureMessage,
+    maxRetries = DEFAULT_MAX_RETRIES,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    sleep: sleepOverride,
+  } = options
+
+  const sleepFn = sleepOverride ?? defaultSleep
+
+  const limiter = getCopilotRateLimiter(accountId)
+
+  let lastNonHttpError: unknown = undefined
+
+  for (let retryAttempt = 0; retryAttempt <= maxRetries; retryAttempt += 1) {
+    try {
+      await limiter.acquire()
+
+      const { response, clear } = await fetchWithTimeout(url, init, timeoutMs)
+      try {
+        if (response.ok) {
+          return (await response.json()) as T
+        }
+
+        if (!isRetryableStatus(response.status)) {
+          throw responseToHttpError(failureMessage, response)
+        }
+
+        if (retryAttempt === maxRetries) {
+          throw responseToHttpError(failureMessage, response)
+        }
+
+        if (response.status === 429) {
+          await waitForRateLimitRetry({
+            limiter,
+            response,
+            accountId,
+            operation,
+            retryAttempt,
+            maxRetries,
+            sleep: sleepFn,
+          })
+
+          continue
+        }
+
+        await waitForRetryableHttpStatus({
+          status: response.status,
+          accountId,
+          operation,
+          retryAttempt,
+          maxRetries,
+          sleep: sleepFn,
+        })
+        continue
+      } finally {
+        clear()
+      }
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        throw error
+      }
+
+      lastNonHttpError = error
+
+      if (!shouldRetryError(error)) {
+        throw wrapFinalNonHttpError(failureMessage, error)
+      }
+
+      if (retryAttempt === maxRetries) {
+        throw wrapFinalNonHttpError(failureMessage, error)
+      }
+
+      await waitForRetryableError({
+        operation,
+        accountId,
+        retryAttempt,
+        maxRetries,
+        error,
+        stream: false,
+        sleep: sleepFn,
+      })
+    }
+  }
+
+  throw wrapFinalNonHttpError(
+    failureMessage,
+    lastNonHttpError ?? new Error("Retry loop ended unexpectedly"),
+  )
+}
+
+async function* asyncIterableFromIterator<T>(
+  iterator: AsyncIterator<T>,
+): AsyncIterable<T> {
+  while (true) {
+    const next = await iterator.next()
+    if (next.done) return
+    yield next.value
+  }
+}
+
+export async function copilotFetchEventsWithRetry(
+  options: StreamOptions,
+): Promise<AsyncIterable<unknown>> {
+  const {
+    accountId,
+    operation,
+    url,
+    init,
+    failureMessage,
+    maxRetries = DEFAULT_MAX_RETRIES,
+    connectTimeoutMs = DEFAULT_TIMEOUT_MS,
+    firstEventTimeoutMs = DEFAULT_FIRST_EVENT_TIMEOUT_MS,
+    sleep: sleepOverride,
+  } = options
+
+  const sleepFn = sleepOverride ?? defaultSleep
+
+  const limiter = getCopilotRateLimiter(accountId)
+
+  let lastNonHttpError: unknown = undefined
+
+  for (let retryAttempt = 0; retryAttempt <= maxRetries; retryAttempt += 1) {
+    try {
+      await limiter.acquire()
+
+      const { response, controller, clear } = await fetchWithTimeout(
+        url,
+        init,
+        connectTimeoutMs,
+      )
+
+      clear()
+
+      if (!response.ok) {
+        if (!isRetryableStatus(response.status)) {
+          throw responseToHttpError(failureMessage, response)
+        }
+
+        if (retryAttempt === maxRetries) {
+          throw responseToHttpError(failureMessage, response)
+        }
+
+        if (response.status === 429) {
+          await waitForRateLimitRetry({
+            limiter,
+            response,
+            accountId,
+            operation,
+            retryAttempt,
+            maxRetries,
+            sleep: sleepFn,
+          })
+
+          continue
+        }
+
+        await waitForRetryableHttpStatus({
+          status: response.status,
+          accountId,
+          operation,
+          retryAttempt,
+          maxRetries,
+          sleep: sleepFn,
+        })
+        continue
+      }
+
+      const iterable = events(response)
+      const iterator = (iterable as AsyncIterable<unknown>)[
+        Symbol.asyncIterator
+      ]()
+
+      const first = await prefetchFirstEvent({
+        iterator,
+        controller,
+        firstEventTimeoutMs,
+      })
+
+      if (first.done) {
+        throw new Error("Upstream stream ended before first event")
+      }
+
+      return (async function* () {
+        yield first.value
+        yield* asyncIterableFromIterator(iterator)
+      })()
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        throw error
+      }
+
+      lastNonHttpError = error
+
+      if (!shouldRetryError(error)) {
+        throw wrapFinalNonHttpError(failureMessage, error)
+      }
+
+      if (retryAttempt === maxRetries) {
+        throw wrapFinalNonHttpError(failureMessage, error)
+      }
+
+      await waitForRetryableError({
+        operation,
+        accountId,
+        retryAttempt,
+        maxRetries,
+        error,
+        stream: true,
+        sleep: sleepFn,
+      })
+    }
+  }
+
+  throw wrapFinalNonHttpError(
+    failureMessage,
+    lastNonHttpError ?? new Error("Retry loop ended unexpectedly"),
+  )
+}

--- a/src/lib/resilient-copilot-fetch.ts
+++ b/src/lib/resilient-copilot-fetch.ts
@@ -118,7 +118,7 @@ async function waitForRateLimitRetry(params: {
   const baseSeconds = Math.max(1, Math.ceil(baseMs / 1000))
 
   consola.warn(
-    `[retry] Rate limit hit for ${operation} (account=${accountId}) (attempt ${retryAttempt + 1}/${maxRetries}). Waiting ${Math.round(waitMs / 100) / 10}s before retry...`,
+    `[retry] Rate limit hit for ${operation} (account=${accountId}) (retry ${retryAttempt + 1} of ${maxRetries}). Waiting ${Math.round(waitMs / 100) / 10}s before retry...`,
   )
 
   if (state.rateLimitSeconds !== undefined) {
@@ -143,7 +143,7 @@ async function waitForRetryableHttpStatus(params: {
   const backoffMs = addJitter(getExponentialBackoffMs(retryAttempt + 1))
 
   consola.warn(
-    `[retry] Transient HTTP ${status} for ${operation} (account=${accountId}) (attempt ${retryAttempt + 1}/${maxRetries}). Waiting ${Math.round(backoffMs / 100) / 10}s before retry...`,
+    `[retry] Transient HTTP ${status} for ${operation} (account=${accountId}) (retry ${retryAttempt + 1} of ${maxRetries}). Waiting ${Math.round(backoffMs / 100) / 10}s before retry...`,
   )
 
   await sleep(backoffMs)
@@ -178,7 +178,7 @@ async function waitForRetryableError(params: {
   const details = describeError(error)
 
   consola.warn(
-    `[retry] Transient${stream ? " stream" : ""} error for ${operation} (account=${accountId}) (attempt ${retryAttempt + 1}/${maxRetries}): ${details}. Waiting ${Math.round(backoffMs / 100) / 10}s before retry...`,
+    `[retry] Transient${stream ? " stream" : ""} error for ${operation} (account=${accountId}) (retry ${retryAttempt + 1} of ${maxRetries}): ${details}. Waiting ${Math.round(backoffMs / 100) / 10}s before retry...`,
   )
 
   await sleep(backoffMs)

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -90,6 +90,8 @@ export interface AccountRuntime extends AccountMeta {
  * This is a subset of AccountRuntime used by service functions.
  */
 export interface AccountContext {
+  /** GitHub login (username). Optional for legacy single-account state context. */
+  id?: string
   /** GitHub personal access token */
   githubToken: string
   /** Copilot API token */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ import { getVSCodeVersion } from "~/services/get-vscode-version"
 
 import { state } from "./state"
 
-export const sleep = (ms: number) =>
+export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms)
   })

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -11,7 +11,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
-import { checkRateLimit } from "~/lib/rate-limit"
+import { applyRateLimitHeaders } from "~/lib/rate-limit-headers"
 import {
   getClientIpInfo,
   getRequestHistoryStore,
@@ -33,8 +33,6 @@ const logger = createHandlerLogger("chat-completions-handler")
 const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
 
 export async function handleCompletion(c: Context) {
-  await checkRateLimit(state)
-
   const store = getRequestHistoryStore()
   const request = buildRequestContext(c)
 
@@ -65,6 +63,8 @@ export async function handleCompletion(c: Context) {
   }
 
   const { account, selectedModel } = selection
+
+  applyRateLimitHeaders(c, { accountId: account.id })
 
   const premiumRemainingBefore = account.premiumRemaining
   const premiumUnlimitedBefore = account.unlimited

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -8,6 +8,7 @@ import {
   extractErrorDetails,
   toAccountContext,
 } from "~/lib/handler-utils"
+import { applyRateLimitHeaders } from "~/lib/rate-limit-headers"
 import {
   getClientIpInfo,
   getRequestHistoryStore,
@@ -83,6 +84,8 @@ embeddingRoutes.post("/", async (c) => {
       })
       return selectionFailureResponse(c, payload.model, selection.reason)
     }
+
+    applyRateLimitHeaders(c, { accountId: selection.account.id })
 
     return await runEmbeddingsWithAccount({
       c,

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -14,7 +14,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
-import { checkRateLimit } from "~/lib/rate-limit"
+import { applyRateLimitHeaders } from "~/lib/rate-limit-headers"
 import {
   extractResponsesUsageFromResult,
   extractResponsesUsageFromStreamEvent,
@@ -93,8 +93,6 @@ type InstrumentationContext = {
 }
 
 export async function handleCompletion(c: Context) {
-  await checkRateLimit(state)
-
   const store = getRequestHistoryStore()
 
   const requestId = randomUUID()
@@ -175,6 +173,8 @@ export async function handleCompletion(c: Context) {
   }
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
+
+  applyRateLimitHeaders(c, { accountId: account.id })
 
   const premiumRemainingBefore = account.premiumRemaining
   const premiumUnlimitedBefore = account.unlimited

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -11,7 +11,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger } from "~/lib/logger"
-import { checkRateLimit } from "~/lib/rate-limit"
+import { applyRateLimitHeaders } from "~/lib/rate-limit-headers"
 import {
   extractResponsesUsageFromResult,
   extractResponsesUsageFromStreamEvent,
@@ -34,8 +34,6 @@ const logger = createHandlerLogger("responses-handler")
 const RESPONSES_ENDPOINT = "/responses"
 
 export const handleResponses = async (c: Context) => {
-  await checkRateLimit(state)
-
   const store = getRequestHistoryStore()
   const request = buildRequestContext(c)
 
@@ -65,6 +63,8 @@ export const handleResponses = async (c: Context) => {
   }
 
   const { account } = selection
+
+  applyRateLimitHeaders(c, { accountId: account.id })
 
   const premiumRemainingBefore = account.premiumRemaining
   const premiumUnlimitedBefore = account.unlimited

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 
 import { createApiKeyAuthMiddleware } from "~/lib/api-key-auth"
+import { rateLimitHeadersMiddleware } from "~/lib/rate-limit-headers"
 
 import { adminApiRoutes } from "./routes/admin-api/route"
 import { adminRoutes } from "./routes/admin/route"
@@ -18,6 +19,7 @@ export const server = new Hono()
 
 server.use(logger())
 server.use(cors())
+server.use("*", rateLimitHeadersMiddleware())
 server.use("*", createApiKeyAuthMiddleware())
 
 server.get("/", (c) => c.text("Server running"))

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -1,11 +1,11 @@
-import consola from "consola"
-import { events } from "fetch-event-stream"
-
 import type { AccountContext } from "~/lib/types/account"
 
-import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
+import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
 import { getReasoningEffortForModel } from "~/lib/config"
-import { HTTPError } from "~/lib/error"
+import {
+  copilotFetchEventsWithRetry,
+  copilotFetchJsonWithRetry,
+} from "~/lib/resilient-copilot-fetch"
 import { accountFromState } from "~/lib/state"
 
 function isGpt5MiniFamily(modelId: string): boolean {
@@ -37,6 +37,8 @@ export const createChatCompletions = async (
   const ctx = account ?? accountFromState()
   if (!ctx.copilotToken) throw new Error("Copilot token not found")
 
+  const accountId = ctx.id ?? "unknown"
+
   const enableVision = payload.messages.some(
     (x) =>
       typeof x.content !== "string"
@@ -57,22 +59,30 @@ export const createChatCompletions = async (
 
   const upstreamPayload = applyDefaultReasoningEffort(payload)
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/chat/completions`, {
+  const url = `${copilotBaseUrl(ctx)}/chat/completions`
+  const init: RequestInit = {
     method: "POST",
     headers,
     body: JSON.stringify(upstreamPayload),
-  })
-
-  if (!response.ok) {
-    consola.error("Failed to create chat completions", response)
-    throw new HTTPError("Failed to create chat completions", response)
   }
 
   if (payload.stream) {
-    return events(response)
+    return copilotFetchEventsWithRetry({
+      accountId,
+      operation: "POST /chat/completions",
+      url,
+      init,
+      failureMessage: "Failed to create chat completions",
+    })
   }
 
-  return (await response.json()) as ChatCompletionResponse
+  return copilotFetchJsonWithRetry<ChatCompletionResponse>({
+    accountId,
+    operation: "POST /chat/completions",
+    url,
+    init,
+    failureMessage: "Failed to create chat completions",
+  })
 }
 
 // Streaming types

--- a/src/services/copilot/create-embeddings.ts
+++ b/src/services/copilot/create-embeddings.ts
@@ -1,7 +1,7 @@
 import type { AccountContext } from "~/lib/types/account"
 
-import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
-import { HTTPError } from "~/lib/error"
+import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
+import { copilotFetchJsonWithRetry } from "~/lib/resilient-copilot-fetch"
 import { accountFromState } from "~/lib/state"
 
 export const createEmbeddings = async (
@@ -11,15 +11,22 @@ export const createEmbeddings = async (
   const ctx = account ?? accountFromState()
   if (!ctx.copilotToken) throw new Error("Copilot token not found")
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/embeddings`, {
+  const accountId = ctx.id ?? "unknown"
+
+  const url = `${copilotBaseUrl(ctx)}/embeddings`
+  const init: RequestInit = {
     method: "POST",
     headers: copilotHeaders(ctx),
     body: JSON.stringify(payload),
+  }
+
+  return copilotFetchJsonWithRetry<EmbeddingResponse>({
+    accountId,
+    operation: "POST /embeddings",
+    url,
+    init,
+    failureMessage: "Failed to create embeddings",
   })
-
-  if (!response.ok) throw new HTTPError("Failed to create embeddings", response)
-
-  return (await response.json()) as EmbeddingResponse
 }
 
 export interface EmbeddingRequest {

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,10 +1,10 @@
-import consola from "consola"
-import { events } from "fetch-event-stream"
-
 import type { AccountContext } from "~/lib/types/account"
 
 import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
-import { HTTPError } from "~/lib/error"
+import {
+  copilotFetchEventsWithRetry,
+  copilotFetchJsonWithRetry,
+} from "~/lib/resilient-copilot-fetch"
 import { accountFromState } from "~/lib/state"
 
 export interface ResponsesPayload {
@@ -320,7 +320,7 @@ export interface ResponseTextDoneEvent {
   type: "response.output_text.done"
 }
 
-export type ResponsesStream = ReturnType<typeof events>
+export type ResponsesStream = AsyncIterable<unknown>
 export type CreateResponsesReturn = ResponsesResult | ResponsesStream
 
 interface ResponsesRequestOptions {
@@ -336,6 +336,8 @@ export const createResponses = async (
   const ctx = account ?? accountFromState()
   if (!ctx.copilotToken) throw new Error("Copilot token not found")
 
+  const accountId = ctx.id ?? "unknown"
+
   const headers: Record<string, string> = {
     ...copilotHeaders(ctx, vision),
     "X-Initiator": initiator,
@@ -344,20 +346,28 @@ export const createResponses = async (
   // service_tier is not supported by github copilot
   payload.service_tier = null
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/responses`, {
+  const url = `${copilotBaseUrl(ctx)}/responses`
+  const init: RequestInit = {
     method: "POST",
     headers,
     body: JSON.stringify(payload),
-  })
-
-  if (!response.ok) {
-    consola.error("Failed to create responses", response)
-    throw new HTTPError("Failed to create responses", response)
   }
 
   if (payload.stream) {
-    return events(response)
+    return copilotFetchEventsWithRetry({
+      accountId,
+      operation: "POST /responses",
+      url,
+      init,
+      failureMessage: "Failed to create responses",
+    })
   }
 
-  return (await response.json()) as ResponsesResult
+  return copilotFetchJsonWithRetry<ResponsesResult>({
+    accountId,
+    operation: "POST /responses",
+    url,
+    init,
+    failureMessage: "Failed to create responses",
+  })
 }

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -3,19 +3,29 @@ import fs from "node:fs/promises"
 import type { AccountContext } from "~/lib/types/account"
 
 import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
-import { HTTPError } from "~/lib/error"
 import { PATHS } from "~/lib/paths"
+import { copilotFetchJsonWithRetry } from "~/lib/resilient-copilot-fetch"
 import { accountFromState } from "~/lib/state"
 
 export const getModels = async (account?: AccountContext) => {
   const ctx = account ?? accountFromState()
-  const response = await fetch(`${copilotBaseUrl(ctx)}/models`, {
+  if (!ctx.copilotToken) throw new Error("Copilot token not found")
+
+  const accountId = ctx.id ?? "unknown"
+
+  const url = `${copilotBaseUrl(ctx)}/models`
+  const init: RequestInit = {
+    method: "GET",
     headers: copilotHeaders(ctx),
+  }
+
+  const models = await copilotFetchJsonWithRetry<ModelsResponse>({
+    accountId,
+    operation: "GET /models",
+    url,
+    init,
+    failureMessage: "Failed to get models",
   })
-
-  if (!response.ok) throw new HTTPError("Failed to get models", response)
-
-  const models = (await response.json()) as ModelsResponse
 
   // Persist models response for debugging/inspection.
   // Best effort: do not fail startup if the local write fails.

--- a/src/start.ts
+++ b/src/start.ts
@@ -236,7 +236,7 @@ export const start = defineCommand({
       type: "boolean",
       default: false,
       description:
-        "Wait instead of error when rate limit is hit. Has no effect if rate limit is not set",
+        "DEPRECATED: No longer needed. When --rate-limit is set, requests are always queued. This flag is ignored and will be removed.",
     },
     "github-token": {
       alias: "g",
@@ -268,6 +268,21 @@ export const start = defineCommand({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       rateLimitRaw === undefined ? undefined : Number.parseInt(rateLimitRaw, 10)
 
+    // When rate limiting is enabled, we always queue (never reject).
+    const rateLimitWait = rateLimit === undefined ? false : true
+
+    if (args.wait) {
+      if (rateLimit === undefined) {
+        consola.warn(
+          "`--wait` is deprecated and has no effect unless `--rate-limit` is set. This flag will be removed in a future version.",
+        )
+      } else {
+        consola.warn(
+          "`--wait` is deprecated and ignored. When `--rate-limit` is set, the proxy always queues requests instead of returning 429.",
+        )
+      }
+    }
+
     let accountType: AccountType
     try {
       accountType = parseAccountType(args["account-type"])
@@ -282,7 +297,7 @@ export const start = defineCommand({
       accountType,
       manual: args.manual,
       rateLimit,
-      rateLimitWait: args.wait,
+      rateLimitWait,
       githubToken: args["github-token"],
       claudeCode: args["claude-code"],
       showToken: args["show-token"],

--- a/tests/copilot-rate-limiter.test.ts
+++ b/tests/copilot-rate-limiter.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, expect, test } from "bun:test"
+
+import { CopilotRateLimiter } from "../src/lib/copilot-rate-limiter"
+import { state } from "../src/lib/state"
+
+afterEach(() => {
+  // Avoid leaking config across tests.
+  state.rateLimitSeconds = undefined
+})
+
+test("acquire is a no-op when rate limiting is disabled", async () => {
+  state.rateLimitSeconds = undefined
+
+  let slept = false
+
+  const limiter = new CopilotRateLimiter("acct", {
+    nowMs: () => 0,
+    sleep: () => {
+      slept = true
+      return Promise.resolve()
+    },
+  })
+
+  await limiter.acquire()
+
+  expect(slept).toBe(false)
+  expect(limiter.snapshot()).toEqual({
+    enabled: false,
+    queueDepth: 0,
+    nextAllowedAtMs: 0,
+  })
+})
+
+test("acquire enforces the configured interval", async () => {
+  state.rateLimitSeconds = 1
+
+  let now = 0
+  const sleeps: Array<number> = []
+
+  const limiter = new CopilotRateLimiter("acct", {
+    nowMs: () => now,
+    sleep: (ms) => {
+      sleeps.push(ms)
+      now += ms
+      return Promise.resolve()
+    },
+  })
+
+  await Promise.all([limiter.acquire(), limiter.acquire()])
+
+  expect(sleeps).toEqual([1000])
+})
+
+test("noteRateLimitHit increases effective interval and enforces cooldown", async () => {
+  state.rateLimitSeconds = 1
+
+  let now = 0
+  const sleeps: Array<number> = []
+
+  const limiter = new CopilotRateLimiter("acct", {
+    nowMs: () => now,
+    sleep: (ms) => {
+      sleeps.push(ms)
+      now += ms
+      return Promise.resolve()
+    },
+  })
+
+  limiter.noteRateLimitHit(5, 5000)
+
+  expect(limiter.snapshot()).toEqual({
+    enabled: true,
+    effectiveSeconds: 5,
+    queueDepth: 0,
+    nextAllowedAtMs: 5000,
+  })
+
+  await limiter.acquire()
+
+  expect(sleeps).toEqual([5000])
+})

--- a/tests/handler-utils.test.ts
+++ b/tests/handler-utils.test.ts
@@ -39,6 +39,7 @@ test("toAccountContext projects AccountRuntime to AccountContext", () => {
   }
 
   expect(toAccountContext(runtime)).toEqual({
+    id: "octocat",
     githubToken: "ghp_test",
     copilotToken: "copilot_test",
     accountType: "individual",

--- a/tests/rate-limit-headers.test.ts
+++ b/tests/rate-limit-headers.test.ts
@@ -1,0 +1,105 @@
+import type { Context } from "hono"
+
+import { expect, test } from "bun:test"
+
+import {
+  getCopilotRateLimiter,
+  resetCopilotRateLimitersForTest,
+} from "../src/lib/copilot-rate-limiter"
+import { applyRateLimitHeaders } from "../src/lib/rate-limit-headers"
+import { state } from "../src/lib/state"
+
+class TestContext {
+  readonly headers = new Headers()
+
+  header(name: string, value: string) {
+    this.headers.set(name, value)
+  }
+}
+
+test("applyRateLimitHeaders sets unlimited headers when rate limiting is disabled", () => {
+  state.rateLimitSeconds = undefined
+  resetCopilotRateLimitersForTest()
+
+  const c = new TestContext()
+  applyRateLimitHeaders(c as unknown as Context)
+
+  expect(c.headers.get("X-RateLimit-Limit")).toBe("unlimited")
+  expect(c.headers.get("X-RateLimit-Remaining")).toBe("unlimited")
+  expect(c.headers.get("X-RateLimit-Reset")).toBe("unlimited")
+  expect(c.headers.get("X-Queue-Depth")).toBe("0")
+})
+
+test("applyRateLimitHeaders falls back when accountId is not known", () => {
+  state.rateLimitSeconds = 2
+  resetCopilotRateLimitersForTest()
+
+  const realNow = Date.now
+  Date.now = () => 1000
+
+  try {
+    const c = new TestContext()
+    applyRateLimitHeaders(c as unknown as Context)
+
+    expect(c.headers.get("X-RateLimit-Limit")).toBe("30")
+    expect(c.headers.get("X-RateLimit-Remaining")).toBe("30")
+    expect(c.headers.get("X-RateLimit-Reset")).toBe("3")
+    expect(c.headers.get("X-Queue-Depth")).toBe("0")
+  } finally {
+    Date.now = realNow
+  }
+})
+
+test("applyRateLimitHeaders uses per-account limiter snapshot when accountId is provided", () => {
+  state.rateLimitSeconds = 1
+  resetCopilotRateLimitersForTest()
+
+  const realNow = Date.now
+  Date.now = () => 1000
+
+  try {
+    const limiter = getCopilotRateLimiter("acct")
+    limiter.noteRateLimitHit(10, 5000)
+
+    const c = new TestContext()
+    applyRateLimitHeaders(c as unknown as Context, { accountId: "acct" })
+
+    // effectiveSeconds = max(configured=1, learned=10) = 10 => floor(60/10)=6
+    expect(c.headers.get("X-RateLimit-Limit")).toBe("6")
+    expect(c.headers.get("X-RateLimit-Remaining")).toBe("6")
+    // cooldownUntilMs = now(1000)+5000 => 6000 => reset=6
+    expect(c.headers.get("X-RateLimit-Reset")).toBe("6")
+    expect(c.headers.get("X-Queue-Depth")).toBe("0")
+  } finally {
+    Date.now = realNow
+  }
+})
+
+test("applyRateLimitHeaders sets Retry-After when queue depth is high", async () => {
+  state.rateLimitSeconds = 1
+  resetCopilotRateLimitersForTest()
+
+  const limiter = getCopilotRateLimiter("acct")
+
+  // Override internals to avoid real timers.
+  let now = 0
+  const hacked = limiter as unknown as {
+    nowMs: () => number
+    sleep: (ms: number) => Promise<void>
+  }
+  hacked.nowMs = () => now
+  hacked.sleep = (ms) => {
+    now += ms
+    return Promise.resolve()
+  }
+
+  const acquires = Array.from({ length: 51 }, () => limiter.acquire())
+
+  const c = new TestContext()
+  applyRateLimitHeaders(c as unknown as Context, { accountId: "acct" })
+
+  expect(Number(c.headers.get("X-Queue-Depth"))).toBeGreaterThan(50)
+  expect(c.headers.get("Retry-After")).toBe("1")
+
+  await Promise.all(acquires)
+})

--- a/tests/resilient-copilot-fetch.test.ts
+++ b/tests/resilient-copilot-fetch.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test"
+
+import { resetCopilotRateLimitersForTest } from "../src/lib/copilot-rate-limiter"
+import { HTTPError } from "../src/lib/error"
+import {
+  copilotFetchEventsWithRetry,
+  copilotFetchJsonWithRetry,
+} from "../src/lib/resilient-copilot-fetch"
+import { state } from "../src/lib/state"
+
+function getChunkData(chunk: unknown): string | Promise<string> | undefined {
+  const obj = chunk as { data?: string | Promise<string> }
+  return obj.data
+}
+
+function immediateSleep(): Promise<void> {
+  return Promise.resolve()
+}
+
+function installMockFetch(mock: typeof fetch): () => void {
+  const realFetch = globalThis.fetch
+
+  globalThis.fetch = mock
+
+  return () => {
+    globalThis.fetch = realFetch
+  }
+}
+
+test("copilotFetchJsonWithRetry retries once on 503 then returns JSON", async () => {
+  state.rateLimitSeconds = undefined
+  resetCopilotRateLimitersForTest()
+
+  let callCount = 0
+
+  const restore = installMockFetch(((..._args) => {
+    callCount += 1
+
+    if (callCount === 1) {
+      return Promise.resolve(new Response("transient", { status: 503 }))
+    }
+
+    return Promise.resolve(Response.json({ ok: true }, { status: 200 }))
+  }) as typeof fetch)
+
+  try {
+    const result = await copilotFetchJsonWithRetry<{ ok: boolean }>({
+      accountId: "acct",
+      operation: "POST /test",
+      url: "http://unit-test.local/json",
+      init: {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      },
+      failureMessage: "Failed to fetch JSON",
+      maxRetries: 1,
+      timeoutMs: 1000,
+      sleep: immediateSleep,
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(callCount).toBe(2)
+  } finally {
+    restore()
+  }
+})
+
+test("copilotFetchJsonWithRetry throws HTTPError on non-retryable status", async () => {
+  state.rateLimitSeconds = undefined
+  resetCopilotRateLimitersForTest()
+
+  let callCount = 0
+
+  const restore = installMockFetch(((..._args) => {
+    callCount += 1
+    return Promise.resolve(new Response("bad request", { status: 400 }))
+  }) as typeof fetch)
+
+  try {
+    let thrown: unknown
+
+    try {
+      await copilotFetchJsonWithRetry({
+        accountId: "acct",
+        operation: "POST /test",
+        url: "http://unit-test.local/bad",
+        init: { method: "POST" },
+        failureMessage: "Failed",
+        maxRetries: 1,
+        timeoutMs: 1000,
+        sleep: immediateSleep,
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(HTTPError)
+    expect(callCount).toBe(1)
+  } finally {
+    restore()
+  }
+})
+
+test("copilotFetchEventsWithRetry retries when stream ends before first event", async () => {
+  state.rateLimitSeconds = undefined
+  resetCopilotRateLimitersForTest()
+
+  let callCount = 0
+
+  const restore = installMockFetch(((..._args) => {
+    callCount += 1
+
+    // First attempt: stream ends immediately (no events)
+    if (callCount === 1) {
+      return Promise.resolve(
+        new Response("", {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+      )
+    }
+
+    // Second attempt: valid first event
+    const sse = "event: message\ndata: hello\n\n"
+    return Promise.resolve(
+      new Response(sse, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    )
+  }) as typeof fetch)
+
+  try {
+    const stream = await copilotFetchEventsWithRetry({
+      accountId: "acct",
+      operation: "POST /stream",
+      url: "http://unit-test.local/stream",
+      init: { method: "POST" },
+      failureMessage: "Failed to fetch stream",
+      maxRetries: 1,
+      connectTimeoutMs: 1000,
+      firstEventTimeoutMs: 1000,
+      sleep: immediateSleep,
+    })
+
+    const iterator = stream[Symbol.asyncIterator]()
+    const first = await iterator.next()
+
+    expect(first.done).toBe(false)
+
+    const rawData = getChunkData(first.value)
+
+    let data = ""
+    if (typeof rawData === "string") {
+      data = rawData
+    } else if (rawData) {
+      data = await rawData
+    }
+
+    expect(data).toContain("hello")
+    expect(callCount).toBe(2)
+  } finally {
+    restore()
+  }
+})


### PR DESCRIPTION
## Summary

- Add per-account `CopilotRateLimiter` that learns optimal intervals from upstream 429 responses
- Add resilient fetch utilities (`copilotFetchJsonWithRetry`, `copilotFetchEventsWithRetry`) with automatic retry for 429/5xx errors and exponential backoff
- Replace inline `checkRateLimit()` calls with response `X-RateLimit-*` headers for better client visibility
- Deprecate `--wait` flag (queue mode is now the default when `--rate-limit` is set)

## Changes

### New Files
- `src/lib/copilot-rate-limiter.ts` - Per-account rate limiter with mutex-based queuing and learned interval support
- `src/lib/rate-limit-headers.ts` - Middleware and utility to apply rate-limit headers to responses
- `src/lib/resilient-copilot-fetch.ts` - Resilient fetch wrappers with retry logic for JSON and SSE streams

### Modified Files
- `src/services/copilot/*` - Migrated to use resilient fetch utilities
- `src/routes/*/handler.ts` - Replaced `checkRateLimit()` with `applyRateLimitHeaders()`
- `src/server.ts` - Added rate-limit headers middleware
- `src/start.ts` - Deprecated `--wait` flag, queue mode is now default
- `src/lib/types/account.ts` - Added `id` field to `AccountContext`
- `AGENTS.md` - Added project background section

### Tests
- `tests/copilot-rate-limiter.test.ts`
- `tests/rate-limit-headers.test.ts`
- `tests/resilient-copilot-fetch.test.ts`

## Test Plan

- [x] Unit tests pass (`bun test`)
- [ ] Manual test with `--rate-limit` flag enabled
- [ ] Verify `X-RateLimit-*` headers appear in responses
- [ ] Verify retry behavior on simulated 429/503 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 按账户生效的 Copilot 速率限制与队列控制（可观测快照）
  * 面向 Copilot 的稳健请求重试与流式重试支持（超时、退避、429 处理）
  * 全局与路由级别自动添加速率限制响应头（含队列深度与 Retry-After 提示）

* **修复 / 改进**
  * 在响应上下文中统一包含账号 id 字段
  * 启用服务器中间件以在所有路由应用速率限制头

* **文档**
  * 更新项目背景、分支/PR 工作流与速率限制使用说明

* **测试**
  * 新增速率限制、速率头与重试逻辑的单元测试覆盖

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->