### PR TITLE
style(admin-ui): polish quota progress display

### DIFF
--- a/admin-ui/src/components/ui/progress.tsx
+++ b/admin-ui/src/components/ui/progress.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { useMotionPreference } from "@/lib/motion-preference"
 import { cn } from "@/lib/utils"
 
 export type ProgressProps = React.ComponentProps<"div"> & {
@@ -21,9 +22,16 @@ function Progress({
   value = 0,
   className,
   indicatorClassName,
+  style,
   ...props
 }: ProgressProps) {
+  const { effective } = useMotionPreference()
+
   const safeValue = Number.isFinite(value) ? clamp(value, 0, 100) : 0
+
+  const animated = effective !== "off"
+  const shimmer = effective === "magic"
+  const speed = effective === "subtle" ? "4s" : "2.2s"
 
   return (
     <div
@@ -33,15 +41,29 @@ function Progress({
       aria-valuemin={0}
       aria-valuemax={100}
       className={cn(
-        "bg-muted relative h-1 w-full overflow-hidden rounded-full",
+        "bg-muted/60 relative h-1.5 w-full overflow-hidden rounded-full ring-1 ring-border/40",
         className
       )}
+      style={{
+        ...style,
+        "--speed": speed,
+      } as React.CSSProperties}
       {...props}
     >
       <div
         data-slot="progress-indicator"
         className={cn(
-          "bg-primary h-full transition-[width] duration-300 ease-out",
+          "relative h-full rounded-full",
+          "[container-type:inline-size] overflow-hidden",
+          "transition-[width] duration-700 ease-out",
+          // Magic UI vibe: animated multi-stop gradient (same tokens used by RainbowButton)
+          "bg-[linear-gradient(90deg,var(--color-1),var(--color-5),var(--color-3),var(--color-4),var(--color-2))] bg-[length:200%_100%]",
+          animated ? "animate-rainbow" : undefined,
+          shimmer
+            ? "before:absolute before:inset-y-0 before:left-0 before:w-3/5 before:rounded-full before:bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.55),transparent)] before:opacity-50 before:animate-shimmer-slide before:content-['']"
+            : undefined,
+          // subtle glow
+          "dark:shadow-[0_0_12px_rgba(255,255,255,0.12)] shadow-[0_0_8px_rgba(0,0,0,0.06)]",
           indicatorClassName
         )}
         style={{ width: `${safeValue}%` }}

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -436,15 +436,19 @@ export function AccountsPage(): React.JSX.Element {
                     <Badge variant="secondary">unlimited</Badge>
                   ) : (
                     <div className="flex flex-col gap-1">
-                      <div className="text-xs">
-                        <span className="text-muted-foreground">Used:</span>{" "}
-                        <span className="tabular-nums">{fmtNumOrDash(usedQuota)}</span>
-                      </div>
-                      <div className="text-xs">
-                        <span className="text-muted-foreground">Remaining:</span>{" "}
-                        <span className="tabular-nums">
-                          {fmtNumOrDash(remainingQuota)}
-                        </span>
+                      <div className="flex items-baseline justify-between gap-2 text-xs whitespace-nowrap">
+                        <div className="flex items-baseline gap-1">
+                          <span className="text-muted-foreground">Used</span>
+                          <span className="tabular-nums font-medium">
+                            {fmtNumOrDash(usedQuota)}
+                          </span>
+                        </div>
+                        <div className="flex items-baseline gap-1">
+                          <span className="text-muted-foreground">Remaining</span>
+                          <span className="tabular-nums font-medium">
+                            {fmtNumOrDash(remainingQuota)}
+                          </span>
+                        </div>
                       </div>
                       {percentUsed != null ? (
                         <Progress


### PR DESCRIPTION
## Summary
- Display `Used` (left) and `Remaining` (right) in a single row for better scanability.
- Upgrade the quota progress bar to a Magic UI-style animated gradient (respects motion preference).

## Test plan
- [ ] Open `/admin/#/accounts` and verify Remaining shows `Used` (left) + `Remaining` (right) on one line.
- [ ] Verify progress bar has Magic-style gradient + shimmer (motion=magic) and degrades when motion is off.
- [ ] Verify `unlimited` accounts still show badge and no progress bar.
- [ ] Run `bun run --cwd admin-ui lint && bun run --cwd admin-ui typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 进度条组件：新增动感响应能力，支持梯度填充、动画效果和微光视觉增强
  * 账户配额显示：改进布局设计，采用水平排列方式呈现已用和剩余配额信息，提升可读性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->