### PR TITLE
feat(admin): show premium quota usage progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # AGENTS.md
 
+## Project Background
+
+This project is a fork of `ericc-ch/copilot-api`, created because the original repository appears to be unmaintained.
+
+- **Current Repository**: [nick3/copilot-api](https://github.com/nick3/copilot-api)
+- **Workflow**:
+  - All pushes and Pull Requests should be directed to `nick3/copilot-api`.
+  - The default active branch is `all` (not `master` or `main`).
+  - All Pull Requests should target the `all` branch.
+
 ## Build, Lint, and Test Commands
 
 - **Build:**  

--- a/admin-ui/src/components/ui/progress.tsx
+++ b/admin-ui/src/components/ui/progress.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export type ProgressProps = React.ComponentProps<"div"> & {
+  /**
+   * Progress value in the range 0-100.
+   */
+  value?: number
+  /**
+   * Extra classes applied to the inner indicator.
+   */
+  indicatorClassName?: string
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function Progress({
+  value = 0,
+  className,
+  indicatorClassName,
+  ...props
+}: ProgressProps) {
+  const safeValue = Number.isFinite(value) ? clamp(value, 0, 100) : 0
+
+  return (
+    <div
+      data-slot="progress"
+      role="progressbar"
+      aria-valuenow={Math.round(safeValue)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={cn(
+        "bg-muted relative h-1 w-full overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    >
+      <div
+        data-slot="progress-indicator"
+        className={cn(
+          "bg-primary h-full transition-[width] duration-300 ease-out",
+          indicatorClassName
+        )}
+        style={{ width: `${safeValue}%` }}
+      />
+    </div>
+  )
+}
+
+export { Progress }

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -9,6 +9,7 @@ export type AdminAccountItem = {
   account_id: string
   account_type?: string
   runtime?: {
+    entitlement?: number
     remaining?: number
     unlimited?: boolean
     failed?: boolean

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -37,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Progress } from "@/components/ui/progress"
 import { BentoGrid } from "@/components/ui/bento-grid"
 import { MagicCard } from "@/components/ui/magic-card"
 import { NumberTicker } from "@/components/ui/number-ticker"
@@ -48,6 +49,15 @@ type SortBy = "account" | "requests" | "errors" | "tokens" | "last_req"
 
 function sum(items: Array<number | undefined>): number {
   return items.reduce<number>((acc, x) => acc + (x ?? 0), 0)
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+function fmtNumOrDash(n?: number | null): string {
+  const s = fmtNum(n)
+  return s || "—"
 }
 
 function calcWeightedAvgDurationMs(accounts: AdminAccountItem[]): number {
@@ -405,10 +415,45 @@ export function AccountsPage(): React.JSX.Element {
                     <Badge variant="secondary">ok</Badge>
                   )
 
-                  const remaining = a.runtime?.unlimited ? (
+                  const total = a.runtime?.entitlement
+                  const remainingQuota = a.runtime?.remaining
+                  const usedQuota =
+                    total != null && remainingQuota != null ?
+                      total - remainingQuota
+                    : undefined
+
+                  const percentUsedRaw =
+                    total != null && total > 0 && usedQuota != null ?
+                      (usedQuota / total) * 100
+                    : undefined
+
+                  const percentUsed =
+                    percentUsedRaw != null && Number.isFinite(percentUsedRaw) ?
+                      clampPercent(percentUsedRaw)
+                    : undefined
+
+                  const remainingCell = a.runtime?.unlimited ? (
                     <Badge variant="secondary">unlimited</Badge>
                   ) : (
-                    fmtNum(a.runtime?.remaining)
+                    <div className="flex flex-col gap-1">
+                      <div className="text-xs">
+                        <span className="text-muted-foreground">Used:</span>{" "}
+                        <span className="tabular-nums">{fmtNumOrDash(usedQuota)}</span>
+                      </div>
+                      <div className="text-xs">
+                        <span className="text-muted-foreground">Remaining:</span>{" "}
+                        <span className="tabular-nums">
+                          {fmtNumOrDash(remainingQuota)}
+                        </span>
+                      </div>
+                      {percentUsed != null ? (
+                        <Progress
+                          value={percentUsed}
+                          className="h-1.5"
+                          aria-label="Premium interactions quota used"
+                        />
+                      ) : null}
+                    </div>
                   )
 
                   const last = a.stats?.last_request_at_ms
@@ -435,7 +480,11 @@ export function AccountsPage(): React.JSX.Element {
                           ) : null}
                         </div>
                       </TableCell>
-                      <TableCell className={cn(accountsTableColVisibility[2])}>{remaining}</TableCell>
+                      <TableCell
+                        className={cn(accountsTableColVisibility[2], "whitespace-normal")}
+                      >
+                        {remainingCell}
+                      </TableCell>
                       <TableCell>{fmtNum(a.stats?.request_count)}</TableCell>
                       <TableCell>{fmtNum(a.stats?.error_count)}</TableCell>
                       <TableCell className={cn(accountsTableColVisibility[5])}>

--- a/src/lib/accounts-manager-auth.ts
+++ b/src/lib/accounts-manager-auth.ts
@@ -107,6 +107,7 @@ export const applyQuotaRefreshSuccessIfCurrent = (
     return false
   }
 
+  account.premiumEntitlement = premium.entitlement
   account.premiumRemaining = premium.remaining
   account.unlimited = premium.unlimited
   account.lastQuotaFetch = Date.now()

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -618,6 +618,7 @@ export class AccountsManager {
    */
   getAccountStatus(): Array<{
     id: string
+    entitlement?: number
     remaining?: number
     unlimited?: boolean
     failed?: boolean
@@ -625,6 +626,7 @@ export class AccountsManager {
   }> {
     const statuses: Array<{
       id: string
+      entitlement?: number
       remaining?: number
       unlimited?: boolean
       failed?: boolean
@@ -634,6 +636,7 @@ export class AccountsManager {
     if (this.temporaryAccount) {
       statuses.push({
         id: "(temporary)",
+        entitlement: this.temporaryAccount.premiumEntitlement,
         remaining: this.temporaryAccount.premiumRemaining,
         unlimited: this.temporaryAccount.unlimited,
         failed: this.temporaryAccount.failed,
@@ -646,6 +649,7 @@ export class AccountsManager {
       if (account) {
         statuses.push({
           id: account.id,
+          entitlement: account.premiumEntitlement,
           remaining: account.premiumRemaining,
           unlimited: account.unlimited,
           failed: account.failed,

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -63,6 +63,8 @@ export interface AccountRuntime extends AccountMeta {
   vsCodeVersion?: string
   /** Cached available models for this account */
   models?: ModelsResponse
+  /** Total premium interactions quota entitlement */
+  premiumEntitlement?: number
   /** Remaining premium interactions quota */
   premiumRemaining?: number
   /** Reserved premium interaction units for in-flight requests */

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -95,6 +95,7 @@ type AccountItem = {
   account_id: string
   account_type?: string
   runtime: {
+    entitlement?: number
     remaining?: number
     unlimited?: boolean
     failed?: boolean
@@ -185,6 +186,7 @@ adminApiRoutes.get("/accounts", async (c) => {
       account_id: s.id,
       account_type: accountType,
       runtime: {
+        entitlement: s.entitlement,
         remaining: s.remaining,
         unlimited: s.unlimited,
         failed: s.failed,


### PR DESCRIPTION
## Summary
- Cache and expose premium quota entitlement in the admin accounts API.
- Improve Accounts Remaining column to show Used/Remaining plus a progress bar.
- Add a reusable Progress UI component for admin-ui.

## Test plan
- [ ] Open `/admin/#/accounts` and verify Remaining shows Used/Remaining + progress bar for limited accounts.
- [ ] Verify unlimited accounts show `unlimited` badge and no progress bar.
- [ ] Verify missing data shows `—` and no progress bar.
- [ ] Run `bun run typecheck && bun run typecheck:admin`
- [ ] Run `bun run lint && bun run lint:admin`
- [ ] Run `bun test` and `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新增功能**
  * 添加配额使用情况的可视化展示，在账户页面显示已用/剩余配额及进度条
  * 新增进度条组件用于展示使用率

* **文档**
  * 添加项目背景信息说明

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->