### PR TITLE
fix(messages): detect Claude Code warmup probe message

### DIFF
--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -28,6 +28,9 @@ export interface AnthropicMessagesPayload {
 export interface AnthropicTextBlock {
   type: "text"
   text: string
+  cache_control?: {
+    type: string
+  }
 }
 
 export interface AnthropicImageBlock {

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -92,6 +92,21 @@ type InstrumentationContext = {
   premiumUnlimitedBefore?: boolean
 }
 
+const isWarmupProbeRequest = (payload: AnthropicMessagesPayload): boolean => {
+  const lastMsg = payload.messages.at(-1)
+  if (!lastMsg || lastMsg.role !== "user" || !Array.isArray(lastMsg.content)) {
+    return false
+  }
+
+  const lastBlock = lastMsg.content.at(-1)
+  if (!lastBlock || lastBlock.type !== "text") {
+    return false
+  }
+
+  const text = lastBlock.text.trim().toLowerCase()
+  return text === "warmup" && lastBlock.cache_control?.type === "ephemeral"
+}
+
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
@@ -109,11 +124,10 @@ export async function handleCompletion(c: Context) {
   const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
   logger.debug("Anthropic request payload:", JSON.stringify(anthropicPayload))
 
-  // fix claude code 2.0.28+ warmup request consume premium request, forcing small model if no tools are used
+  // fix claude code 2.0.28+ warmup request consume premium request, forcing small model for warmup probe requests
   // set "CLAUDE_CODE_SUBAGENT_MODEL": "you small model" also can avoid this
   const anthropicBeta = c.req.header("anthropic-beta")
-  const noTools = !anthropicPayload.tools || anthropicPayload.tools.length === 0
-  if (anthropicBeta && noTools) {
+  if (anthropicBeta && isWarmupProbeRequest(anthropicPayload)) {
     anthropicPayload.model = getSmallModel()
   }
 


### PR DESCRIPTION
## Summary
- Detect Claude Code warmup probe by matching the last user text block "Warmup" (case-insensitive, trimmed) with `cache_control.type === "ephemeral"`.
- Remove warmup detection dependency on tool definitions to avoid missing real warmup requests that still declare tools.
- Extend Anthropic text block typing to include optional `cache_control`.

## Test plan
- [x] `bun run lint`
- [x] `bun test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为消息请求添加了缓存控制字段支持，提供更灵活的请求配置选项
  * 实现了预热请求的智能识别机制，自动采用优化策略以提升系统响应效率

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->