### PR TITLE
Add forceAgent and streaming resiliency

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Copilot. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts.
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests) to avoid spending premium requests; defaults to `gpt-5-mini`.
 - **freeModelLoadBalancing:** Enable round-robin routing for free-model requests across multiple accounts. Defaults to `true`. Set to `false` to route free-model requests sequentially (same ordering strategy as premium models).
-- **forceAgent:** When `true`, force all forwarded requests to use `X-Initiator: agent`, ignoring message-role inference. Defaults to `false`.
+- **forceAgent:** When `true`, set `X-Initiator` to `agent` only if any message has role `assistant` or `tool`; otherwise use `user`. When `false`, `X-Initiator` is inferred from the last message (`user` → `user`, otherwise `agent`). Defaults to `false`.
 - **apiKey (optional):** API key used to protect selected endpoints (see **API Key authentication** below). Prefer setting the `COPILOT_API_KEY` environment variable (takes precedence over `config.json`). The server does not generate an API key automatically — you must provide one. If no key is configured, protected endpoints remain publicly accessible (fail-open). **Do not commit secrets.**
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
     },
     "smallModel": "gpt-5-mini",
     "freeModelLoadBalancing": true,
+    "forceAgent": false,
     "apiKey": "<your_api_key_here>",
     "modelReasoningEfforts": {
       "gpt-5-mini": "low"
@@ -255,6 +256,7 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Copilot. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts.
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests) to avoid spending premium requests; defaults to `gpt-5-mini`.
 - **freeModelLoadBalancing:** Enable round-robin routing for free-model requests across multiple accounts. Defaults to `true`. Set to `false` to route free-model requests sequentially (same ordering strategy as premium models).
+- **forceAgent:** When `true`, force all forwarded requests to use `X-Initiator: agent`, ignoring message-role inference. Defaults to `false`.
 - **apiKey (optional):** API key used to protect selected endpoints (see **API Key authentication** below). Prefer setting the `COPILOT_API_KEY` environment variable (takes precedence over `config.json`). The server does not generate an API key automatically — you must provide one. If no key is configured, protected endpoints remain publicly accessible (fail-open). **Do not commit secrets.**
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
 

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,10 @@
+# Findings
+
+## Discoveries
+- 配置位置与默认值：PATHS.CONFIG_PATH 位于 src/lib/paths.ts，配置结构与默认值在 src/lib/config.ts（AppConfig/defaultConfig/mergeConfigWithDefaults），启动时 start.ts 会调用 mergeConfigWithDefaults。当前 mergeConfigWithDefaults 会补齐 extraPrompts、freeModelLoadBalancing 与 forceAgent。
+- X-Initiator 注入点：chat-completions 在 src/services/copilot/create-chat-completions.ts 里根据最后一条消息 role 判定（非 user -> agent）；responses 通过 src/routes/responses/utils.ts 的 getResponsesRequestOptions/hasAgentInitiator 计算并传给 src/services/copilot/create-responses.ts。
+- Streaming 处理器：src/routes/chat-completions/handler.ts、src/routes/responses/handler.ts、src/routes/messages/handler.ts 均使用 streamSSE/stream.writeSSE 转发 SSE。
+- 日志与配额链路：logger 记录落盘；request-history/account-manager 在 streaming finally 中写入 usage 与 premium 快照。现已新增 formatStreamLog/getPremiumInfo 与 setupPingInterval 以支持进度输出与 SSE keepalive，并补充日志/异常可观测性。
+
+## Open Questions
+- (已解决) README 配置章节已补充 forceAgent 说明。

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,25 @@
+# Progress Log
+
+## 2026-01-16
+- 初始化规划文件
+- 尝试设置终端标题失败：scripts/set_title.sh 不存在
+- 完成初步勘察：配置读取（config.ts/paths.ts）、X-Initiator 注入（create-chat-completions.ts/create-responses.ts）、responses/utils.ts、三类 streaming handler
+- 细读 config.ts 与 responses/utils.ts：未包含 forceAgent；initiator 仅看最后一条 role
+- 细读 create-chat-completions.ts / create-responses.ts：chat-completions X-Initiator 依据最后消息 role（assistant/tool）；responses 使用上层传入 initiator
+- 细读 logger.ts 与 utils.ts：logger 只有落盘逻辑，缺少 stream 进度/配额函数；utils.ts 尚无 setupPingInterval
+- 初读 chat-completions/handler.ts 与 responses/handler.ts：streaming/非 streaming 分支清晰，待在 streaming loop 中接入 ping 与 stdout 进度输出
+- 细读 streaming 入口：chat-completions handleStreamingRequest -> streamChatCompletionsAndLog；responses handleStreamingResponses -> streamResponsesAndLog
+- 细读 streaming loop：两处都在 for-await 中写 SSE，并在 finally 里 finalizeQuota/insertRequestLog
+- 初读 messages/handler.ts 与 get-copilot-usage.ts：messages 使用 responses/utils 计算 initiator；getCopilotUsage 提供 premium_interactions 配额
+- 细读 messages streaming：chat 与 responses 两路在 for-await 中写 SSE，responses 已转发上游 ping
+- 已实现 forceAgent 配置与 X-Initiator 判定逻辑（config.ts/create-chat-completions.ts/responses/utils.ts）
+- 已新增 setupPingInterval 并接入 chat-completions/responses/messages 的 streaming handler
+- 已新增 stdout 进度输出与 premium 配额展示（logger.ts + 各 handler）
+- 已更新 README 配置章节增加 forceAgent
+- 已为 getPremiumInfo 增加告警日志，避免静默失败
+- streaming handler 已加入 ping 失败回调并在 request log 中标记 PingFailed
+- streaming 异常时发送 SSE error 事件并避免输出完成 ✓
+- request log 与 finalizeQuota 写入增加 try/catch（含 embeddings/route）
+- 修复 finalizeQuotaSafely 递归错误，并为 pingFailed 增加 streamCompleted 限制
+- formatStreamLog 增加 total=0 保护，避免除零
+- forceAgent 判定逻辑调整为：true→检查是否存在 assistant/tool；false→仅看最后一条是否 user

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ export interface AppConfig {
   extraPrompts?: Record<string, string>
   smallModel?: string
   freeModelLoadBalancing?: boolean
+  forceAgent?: boolean
   apiKey?: string
   modelReasoningEfforts?: Record<
     string,
@@ -29,6 +30,7 @@ const defaultConfig: AppConfig = {
   },
   smallModel: "gpt-5-mini",
   freeModelLoadBalancing: true,
+  forceAgent: false,
   modelReasoningEfforts: {
     "gpt-5-mini": "low",
   },
@@ -125,6 +127,23 @@ function mergeDefaultFreeModelLoadBalancing(config: AppConfig): {
   }
 }
 
+function mergeDefaultForceAgent(config: AppConfig): {
+  mergedConfig: AppConfig
+  changed: boolean
+} {
+  if (typeof config.forceAgent === "boolean") {
+    return { mergedConfig: config, changed: false }
+  }
+
+  return {
+    mergedConfig: {
+      ...config,
+      forceAgent: defaultConfig.forceAgent ?? false,
+    },
+    changed: true,
+  }
+}
+
 type ConfigMergeResult = {
   mergedConfig: AppConfig
   changed: boolean
@@ -154,6 +173,7 @@ export function mergeConfigWithDefaults(): AppConfig {
   const { mergedConfig, changed } = applyConfigMerges(config, [
     mergeDefaultExtraPrompts,
     mergeDefaultFreeModelLoadBalancing,
+    mergeDefaultForceAgent,
   ])
 
   if (changed) {
@@ -190,6 +210,11 @@ export function getSmallModel(): string {
 export function isFreeModelLoadBalancingEnabled(): boolean {
   const config = getConfig()
   return config.freeModelLoadBalancing ?? true
+}
+
+export function isForceAgentEnabled(): boolean {
+  const config = getConfig()
+  return config.forceAgent ?? false
 }
 
 export function getReasoningEffortForModel(

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,6 +3,8 @@ import fs from "node:fs"
 import path from "node:path"
 import util from "node:util"
 
+import { getCopilotUsage } from "~/services/github/get-copilot-usage"
+
 import { PATHS } from "./paths"
 import { state } from "./state"
 
@@ -179,4 +181,47 @@ export const createHandlerLogger = (name: string): ConsolaInstance => {
   })
 
   return instance
+}
+
+// Stream progress logging utilities
+export interface StreamLogOptions {
+  model: string
+  chunks: number
+  done: boolean
+  premium?: { remaining: number; total: number } | null
+}
+
+export const formatStreamLog = ({
+  model,
+  chunks,
+  done,
+  premium,
+}: StreamLogOptions): string => {
+  const base = `\x1b[2K\r↪ ${model} ${chunks}${done ? " ✓" : ""}`
+  if (done && premium) {
+    const pct = premium.total > 0 ? premium.remaining / premium.total : 0
+    let numColor = "\x1b[31m"
+    if (pct > 0.5) numColor = "\x1b[32m"
+    else if (pct > 0.2) numColor = "\x1b[33m"
+    const reset = "\x1b[0m"
+    const dim = "\x1b[2m"
+    return `${base} [${numColor}${premium.remaining}${reset} ${dim}left${reset}]`
+  }
+  return base
+}
+
+export const getPremiumInfo = async (): Promise<{
+  remaining: number
+  total: number
+} | null> => {
+  try {
+    const usage = await getCopilotUsage()
+    const pi = usage.quota_snapshots.premium_interactions
+    if (!pi.unlimited) {
+      return { remaining: pi.remaining, total: pi.entitlement }
+    }
+  } catch (error) {
+    consola.warn("Failed to fetch premium usage:", error)
+  }
+  return null
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -193,6 +193,14 @@ export interface StreamLogOptions {
   premium?: { remaining: number; total: number } | null
 }
 
+const getPremiumColorCode = (remaining: number, total: number): string => {
+  if (total <= 0) return "\x1b[31m"
+  const pct = remaining / total
+  if (pct > 0.5) return "\x1b[32m"
+  if (pct > 0.2) return "\x1b[33m"
+  return "\x1b[31m"
+}
+
 export const formatStreamLog = ({
   model,
   chunks,
@@ -200,16 +208,12 @@ export const formatStreamLog = ({
   premium,
 }: StreamLogOptions): string => {
   const base = `\x1b[2K\r↪ ${model} ${chunks}${done ? " ✓" : ""}`
-  if (done && premium) {
-    const pct = premium.total > 0 ? premium.remaining / premium.total : 0
-    let numColor = "\x1b[31m"
-    if (pct > 0.5) numColor = "\x1b[32m"
-    else if (pct > 0.2) numColor = "\x1b[33m"
-    const reset = "\x1b[0m"
-    const dim = "\x1b[2m"
-    return `${base} [${numColor}${premium.remaining}${reset} ${dim}left${reset}]`
-  }
-  return base
+  if (!done || !premium) return base
+
+  const numColor = getPremiumColorCode(premium.remaining, premium.total)
+  const reset = "\x1b[0m"
+  const dim = "\x1b[2m"
+  return `${base} [${numColor}${premium.remaining}${reset} ${dim}left${reset}]`
 }
 
 export const getPremiumInfo = async (

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -5,6 +5,8 @@ import util from "node:util"
 
 import { getCopilotUsage } from "~/services/github/get-copilot-usage"
 
+import type { AccountContext } from "./types/account"
+
 import { PATHS } from "./paths"
 import { state } from "./state"
 
@@ -210,12 +212,18 @@ export const formatStreamLog = ({
   return base
 }
 
-export const getPremiumInfo = async (): Promise<{
+export const getPremiumInfo = async (
+  account?: AccountContext,
+): Promise<{
   remaining: number
   total: number
 } | null> => {
+  // Require account context - multi-account mode doesn't use global state
+  if (!account) {
+    return null
+  }
   try {
-    const usage = await getCopilotUsage()
+    const usage = await getCopilotUsage(account)
     const pi = usage.quota_snapshots.premium_interactions
     if (!pi.unlimited) {
       return { remaining: pi.remaining, total: pi.entitlement }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,7 +32,17 @@ export const setupPingInterval = (
   intervalMs: number = 3000,
   onError?: (error: unknown) => void,
 ) => {
-  const pingInterval = setInterval(async () => {
+  let inFlight = false
+
+  const pingInterval = setInterval(() => {
+    if (inFlight) return
+    inFlight = true
+    void sendPing().finally(() => {
+      inFlight = false
+    })
+  }, intervalMs)
+
+  async function sendPing() {
     try {
       await stream.writeSSE({
         event: "ping",
@@ -44,7 +54,7 @@ export const setupPingInterval = (
       clearInterval(pingInterval)
       onError?.(error)
     }
-  }, intervalMs)
+  }
 
   return pingInterval
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,3 +24,27 @@ export const cacheVSCodeVersion = async () => {
 
   consola.info(`Using VSCode version: ${response}`)
 }
+
+export const setupPingInterval = (
+  stream: {
+    writeSSE: (data: { event: string; data: string }) => Promise<void>
+  },
+  intervalMs: number = 3000,
+  onError?: (error: unknown) => void,
+) => {
+  const pingInterval = setInterval(async () => {
+    try {
+      await stream.writeSSE({
+        event: "ping",
+        data: "",
+      })
+      consola.debug("Sent ping")
+    } catch (error) {
+      consola.warn("Failed to send ping:", error)
+      clearInterval(pingInterval)
+      onError?.(error)
+    }
+  }, intervalMs)
+
+  return pingInterval
+}

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -490,6 +490,19 @@ async function handleNonStreamingUpstreamResponse(params: {
   }
 }
 
+function computeFinalStreamError(params: {
+  pingFailed: boolean
+  streamCompleted: boolean
+  errorName: string | undefined
+  errorMessage: string | undefined
+}): { errorName: string | undefined; errorMessage: string | undefined } {
+  const { pingFailed, streamCompleted, errorName, errorMessage } = params
+  if (pingFailed && !errorName && !streamCompleted) {
+    return { errorName: "PingFailed", errorMessage: "SSE ping failed" }
+  }
+  return { errorName, errorMessage }
+}
+
 // eslint-disable-next-line max-lines-per-function
 async function streamChatCompletionsAndLog(params: {
   stream: StreamSseStream
@@ -585,14 +598,12 @@ async function streamChatCompletionsAndLog(params: {
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
 
-    const finalErrorName =
-      pingFailed.value && !errorName && !streamCompleted ?
-        "PingFailed"
-      : errorName
-    const finalErrorMessage =
-      pingFailed.value && !errorName && !streamCompleted ?
-        "SSE ping failed"
-      : errorMessage
+    const finalError = computeFinalStreamError({
+      pingFailed: pingFailed.value,
+      streamCompleted,
+      errorName,
+      errorMessage,
+    })
 
     insertRequestLog(store, request, {
       finishedAtMs,
@@ -614,10 +625,10 @@ async function streamChatCompletionsAndLog(params: {
       ),
       premiumUnlimitedBefore,
       premiumUnlimitedAfter,
-      httpStatus: errorStatus ?? (finalErrorName ? 500 : 200),
-      errorName: finalErrorName,
+      httpStatus: errorStatus ?? (finalError.errorName ? 500 : 200),
+      errorName: finalError.errorName,
       errorStatus,
-      errorMessage: finalErrorMessage,
+      errorMessage: finalError.errorMessage,
     })
 
     const premium = await getPremiumInfo(account)
@@ -625,7 +636,7 @@ async function streamChatCompletionsAndLog(params: {
       `${formatStreamLog({
         model: payload.model,
         chunks: chunkCount,
-        done: !finalErrorName,
+        done: !finalError.errorName,
         premium,
       })}\n`,
     )

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -10,7 +10,11 @@ import {
   extractErrorDetails,
   toAccountContext,
 } from "~/lib/handler-utils"
-import { createHandlerLogger } from "~/lib/logger"
+import {
+  createHandlerLogger,
+  formatStreamLog,
+  getPremiumInfo,
+} from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
   getClientIpInfo,
@@ -20,7 +24,7 @@ import {
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
-import { isNullish } from "~/lib/utils"
+import { isNullish, setupPingInterval } from "~/lib/utils"
 import {
   createChatCompletions,
   type ChatCompletionChunk,
@@ -170,16 +174,31 @@ function insertRequestLog(
     | "userAgent"
   >,
 ): void {
-  store.insert({
-    requestId: request.requestId,
-    startedAtMs: request.startedAtMs,
-    method: request.method,
-    path: request.path,
-    clientIp: request.clientIp,
-    clientIpSource: request.clientIpSource,
-    userAgent: request.userAgent,
-    ...record,
-  })
+  try {
+    store.insert({
+      requestId: request.requestId,
+      startedAtMs: request.startedAtMs,
+      method: request.method,
+      path: request.path,
+      clientIp: request.clientIp,
+      clientIpSource: request.clientIpSource,
+      userAgent: request.userAgent,
+      ...record,
+    })
+  } catch (error) {
+    logger.warn("Failed to write request log:", error)
+  }
+}
+
+async function finalizeQuotaSafely(
+  account: AccountSelectionOk["account"],
+  reservation: AccountSelectionOk["reservation"],
+): Promise<void> {
+  try {
+    await accountsManager.finalizeQuota(account, reservation)
+  } catch (error) {
+    logger.warn("Failed to finalize quota:", error)
+  }
 }
 
 function recordSelectionFailure(
@@ -364,7 +383,7 @@ async function handleUpstreamCreateError(params: {
     accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
   }
 
-  await accountsManager.finalizeQuota(account, reservation)
+  await finalizeQuotaSafely(account, reservation)
 
   const premiumRemainingAfter = account.premiumRemaining
   const premiumUnlimitedAfter = account.unlimited
@@ -439,7 +458,7 @@ async function handleNonStreamingUpstreamResponse(params: {
 
     throw error
   } finally {
-    await accountsManager.finalizeQuota(account, reservation)
+    await finalizeQuotaSafely(account, reservation)
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
@@ -471,6 +490,7 @@ async function handleNonStreamingUpstreamResponse(params: {
   }
 }
 
+// eslint-disable-next-line max-lines-per-function
 async function streamChatCompletionsAndLog(params: {
   stream: StreamSseStream
   response: ChatCompletionsStream
@@ -500,6 +520,14 @@ async function streamChatCompletionsAndLog(params: {
   let errorStatus: number | undefined
   let errorMessage: string | undefined
 
+  const pingFailed = { value: false }
+  let streamCompleted = false
+  const pingInterval = setupPingInterval(stream, 3000, (error) => {
+    pingFailed.value = true
+    logger.warn("SSE ping failed:", error)
+  })
+  let chunkCount = 0
+
   try {
     for await (const rawChunk of response) {
       const chunk = rawChunk as SSEMessage
@@ -513,9 +541,20 @@ async function streamChatCompletionsAndLog(params: {
         lastUsage = usage
       }
 
+      chunkCount++
+      process.stdout.write(
+        formatStreamLog({
+          model: payload.model,
+          chunks: chunkCount,
+          done: false,
+        }),
+      )
+
       logger.debug("Streaming chunk:", JSON.stringify(chunk))
       await stream.writeSSE(chunk)
     }
+
+    streamCompleted = true
   } catch (error) {
     const details = extractErrorDetails(error)
     errorName = details.errorName
@@ -523,13 +562,37 @@ async function streamChatCompletionsAndLog(params: {
     errorMessage = details.errorMessage
 
     logger.warn("Streaming error:", error)
+    try {
+      const errorEvent = {
+        error: {
+          message: details.errorMessage,
+          type: "error",
+        },
+      }
+      await stream.writeSSE({
+        event: "error",
+        data: JSON.stringify(errorEvent),
+      })
+    } catch (writeError) {
+      logger.warn("Failed to send streaming error event:", writeError)
+    }
   } finally {
+    clearInterval(pingInterval)
     const finishedAtMs = Date.now()
 
-    await accountsManager.finalizeQuota(account, reservation)
+    await finalizeQuotaSafely(account, reservation)
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
+
+    const finalErrorName =
+      pingFailed.value && !errorName && !streamCompleted ?
+        "PingFailed"
+      : errorName
+    const finalErrorMessage =
+      pingFailed.value && !errorName && !streamCompleted ?
+        "SSE ping failed"
+      : errorMessage
 
     insertRequestLog(store, request, {
       finishedAtMs,
@@ -551,11 +614,21 @@ async function streamChatCompletionsAndLog(params: {
       ),
       premiumUnlimitedBefore,
       premiumUnlimitedAfter,
-      httpStatus: errorStatus ?? (errorName ? 500 : 200),
-      errorName,
+      httpStatus: errorStatus ?? (finalErrorName ? 500 : 200),
+      errorName: finalErrorName,
       errorStatus,
-      errorMessage,
+      errorMessage: finalErrorMessage,
     })
+
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model: payload.model,
+        chunks: chunkCount,
+        done: !finalErrorName,
+        premium,
+      })}\n`,
+    )
   }
 }
 
@@ -626,6 +699,15 @@ async function handleNonStreamingRequest(params: {
     usage = normalizeChatCompletionsUsage(response.usage)
 
     logger.debug("Non-streaming response:", JSON.stringify(response))
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model: payload.model,
+        chunks: 0,
+        done: true,
+        premium,
+      })}\n`,
+    )
     return c.json(response)
   } catch (error) {
     finishedAtMs = Date.now()
@@ -645,7 +727,7 @@ async function handleNonStreamingRequest(params: {
   } finally {
     const finishedAtMsFinal = finishedAtMs ?? Date.now()
 
-    await accountsManager.finalizeQuota(account, reservation)
+    await finalizeQuotaSafely(account, reservation)
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -620,7 +620,7 @@ async function streamChatCompletionsAndLog(params: {
       errorMessage: finalErrorMessage,
     })
 
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(account)
     process.stdout.write(
       `${formatStreamLog({
         model: payload.model,
@@ -699,7 +699,7 @@ async function handleNonStreamingRequest(params: {
     usage = normalizeChatCompletionsUsage(response.usage)
 
     logger.debug("Non-streaming response:", JSON.stringify(response))
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(account)
     process.stdout.write(
       `${formatStreamLog({
         model: payload.model,

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -209,9 +209,11 @@ async function runEmbeddingsWithAccount({
   } finally {
     const finishedAtMsFinal = finishedAtMs ?? Date.now()
 
+    let finalizeOk = true
     try {
       await accountsManager.finalizeQuota(account, reservation)
     } catch (error) {
+      finalizeOk = false
       consola.warn("Failed to finalize quota:", error)
     }
 
@@ -239,10 +241,10 @@ async function runEmbeddingsWithAccount({
         ...usage,
         premiumRemainingBefore,
         premiumRemainingAfter,
-        premiumRemainingDiff: computeDiff(
-          premiumRemainingBefore,
-          premiumRemainingAfter,
-        ),
+        premiumRemainingDiff:
+          finalizeOk ?
+            computeDiff(premiumRemainingBefore, premiumRemainingAfter)
+          : undefined,
         premiumUnlimitedBefore,
         premiumUnlimitedAfter,
         httpStatus,

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -1,3 +1,4 @@
+import consola from "consola"
 import { Hono, type Context } from "hono"
 import { randomUUID } from "node:crypto"
 
@@ -208,41 +209,49 @@ async function runEmbeddingsWithAccount({
   } finally {
     const finishedAtMsFinal = finishedAtMs ?? Date.now()
 
-    await accountsManager.finalizeQuota(account, reservation)
+    try {
+      await accountsManager.finalizeQuota(account, reservation)
+    } catch (error) {
+      consola.warn("Failed to finalize quota:", error)
+    }
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
 
-    store.insert({
-      requestId: ctx.requestId,
-      startedAtMs: ctx.startedAtMs,
-      finishedAtMs: finishedAtMsFinal,
-      durationMs: finishedAtMsFinal - ctx.startedAtMs,
-      method: ctx.method,
-      path: ctx.path,
-      upstreamEndpoint: endpoint,
-      stream: false,
-      accountId: account.id,
-      accountType: account.accountType,
-      costUnits,
-      clientModel: payload.model,
-      upstreamModel: selectedModel.id,
-      clientIp: ctx.clientIp,
-      clientIpSource: ctx.clientIpSource,
-      userAgent: ctx.userAgent,
-      ...usage,
-      premiumRemainingBefore,
-      premiumRemainingAfter,
-      premiumRemainingDiff: computeDiff(
+    try {
+      store.insert({
+        requestId: ctx.requestId,
+        startedAtMs: ctx.startedAtMs,
+        finishedAtMs: finishedAtMsFinal,
+        durationMs: finishedAtMsFinal - ctx.startedAtMs,
+        method: ctx.method,
+        path: ctx.path,
+        upstreamEndpoint: endpoint,
+        stream: false,
+        accountId: account.id,
+        accountType: account.accountType,
+        costUnits,
+        clientModel: payload.model,
+        upstreamModel: selectedModel.id,
+        clientIp: ctx.clientIp,
+        clientIpSource: ctx.clientIpSource,
+        userAgent: ctx.userAgent,
+        ...usage,
         premiumRemainingBefore,
         premiumRemainingAfter,
-      ),
-      premiumUnlimitedBefore,
-      premiumUnlimitedAfter,
-      httpStatus,
-      errorName,
-      errorStatus,
-      errorMessage,
-    })
+        premiumRemainingDiff: computeDiff(
+          premiumRemainingBefore,
+          premiumRemainingAfter,
+        ),
+        premiumUnlimitedBefore,
+        premiumUnlimitedAfter,
+        httpStatus,
+        errorName,
+        errorStatus,
+        errorMessage,
+      })
+    } catch (error) {
+      consola.warn("Failed to write request log:", error)
+    }
   }
 }

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -341,24 +341,7 @@ type ChatCompletionsResult = Awaited<ReturnType<typeof createChatCompletions>>
 
 function insertRequestLog(
   instr: InstrumentationContext,
-  record: Omit<
-    RequestLogInsert,
-    | "requestId"
-    | "startedAtMs"
-    | "method"
-    | "path"
-    | "clientIp"
-    | "clientIpSource"
-    | "userAgent"
-    | "clientModel"
-    | "upstreamEndpoint"
-    | "accountId"
-    | "accountType"
-    | "costUnits"
-    | "upstreamModel"
-    | "premiumRemainingBefore"
-    | "premiumUnlimitedBefore"
-  >,
+  record: Record<string, unknown>,
 ): void {
   const {
     store,
@@ -396,7 +379,7 @@ function insertRequestLog(
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       ...record,
-    })
+    } as RequestLogInsert)
   } catch (error) {
     logger.warn("Failed to write request log:", error)
   }

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -13,11 +13,14 @@ import {
   extractErrorDetails,
   toAccountContext,
 } from "~/lib/handler-utils"
-import { createHandlerLogger } from "~/lib/logger"
+import {
+  createHandlerLogger,
+  formatStreamLog,
+  getPremiumInfo,
+} from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
   extractResponsesUsageFromResult,
-  extractResponsesUsageFromStreamEvent,
   getClientIpInfo,
   getRequestHistoryStore,
   normalizeChatCompletionsUsage,
@@ -25,38 +28,27 @@ import {
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
 import {
-  buildErrorEvent,
-  createResponsesStreamState,
-  translateResponsesStreamEvent,
-} from "~/routes/messages/responses-stream-translation"
-import {
   translateAnthropicMessagesToResponsesPayload,
   translateResponsesResultToAnthropic,
 } from "~/routes/messages/responses-translation"
+import { mergeToolResultForClaude } from "~/routes/messages/tool-result-merge"
 import { getResponsesRequestOptions } from "~/routes/responses/utils"
 import {
   createChatCompletions,
-  type ChatCompletionChunk,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
 import {
   createResponses,
   type ResponsesResult,
-  type ResponseStreamEvent,
 } from "~/services/copilot/create-responses"
 
-import {
-  type AnthropicMessagesPayload,
-  type AnthropicStreamState,
-  type AnthropicTextBlock,
-  type AnthropicToolResultBlock,
-} from "./anthropic-types"
+import { type AnthropicMessagesPayload } from "./anthropic-types"
 import {
   translateToAnthropic,
   translateToOpenAI,
 } from "./non-stream-translation"
-import { translateChunkToAnthropicEvents } from "./stream-translation"
+import { streamChatCompletionsAndLog, streamResponsesAndLog } from "./streaming"
 
 const logger = createHandlerLogger("messages-handler")
 
@@ -264,6 +256,7 @@ const handleWithChatCompletions = async (
       c,
       response,
       instr,
+      model: openAIPayload.model,
     })
   }
 
@@ -274,6 +267,10 @@ const handleWithChatCompletions = async (
       stream,
       response,
       instr,
+      model: openAIPayload.model,
+      logger,
+      insertRequestLog,
+      finalizeQuotaAndGetPremiumSnapshot,
     }),
   )
 }
@@ -320,6 +317,10 @@ const handleWithResponsesApi = async (
         stream,
         response,
         instr,
+        model: responsesPayload.model,
+        logger,
+        insertRequestLog,
+        finalizeQuotaAndGetPremiumSnapshot,
       }),
     )
   }
@@ -328,6 +329,7 @@ const handleWithResponsesApi = async (
     c,
     result: response as ResponsesResult,
     instr,
+    model: responsesPayload.model,
   })
 }
 
@@ -335,14 +337,7 @@ type Store = ReturnType<typeof getRequestHistoryStore>
 
 type RequestLogInsert = Parameters<Store["insert"]>[0]
 
-type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
-
 type ChatCompletionsResult = Awaited<ReturnType<typeof createChatCompletions>>
-
-type ChatCompletionsStream = Exclude<
-  ChatCompletionsResult,
-  ChatCompletionResponse
->
 
 function insertRequestLog(
   instr: InstrumentationContext,
@@ -383,24 +378,28 @@ function insertRequestLog(
     premiumUnlimitedBefore,
   } = instr
 
-  store.insert({
-    requestId,
-    startedAtMs,
-    method,
-    path,
-    clientIp,
-    clientIpSource,
-    userAgent,
-    clientModel,
-    upstreamEndpoint,
-    accountId: account.id,
-    accountType: account.accountType,
-    costUnits,
-    upstreamModel,
-    premiumRemainingBefore,
-    premiumUnlimitedBefore,
-    ...record,
-  })
+  try {
+    store.insert({
+      requestId,
+      startedAtMs,
+      method,
+      path,
+      clientIp,
+      clientIpSource,
+      userAgent,
+      clientModel,
+      upstreamEndpoint,
+      accountId: account.id,
+      accountType: account.accountType,
+      costUnits,
+      upstreamModel,
+      premiumRemainingBefore,
+      premiumUnlimitedBefore,
+      ...record,
+    })
+  } catch (error) {
+    logger.warn("Failed to write request log:", error)
+  }
 }
 
 async function finalizeQuotaAndGetPremiumSnapshot(
@@ -410,7 +409,11 @@ async function finalizeQuotaAndGetPremiumSnapshot(
   premiumUnlimitedAfter: boolean | undefined
   premiumRemainingDiff: number | undefined
 }> {
-  await accountsManager.finalizeQuota(instr.account, instr.reservation)
+  try {
+    await accountsManager.finalizeQuota(instr.account, instr.reservation)
+  } catch (error) {
+    logger.warn("Failed to finalize quota:", error)
+  }
 
   const premiumRemainingAfter = instr.account.premiumRemaining
   const premiumUnlimitedAfter = instr.account.unlimited
@@ -462,8 +465,9 @@ async function handleChatCompletionsNonStreaming(params: {
   c: Context
   response: ChatCompletionResponse
   instr: InstrumentationContext
+  model: string
 }): Promise<Response> {
-  const { c, response, instr } = params
+  const { c, response, instr, model } = params
 
   let httpStatus = 200
   const usage: NormalizedUsage = normalizeChatCompletionsUsage(response.usage)
@@ -486,6 +490,15 @@ async function handleChatCompletionsNonStreaming(params: {
       JSON.stringify(anthropicResponse),
     )
 
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model,
+        chunks: 0,
+        done: true,
+        premium,
+      })}\n`,
+    )
     return c.json(anthropicResponse)
   } catch (error) {
     const details = extractErrorDetails(error)
@@ -517,102 +530,6 @@ async function handleChatCompletionsNonStreaming(params: {
       premiumUnlimitedAfter,
       premiumRemainingDiff,
       httpStatus,
-      errorName,
-      errorStatus,
-      errorMessage,
-    })
-  }
-}
-
-async function streamChatCompletionsAndLog(params: {
-  stream: StreamSseStream
-  response: ChatCompletionsStream
-  instr: InstrumentationContext
-}): Promise<void> {
-  const { stream, response, instr } = params
-
-  let ttfbMs: number | undefined
-  let lastUsage: NormalizedUsage = {}
-
-  let errorName: string | undefined
-  let errorStatus: number | undefined
-  let errorMessage: string | undefined
-
-  const streamState: AnthropicStreamState = {
-    messageStartSent: false,
-    contentBlockIndex: 0,
-    contentBlockOpen: false,
-    toolCalls: {},
-    thinkingBlockOpen: false,
-  }
-
-  try {
-    for await (const rawEvent of response) {
-      if (ttfbMs === undefined) {
-        ttfbMs = Date.now() - instr.startedAtMs
-      }
-
-      logger.debug("Copilot raw stream event:", JSON.stringify(rawEvent))
-
-      const { data: rawData } = rawEvent as {
-        data?: string | Promise<string>
-      }
-      const data = typeof rawData === "string" ? rawData : await rawData
-
-      if (data === "[DONE]") {
-        break
-      }
-
-      if (!data) {
-        continue
-      }
-
-      const chunk = JSON.parse(data) as ChatCompletionChunk
-      if (chunk.usage) {
-        lastUsage = normalizeChatCompletionsUsage(chunk.usage)
-      }
-
-      const events = translateChunkToAnthropicEvents(chunk, streamState)
-      for (const event of events) {
-        logger.debug("Translated Anthropic event:", JSON.stringify(event))
-
-        await stream.writeSSE({
-          event: event.type,
-          data: JSON.stringify(event),
-        })
-      }
-    }
-  } catch (error) {
-    const details = extractErrorDetails(error)
-
-    errorName = details.errorName
-    errorStatus = details.errorStatus
-    errorMessage = details.errorMessage
-
-    logger.warn("Streaming error:", error)
-
-    if (details.unauthorized) {
-      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
-    }
-  } finally {
-    const finishedAtMs = Date.now()
-
-    const {
-      premiumRemainingAfter,
-      premiumUnlimitedAfter,
-      premiumRemainingDiff,
-    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
-
-    insertRequestLog(instr, {
-      finishedAtMs,
-      durationMs: finishedAtMs - instr.startedAtMs,
-      ttfbMs,
-      stream: true,
-      ...lastUsage,
-      premiumRemainingAfter,
-      premiumUnlimitedAfter,
-      premiumRemainingDiff,
-      httpStatus: errorStatus ?? (errorName ? 500 : 200),
       errorName,
       errorStatus,
       errorMessage,
@@ -657,8 +574,9 @@ async function handleResponsesNonStreaming(params: {
   c: Context
   result: ResponsesResult
   instr: InstrumentationContext
+  model: string
 }): Promise<Response> {
-  const { c, result, instr } = params
+  const { c, result, instr, model } = params
 
   let httpStatus = 200
   let usage: NormalizedUsage = {}
@@ -683,6 +601,15 @@ async function handleResponsesNonStreaming(params: {
       JSON.stringify(anthropicResponse),
     )
 
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model,
+        chunks: 0,
+        done: true,
+        premium,
+      })}\n`,
+    )
     return c.json(anthropicResponse)
   } catch (error) {
     const details = extractErrorDetails(error)
@@ -721,133 +648,6 @@ async function handleResponsesNonStreaming(params: {
   }
 }
 
-async function ensureResponsesStreamCompleted(params: {
-  stream: StreamSseStream
-  streamState: ReturnType<typeof createResponsesStreamState>
-  setStreamError: (name: string, message: string) => void
-}): Promise<void> {
-  const { stream, streamState, setStreamError } = params
-
-  if (streamState.messageCompleted) {
-    return
-  }
-
-  logger.warn("Responses stream ended without completion; sending error event")
-
-  const msg = "Responses stream ended without completion"
-  const errorEvent = buildErrorEvent(msg)
-
-  setStreamError("StreamIncomplete", msg)
-
-  await stream.writeSSE({
-    event: errorEvent.type,
-    data: JSON.stringify(errorEvent),
-  })
-}
-
-async function streamResponsesAndLog(params: {
-  stream: StreamSseStream
-  response: AsyncIterable<unknown>
-  instr: InstrumentationContext
-}): Promise<void> {
-  const { stream, response, instr } = params
-
-  let ttfbMs: number | undefined
-  let lastUsage: NormalizedUsage = {}
-
-  let errorName: string | undefined
-  let errorStatus: number | undefined
-  let errorMessage: string | undefined
-
-  const streamState = createResponsesStreamState()
-
-  try {
-    for await (const chunk of response) {
-      if (ttfbMs === undefined) {
-        ttfbMs = Date.now() - instr.startedAtMs
-      }
-
-      const eventName = (chunk as { event?: string }).event
-      if (eventName === "ping") {
-        await stream.writeSSE({ event: "ping", data: "" })
-        continue
-      }
-
-      const data = (chunk as { data?: string }).data
-      if (!data) {
-        continue
-      }
-
-      logger.debug("Responses raw stream event:", data)
-
-      const parsed = JSON.parse(data) as ResponseStreamEvent
-      const u = extractResponsesUsageFromStreamEvent(parsed)
-      if (u.usageJson) {
-        lastUsage = u
-      }
-
-      const events = translateResponsesStreamEvent(parsed, streamState)
-      for (const event of events) {
-        const eventData = JSON.stringify(event)
-        logger.debug("Translated Anthropic event:", eventData)
-        await stream.writeSSE({
-          event: event.type,
-          data: eventData,
-        })
-      }
-
-      if (streamState.messageCompleted) {
-        logger.debug("Message completed, ending stream")
-        break
-      }
-    }
-
-    await ensureResponsesStreamCompleted({
-      stream,
-      streamState,
-      setStreamError: (name, message) => {
-        errorName = name
-        errorMessage = message
-      },
-    })
-  } catch (error) {
-    const details = extractErrorDetails(error)
-
-    errorName = details.errorName
-    errorStatus = details.errorStatus
-    errorMessage = details.errorMessage
-
-    logger.warn("Streaming error:", error)
-
-    if (details.unauthorized) {
-      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
-    }
-  } finally {
-    const finishedAtMs = Date.now()
-
-    const {
-      premiumRemainingAfter,
-      premiumUnlimitedAfter,
-      premiumRemainingDiff,
-    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
-
-    insertRequestLog(instr, {
-      finishedAtMs,
-      durationMs: finishedAtMs - instr.startedAtMs,
-      ttfbMs,
-      stream: true,
-      ...lastUsage,
-      premiumRemainingAfter,
-      premiumUnlimitedAfter,
-      premiumRemainingDiff,
-      httpStatus: errorStatus ?? (errorName ? 500 : 200),
-      errorName,
-      errorStatus,
-      errorMessage,
-    })
-  }
-}
-
 const isNonStreaming = (
   response: Awaited<ReturnType<typeof createChatCompletions>>,
 ): response is ChatCompletionResponse => Object.hasOwn(response, "choices")
@@ -855,73 +655,3 @@ const isNonStreaming = (
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
   Boolean(value)
   && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
-
-const mergeContentWithText = (
-  tr: AnthropicToolResultBlock,
-  textBlock: AnthropicTextBlock,
-): AnthropicToolResultBlock => {
-  if (typeof tr.content === "string") {
-    return { ...tr, content: `${tr.content}\n\n${textBlock.text}` }
-  }
-  return {
-    ...tr,
-    content: [...tr.content, textBlock],
-  }
-}
-
-const mergeContentWithTexts = (
-  tr: AnthropicToolResultBlock,
-  textBlocks: Array<AnthropicTextBlock>,
-): AnthropicToolResultBlock => {
-  if (typeof tr.content === "string") {
-    const appendedTexts = textBlocks.map((tb) => tb.text).join("\n\n")
-    return { ...tr, content: `${tr.content}\n\n${appendedTexts}` }
-  }
-  return { ...tr, content: [...tr.content, ...textBlocks] }
-}
-
-const mergeToolResultForClaude = (
-  anthropicBeta: string | undefined,
-  anthropicPayload: AnthropicMessagesPayload,
-): void => {
-  if (!anthropicBeta) return
-
-  for (const msg of anthropicPayload.messages) {
-    if (msg.role !== "user" || !Array.isArray(msg.content)) continue
-
-    const toolResults: Array<AnthropicToolResultBlock> = []
-    const textBlocks: Array<AnthropicTextBlock> = []
-    let valid = true
-
-    for (const block of msg.content) {
-      if (block.type === "tool_result") {
-        toolResults.push(block)
-      } else if (block.type === "text") {
-        textBlocks.push(block)
-      } else {
-        valid = false
-        break
-      }
-    }
-
-    if (!valid || toolResults.length === 0 || textBlocks.length === 0) continue
-
-    msg.content = mergeToolResult(toolResults, textBlocks)
-  }
-}
-
-const mergeToolResult = (
-  toolResults: Array<AnthropicToolResultBlock>,
-  textBlocks: Array<AnthropicTextBlock>,
-): Array<AnthropicToolResultBlock> => {
-  // equal lengths -> pairwise merge
-  if (toolResults.length === textBlocks.length) {
-    return toolResults.map((tr, i) => mergeContentWithText(tr, textBlocks[i]))
-  }
-
-  // lengths differ -> append all textBlocks to the last tool_result
-  const lastIndex = toolResults.length - 1
-  return toolResults.map((tr, i) =>
-    i === lastIndex ? mergeContentWithTexts(tr, textBlocks) : tr,
-  )
-}

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -490,7 +490,7 @@ async function handleChatCompletionsNonStreaming(params: {
       JSON.stringify(anthropicResponse),
     )
 
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(instr.account)
     process.stdout.write(
       `${formatStreamLog({
         model,
@@ -601,7 +601,7 @@ async function handleResponsesNonStreaming(params: {
       JSON.stringify(anthropicResponse),
     )
 
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(instr.account)
     process.stdout.write(
       `${formatStreamLog({
         model,

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -27,10 +27,19 @@ import {
   type NormalizedUsage,
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
+import { type AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+import {
+  translateToAnthropic,
+  translateToOpenAI,
+} from "~/routes/messages/non-stream-translation"
 import {
   translateAnthropicMessagesToResponsesPayload,
   translateResponsesResultToAnthropic,
 } from "~/routes/messages/responses-translation"
+import {
+  streamChatCompletionsAndLog,
+  streamResponsesAndLog,
+} from "~/routes/messages/streaming"
 import { mergeToolResultForClaude } from "~/routes/messages/tool-result-merge"
 import { getResponsesRequestOptions } from "~/routes/responses/utils"
 import {
@@ -42,13 +51,6 @@ import {
   createResponses,
   type ResponsesResult,
 } from "~/services/copilot/create-responses"
-
-import { type AnthropicMessagesPayload } from "./anthropic-types"
-import {
-  translateToAnthropic,
-  translateToOpenAI,
-} from "./non-stream-translation"
-import { streamChatCompletionsAndLog, streamResponsesAndLog } from "./streaming"
 
 const logger = createHandlerLogger("messages-handler")
 
@@ -392,9 +394,11 @@ async function finalizeQuotaAndGetPremiumSnapshot(
   premiumUnlimitedAfter: boolean | undefined
   premiumRemainingDiff: number | undefined
 }> {
+  let finalized = true
   try {
     await accountsManager.finalizeQuota(instr.account, instr.reservation)
   } catch (error) {
+    finalized = false
     logger.warn("Failed to finalize quota:", error)
   }
 
@@ -404,10 +408,10 @@ async function finalizeQuotaAndGetPremiumSnapshot(
   return {
     premiumRemainingAfter,
     premiumUnlimitedAfter,
-    premiumRemainingDiff: computeDiff(
-      instr.premiumRemainingBefore,
-      premiumRemainingAfter,
-    ),
+    premiumRemainingDiff:
+      finalized ?
+        computeDiff(instr.premiumRemainingBefore, premiumRemainingAfter)
+      : undefined,
   }
 }
 

--- a/src/routes/messages/streaming.ts
+++ b/src/routes/messages/streaming.ts
@@ -244,7 +244,7 @@ export async function streamChatCompletionsAndLog(params: {
       errorMessage: finalError.errorMessage,
     })
 
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(instr.account)
     process.stdout.write(
       `${formatStreamLog({
         model,
@@ -406,7 +406,7 @@ export async function streamResponsesAndLog(params: {
       errorMessage: finalError.errorMessage,
     })
 
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(instr.account)
     process.stdout.write(
       `${formatStreamLog({
         model,

--- a/src/routes/messages/streaming.ts
+++ b/src/routes/messages/streaming.ts
@@ -67,7 +67,7 @@ export type InstrumentationContext = {
 
 export type InsertRequestLog = (
   instr: InstrumentationContext,
-  record: object,
+  record: Record<string, unknown>,
 ) => void
 
 export type FinalizeQuotaAndGetPremiumSnapshot = (

--- a/src/routes/messages/streaming.ts
+++ b/src/routes/messages/streaming.ts
@@ -1,0 +1,413 @@
+import type { ConsolaInstance } from "consola"
+
+import { streamSSE } from "hono/streaming"
+
+import type { AnthropicStreamState } from "~/routes/messages/anthropic-types"
+import type {
+  ChatCompletionChunk,
+  ChatCompletionResponse,
+} from "~/services/copilot/create-chat-completions"
+import type { ResponseStreamEvent } from "~/services/copilot/create-responses"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { extractErrorDetails } from "~/lib/handler-utils"
+import { formatStreamLog, getPremiumInfo } from "~/lib/logger"
+import {
+  extractResponsesUsageFromStreamEvent,
+  normalizeChatCompletionsUsage,
+  type NormalizedUsage,
+} from "~/lib/request-history"
+import { setupPingInterval } from "~/lib/utils"
+import {
+  buildErrorEvent,
+  createResponsesStreamState,
+  translateResponsesStreamEvent,
+} from "~/routes/messages/responses-stream-translation"
+import { translateChunkToAnthropicEvents } from "~/routes/messages/stream-translation"
+
+type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
+
+type ChatCompletionsResult = Awaited<
+  ReturnType<
+    typeof import("~/services/copilot/create-chat-completions").createChatCompletions
+  >
+>
+
+type ChatCompletionsStream = Exclude<
+  ChatCompletionsResult,
+  ChatCompletionResponse
+>
+
+export type InstrumentationContext = {
+  store: ReturnType<
+    typeof import("~/lib/request-history").getRequestHistoryStore
+  >
+  requestId: string
+  startedAtMs: number
+  method: string
+  path: string
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+  clientModel: string
+  account: import("~/lib/types/account").AccountRuntime
+  reservation: unknown
+  upstreamModel: string
+  upstreamEndpoint: string
+  costUnits: number
+  premiumRemainingBefore?: number
+  premiumUnlimitedBefore?: boolean
+}
+
+export type InsertRequestLog = (
+  instr: InstrumentationContext,
+  record: Record<string, unknown>,
+) => void
+
+export type FinalizeQuotaAndGetPremiumSnapshot = (
+  instr: InstrumentationContext,
+) => Promise<{
+  premiumRemainingAfter: number | undefined
+  premiumUnlimitedAfter: boolean | undefined
+  premiumRemainingDiff: number | undefined
+}>
+
+const writeStreamProgress = (model: string, chunkCount: number) =>
+  process.stdout.write(
+    formatStreamLog({ model, chunks: chunkCount, done: false }),
+  )
+
+const sendStreamErrorEvent = async (
+  stream: StreamSseStream,
+  message: string,
+  logger: ConsolaInstance,
+) => {
+  try {
+    const errorEvent = buildErrorEvent(message)
+    await stream.writeSSE({
+      event: errorEvent.type,
+      data: JSON.stringify(errorEvent),
+    })
+  } catch (error) {
+    logger.warn("Failed to send streaming error event:", error)
+  }
+}
+
+const getStreamErrorDetails = (error: unknown) => {
+  const details = extractErrorDetails(error)
+  return {
+    errorName: details.errorName,
+    errorStatus: details.errorStatus,
+    errorMessage: details.errorMessage,
+    unauthorized: details.unauthorized,
+  }
+}
+
+const getFinalStreamError = (params: {
+  pingFailed: boolean
+  streamCompleted: boolean
+  errorName: string | undefined
+  errorMessage: string | undefined
+}) => {
+  const { pingFailed, streamCompleted, errorName, errorMessage } = params
+  if (pingFailed && !errorName && !streamCompleted) {
+    return { errorName: "PingFailed", errorMessage: "SSE ping failed" }
+  }
+  return { errorName, errorMessage }
+}
+
+// eslint-disable-next-line max-lines-per-function
+export async function streamChatCompletionsAndLog(params: {
+  stream: StreamSseStream
+  response: ChatCompletionsStream
+  instr: InstrumentationContext
+  model: string
+  logger: ConsolaInstance
+  insertRequestLog: InsertRequestLog
+  finalizeQuotaAndGetPremiumSnapshot: FinalizeQuotaAndGetPremiumSnapshot
+}): Promise<void> {
+  const {
+    stream,
+    response,
+    instr,
+    model,
+    logger,
+    insertRequestLog,
+    finalizeQuotaAndGetPremiumSnapshot,
+  } = params
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const streamState: AnthropicStreamState = {
+    messageStartSent: false,
+    contentBlockIndex: 0,
+    contentBlockOpen: false,
+    toolCalls: {},
+    thinkingBlockOpen: false,
+  }
+
+  const pingFailed = { value: false }
+  let streamCompleted = false
+  const pingInterval = setupPingInterval(stream, 3000, (error) => {
+    pingFailed.value = true
+    logger.warn("SSE ping failed:", error)
+  })
+  let chunkCount = 0
+
+  try {
+    for await (const rawEvent of response) {
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - instr.startedAtMs
+      }
+
+      logger.debug("Copilot raw stream event:", JSON.stringify(rawEvent))
+
+      const { data: rawData } = rawEvent as {
+        data?: string | Promise<string>
+      }
+      const data = typeof rawData === "string" ? rawData : await rawData
+
+      if (data === "[DONE]") break
+      if (!data) continue
+
+      chunkCount += 1
+      writeStreamProgress(model, chunkCount)
+
+      const chunk = JSON.parse(data) as ChatCompletionChunk
+      if (chunk.usage) {
+        lastUsage = normalizeChatCompletionsUsage(chunk.usage)
+      }
+
+      const events = translateChunkToAnthropicEvents(chunk, streamState)
+      for (const event of events) {
+        logger.debug("Translated Anthropic event:", JSON.stringify(event))
+        await stream.writeSSE({
+          event: event.type,
+          data: JSON.stringify(event),
+        })
+      }
+    }
+
+    streamCompleted = true
+  } catch (error) {
+    const details = getStreamErrorDetails(error)
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Streaming error:", error)
+    await sendStreamErrorEvent(stream, details.errorMessage, logger)
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+  } finally {
+    clearInterval(pingInterval)
+    const finishedAtMs = Date.now()
+
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    const finalError = getFinalStreamError({
+      pingFailed: pingFailed.value,
+      streamCompleted,
+      errorName,
+      errorMessage,
+    })
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      ttfbMs,
+      stream: true,
+      ...lastUsage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus: errorStatus ?? (finalError.errorName ? 500 : 200),
+      errorName: finalError.errorName,
+      errorStatus,
+      errorMessage: finalError.errorMessage,
+    })
+
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model,
+        chunks: chunkCount,
+        done: !finalError.errorName,
+        premium,
+      })}\n`,
+    )
+  }
+}
+
+const ensureResponsesStreamCompleted = async (params: {
+  stream: StreamSseStream
+  streamState: ReturnType<typeof createResponsesStreamState>
+  setStreamError: (name: string, message: string) => void
+}): Promise<void> => {
+  const { stream, streamState, setStreamError } = params
+
+  if (streamState.messageCompleted) return
+
+  const msg = "Responses stream ended without completion"
+  const errorEvent = buildErrorEvent(msg)
+
+  setStreamError("StreamIncomplete", msg)
+
+  await stream.writeSSE({
+    event: errorEvent.type,
+    data: JSON.stringify(errorEvent),
+  })
+}
+
+// eslint-disable-next-line max-lines-per-function
+export async function streamResponsesAndLog(params: {
+  stream: StreamSseStream
+  response: AsyncIterable<unknown>
+  instr: InstrumentationContext
+  model: string
+  logger: ConsolaInstance
+  insertRequestLog: InsertRequestLog
+  finalizeQuotaAndGetPremiumSnapshot: FinalizeQuotaAndGetPremiumSnapshot
+}): Promise<void> {
+  const {
+    stream,
+    response,
+    instr,
+    model,
+    logger,
+    insertRequestLog,
+    finalizeQuotaAndGetPremiumSnapshot,
+  } = params
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const streamState = createResponsesStreamState()
+
+  const pingFailed = { value: false }
+  let streamCompleted = false
+  const pingInterval = setupPingInterval(stream, 3000, (error) => {
+    pingFailed.value = true
+    logger.warn("SSE ping failed:", error)
+  })
+  let chunkCount = 0
+
+  try {
+    for await (const chunk of response) {
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - instr.startedAtMs
+      }
+
+      const eventName = (chunk as { event?: string }).event
+      if (eventName === "ping") {
+        await stream.writeSSE({ event: "ping", data: "" })
+        continue
+      }
+
+      const data = (chunk as { data?: string }).data
+      if (!data) continue
+
+      chunkCount += 1
+      writeStreamProgress(model, chunkCount)
+
+      logger.debug("Responses raw stream event:", data)
+
+      const parsed = JSON.parse(data) as ResponseStreamEvent
+      const usage = extractResponsesUsageFromStreamEvent(parsed)
+      if (usage.usageJson) {
+        lastUsage = usage
+      }
+
+      const events = translateResponsesStreamEvent(parsed, streamState)
+      for (const event of events) {
+        const eventData = JSON.stringify(event)
+        logger.debug("Translated Anthropic event:", eventData)
+        await stream.writeSSE({
+          event: event.type,
+          data: eventData,
+        })
+      }
+
+      if (streamState.messageCompleted) break
+    }
+
+    await ensureResponsesStreamCompleted({
+      stream,
+      streamState,
+      setStreamError: (name, message) => {
+        errorName = name
+        errorMessage = message
+      },
+    })
+
+    streamCompleted = streamState.messageCompleted && !errorName
+  } catch (error) {
+    const details = getStreamErrorDetails(error)
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Streaming error:", error)
+    await sendStreamErrorEvent(stream, details.errorMessage, logger)
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+  } finally {
+    clearInterval(pingInterval)
+    const finishedAtMs = Date.now()
+
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    const finalError = getFinalStreamError({
+      pingFailed: pingFailed.value,
+      streamCompleted,
+      errorName,
+      errorMessage,
+    })
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      ttfbMs,
+      stream: true,
+      ...lastUsage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus: errorStatus ?? (finalError.errorName ? 500 : 200),
+      errorName: finalError.errorName,
+      errorStatus,
+      errorMessage: finalError.errorMessage,
+    })
+
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model,
+        chunks: chunkCount,
+        done: !finalError.errorName,
+        premium,
+      })}\n`,
+    )
+  }
+}

--- a/src/routes/messages/streaming.ts
+++ b/src/routes/messages/streaming.ts
@@ -38,6 +38,12 @@ type ChatCompletionsStream = Exclude<
   ChatCompletionResponse
 >
 
+type AccountSelection = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+
+type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
+
 export type InstrumentationContext = {
   store: ReturnType<
     typeof import("~/lib/request-history").getRequestHistoryStore
@@ -51,7 +57,7 @@ export type InstrumentationContext = {
   userAgent?: string
   clientModel: string
   account: import("~/lib/types/account").AccountRuntime
-  reservation: unknown
+  reservation: AccountSelectionOk["reservation"]
   upstreamModel: string
   upstreamEndpoint: string
   costUnits: number

--- a/src/routes/messages/streaming.ts
+++ b/src/routes/messages/streaming.ts
@@ -67,7 +67,7 @@ export type InstrumentationContext = {
 
 export type InsertRequestLog = (
   instr: InstrumentationContext,
-  record: Record<string, unknown>,
+  record: object,
 ) => void
 
 export type FinalizeQuotaAndGetPremiumSnapshot = (

--- a/src/routes/messages/tool-result-merge.ts
+++ b/src/routes/messages/tool-result-merge.ts
@@ -2,7 +2,7 @@ import type {
   AnthropicMessagesPayload,
   AnthropicTextBlock,
   AnthropicToolResultBlock,
-} from "./anthropic-types"
+} from "~/routes/messages/anthropic-types"
 
 /**
  * Merge a single text block into a tool_result.

--- a/src/routes/messages/tool-result-merge.ts
+++ b/src/routes/messages/tool-result-merge.ts
@@ -1,0 +1,83 @@
+import type {
+  AnthropicMessagesPayload,
+  AnthropicTextBlock,
+  AnthropicToolResultBlock,
+} from "./anthropic-types"
+
+/**
+ * Merge a single text block into a tool_result.
+ * Handles both string and array content types.
+ */
+const mergeContentWithText = (
+  tr: AnthropicToolResultBlock,
+  textBlock: AnthropicTextBlock,
+): AnthropicToolResultBlock => {
+  if (typeof tr.content === "string") {
+    return { ...tr, content: `${tr.content}\n\n${textBlock.text}` }
+  }
+  return {
+    ...tr,
+    content: [...tr.content, textBlock],
+  }
+}
+
+/**
+ * Merge multiple text blocks into a tool_result.
+ * Handles both string and array content types.
+ */
+const mergeContentWithTexts = (
+  tr: AnthropicToolResultBlock,
+  textBlocks: Array<AnthropicTextBlock>,
+): AnthropicToolResultBlock => {
+  if (typeof tr.content === "string") {
+    const appendedTexts = textBlocks.map((tb) => tb.text).join("\n\n")
+    return { ...tr, content: `${tr.content}\n\n${appendedTexts}` }
+  }
+  return { ...tr, content: [...tr.content, ...textBlocks] }
+}
+
+const mergeToolResult = (
+  toolResults: Array<AnthropicToolResultBlock>,
+  textBlocks: Array<AnthropicTextBlock>,
+): Array<AnthropicToolResultBlock> => {
+  // equal lengths -> pairwise merge
+  if (toolResults.length === textBlocks.length) {
+    return toolResults.map((tr, i) => mergeContentWithText(tr, textBlocks[i]))
+  }
+
+  // lengths differ -> append all textBlocks to the last tool_result
+  const lastIndex = toolResults.length - 1
+  return toolResults.map((tr, i) =>
+    i === lastIndex ? mergeContentWithTexts(tr, textBlocks) : tr,
+  )
+}
+
+export const mergeToolResultForClaude = (
+  anthropicBeta: string | undefined,
+  anthropicPayload: AnthropicMessagesPayload,
+): void => {
+  if (!anthropicBeta) return
+
+  for (const msg of anthropicPayload.messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue
+
+    const toolResults: Array<AnthropicToolResultBlock> = []
+    const textBlocks: Array<AnthropicTextBlock> = []
+    let valid = true
+
+    for (const block of msg.content) {
+      if (block.type === "tool_result") {
+        toolResults.push(block)
+      } else if (block.type === "text") {
+        textBlocks.push(block)
+      } else {
+        valid = false
+        break
+      }
+    }
+
+    if (!valid || toolResults.length === 0 || textBlocks.length === 0) continue
+
+    msg.content = mergeToolResult(toolResults, textBlocks)
+  }
+}

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -494,6 +494,19 @@ async function handleNonStreamingUpstreamResult(params: {
   }
 }
 
+function computeFinalStreamError(params: {
+  pingFailed: boolean
+  streamCompleted: boolean
+  errorName: string | undefined
+  errorMessage: string | undefined
+}): { errorName: string | undefined; errorMessage: string | undefined } {
+  const { pingFailed, streamCompleted, errorName, errorMessage } = params
+  if (pingFailed && !errorName && !streamCompleted) {
+    return { errorName: "PingFailed", errorMessage: "SSE ping failed" }
+  }
+  return { errorName, errorMessage }
+}
+
 // eslint-disable-next-line max-lines-per-function
 async function streamResponsesAndLog(params: {
   stream: StreamSseStream
@@ -596,14 +609,12 @@ async function streamResponsesAndLog(params: {
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
 
-    const finalErrorName =
-      pingFailed.value && !errorName && !streamCompleted ?
-        "PingFailed"
-      : errorName
-    const finalErrorMessage =
-      pingFailed.value && !errorName && !streamCompleted ?
-        "SSE ping failed"
-      : errorMessage
+    const finalError = computeFinalStreamError({
+      pingFailed: pingFailed.value,
+      streamCompleted,
+      errorName,
+      errorMessage,
+    })
 
     insertRequestLog(store, request, {
       finishedAtMs,
@@ -625,10 +636,10 @@ async function streamResponsesAndLog(params: {
       ),
       premiumUnlimitedBefore,
       premiumUnlimitedAfter,
-      httpStatus: errorStatus ?? (finalErrorName ? 500 : 200),
-      errorName: finalErrorName,
+      httpStatus: errorStatus ?? (finalError.errorName ? 500 : 200),
+      errorName: finalError.errorName,
       errorStatus,
-      errorMessage: finalErrorMessage,
+      errorMessage: finalError.errorMessage,
     })
 
     const premium = await getPremiumInfo(account)
@@ -636,7 +647,7 @@ async function streamResponsesAndLog(params: {
       `${formatStreamLog({
         model: payload.model,
         chunks: chunkCount,
-        done: !finalErrorName,
+        done: !finalError.errorName,
         premium,
       })}\n`,
     )

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -631,7 +631,7 @@ async function streamResponsesAndLog(params: {
       errorMessage: finalErrorMessage,
     })
 
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(account)
     process.stdout.write(
       `${formatStreamLog({
         model: payload.model,
@@ -709,7 +709,7 @@ async function handleNonStreamingResponses(params: {
       "Forwarding native Responses result:",
       JSON.stringify(response).slice(-400),
     )
-    const premium = await getPremiumInfo()
+    const premium = await getPremiumInfo(account)
     process.stdout.write(
       `${formatStreamLog({
         model: payload.model,

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -11,7 +11,11 @@ import {
   extractErrorDetails,
   toAccountContext,
 } from "~/lib/handler-utils"
-import { createHandlerLogger } from "~/lib/logger"
+import {
+  createHandlerLogger,
+  formatStreamLog,
+  getPremiumInfo,
+} from "~/lib/logger"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
   extractResponsesUsageFromResult,
@@ -21,6 +25,7 @@ import {
   type NormalizedUsage,
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
+import { setupPingInterval } from "~/lib/utils"
 import {
   createResponses,
   type ResponsesPayload,
@@ -167,16 +172,31 @@ function insertRequestLog(
     | "userAgent"
   >,
 ): void {
-  store.insert({
-    requestId: request.requestId,
-    startedAtMs: request.startedAtMs,
-    method: request.method,
-    path: request.path,
-    clientIp: request.clientIp,
-    clientIpSource: request.clientIpSource,
-    userAgent: request.userAgent,
-    ...record,
-  })
+  try {
+    store.insert({
+      requestId: request.requestId,
+      startedAtMs: request.startedAtMs,
+      method: request.method,
+      path: request.path,
+      clientIp: request.clientIp,
+      clientIpSource: request.clientIpSource,
+      userAgent: request.userAgent,
+      ...record,
+    })
+  } catch (error) {
+    logger.warn("Failed to write request log:", error)
+  }
+}
+
+async function finalizeQuotaSafely(
+  account: AccountSelectionOk["account"],
+  reservation: AccountSelectionOk["reservation"],
+): Promise<void> {
+  try {
+    await accountsManager.finalizeQuota(account, reservation)
+  } catch (error) {
+    logger.warn("Failed to finalize quota:", error)
+  }
 }
 
 function recordSelectionFailure(
@@ -363,7 +383,7 @@ async function handleUpstreamCreateError(params: {
     accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
   }
 
-  await accountsManager.finalizeQuota(account, reservation)
+  await finalizeQuotaSafely(account, reservation)
 
   const premiumRemainingAfter = account.premiumRemaining
   const premiumUnlimitedAfter = account.unlimited
@@ -442,7 +462,7 @@ async function handleNonStreamingUpstreamResult(params: {
 
     throw error
   } finally {
-    await accountsManager.finalizeQuota(account, reservation)
+    await finalizeQuotaSafely(account, reservation)
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
@@ -474,6 +494,7 @@ async function handleNonStreamingUpstreamResult(params: {
   }
 }
 
+// eslint-disable-next-line max-lines-per-function
 async function streamResponsesAndLog(params: {
   stream: StreamSseStream
   response: AsyncIterable<unknown>
@@ -503,6 +524,14 @@ async function streamResponsesAndLog(params: {
   let errorStatus: number | undefined
   let errorMessage: string | undefined
 
+  const pingFailed = { value: false }
+  let streamCompleted = false
+  const pingInterval = setupPingInterval(stream, 3000, (error) => {
+    pingFailed.value = true
+    logger.warn("SSE ping failed:", error)
+  })
+  let chunkCount = 0
+
   try {
     for await (const chunk of response) {
       if (ttfbMs === undefined) {
@@ -516,6 +545,17 @@ async function streamResponsesAndLog(params: {
         lastUsage = usage
       }
 
+      if (event !== "ping") {
+        chunkCount++
+        process.stdout.write(
+          formatStreamLog({
+            model: payload.model,
+            chunks: chunkCount,
+            done: false,
+          }),
+        )
+      }
+
       logger.debug("Responses stream chunk:", JSON.stringify(chunk))
 
       await stream.writeSSE({
@@ -524,6 +564,8 @@ async function streamResponsesAndLog(params: {
         data: data ?? "",
       })
     }
+
+    streamCompleted = true
   } catch (error) {
     const details = extractErrorDetails(error)
     errorName = details.errorName
@@ -531,13 +573,37 @@ async function streamResponsesAndLog(params: {
     errorMessage = details.errorMessage
 
     logger.warn("Responses streaming error:", error)
+    try {
+      const errorEvent = {
+        error: {
+          message: details.errorMessage,
+          type: "error",
+        },
+      }
+      await stream.writeSSE({
+        event: "error",
+        data: JSON.stringify(errorEvent),
+      })
+    } catch (writeError) {
+      logger.warn("Failed to send streaming error event:", writeError)
+    }
   } finally {
+    clearInterval(pingInterval)
     const finishedAtMs = Date.now()
 
-    await accountsManager.finalizeQuota(account, reservation)
+    await finalizeQuotaSafely(account, reservation)
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
+
+    const finalErrorName =
+      pingFailed.value && !errorName && !streamCompleted ?
+        "PingFailed"
+      : errorName
+    const finalErrorMessage =
+      pingFailed.value && !errorName && !streamCompleted ?
+        "SSE ping failed"
+      : errorMessage
 
     insertRequestLog(store, request, {
       finishedAtMs,
@@ -559,14 +625,25 @@ async function streamResponsesAndLog(params: {
       ),
       premiumUnlimitedBefore,
       premiumUnlimitedAfter,
-      httpStatus: errorStatus ?? (errorName ? 500 : 200),
-      errorName,
+      httpStatus: errorStatus ?? (finalErrorName ? 500 : 200),
+      errorName: finalErrorName,
       errorStatus,
-      errorMessage,
+      errorMessage: finalErrorMessage,
     })
+
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model: payload.model,
+        chunks: chunkCount,
+        done: !finalErrorName,
+        premium,
+      })}\n`,
+    )
   }
 }
 
+// eslint-disable-next-line max-lines-per-function
 async function handleNonStreamingResponses(params: {
   c: Context
   store: Store
@@ -632,6 +709,15 @@ async function handleNonStreamingResponses(params: {
       "Forwarding native Responses result:",
       JSON.stringify(response).slice(-400),
     )
+    const premium = await getPremiumInfo()
+    process.stdout.write(
+      `${formatStreamLog({
+        model: payload.model,
+        chunks: 0,
+        done: true,
+        premium,
+      })}\n`,
+    )
     return c.json(response)
   } catch (error) {
     finishedAtMs = Date.now()
@@ -651,7 +737,7 @@ async function handleNonStreamingResponses(params: {
   } finally {
     const finishedAtMsFinal = finishedAtMs ?? Date.now()
 
-    await accountsManager.finalizeQuota(account, reservation)
+    await finalizeQuotaSafely(account, reservation)
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -12,7 +12,9 @@ const getPayloadItems = (
 
   const { input } = payload
 
-  if (Array.isArray(input)) {
+  if (typeof input === "string") {
+    result.push({ role: "user", content: input })
+  } else if (Array.isArray(input)) {
     result.push(...input)
   }
 

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -3,33 +3,7 @@ import type {
   ResponsesPayload,
 } from "~/services/copilot/create-responses"
 
-export const getResponsesRequestOptions = (
-  payload: ResponsesPayload,
-): { vision: boolean; initiator: "agent" | "user" } => {
-  const vision = hasVisionInput(payload)
-  const initiator = hasAgentInitiator(payload) ? "agent" : "user"
-
-  return { vision, initiator }
-}
-
-export const hasAgentInitiator = (payload: ResponsesPayload): boolean => {
-  // Refactor `isAgentCall` logic to check only the last message in the history rather than any message. This prevents valid user messages from being incorrectly flagged as agent calls due to previous assistant history, ensuring proper credit consumption for multi-turn conversations.
-  const lastItem = getPayloadItems(payload).at(-1)
-  if (!lastItem) {
-    return false
-  }
-  if (!("role" in lastItem) || !lastItem.role) {
-    return true
-  }
-  const role =
-    typeof lastItem.role === "string" ? lastItem.role.toLowerCase() : ""
-  return role === "assistant"
-}
-
-export const hasVisionInput = (payload: ResponsesPayload): boolean => {
-  const values = getPayloadItems(payload)
-  return values.some((item) => containsVisionContent(item))
-}
+import { isForceAgentEnabled } from "~/lib/config"
 
 const getPayloadItems = (
   payload: ResponsesPayload,
@@ -43,6 +17,57 @@ const getPayloadItems = (
   }
 
   return result
+}
+
+const getItemRole = (
+  item: ResponseInputItem | undefined,
+): string | undefined => {
+  if (!item || typeof item !== "object") {
+    return undefined
+  }
+
+  if (!("role" in item)) {
+    return undefined
+  }
+
+  const role = (item as { role?: unknown }).role
+  return typeof role === "string" ? role.toLowerCase() : undefined
+}
+
+const getLastRole = (payload: ResponsesPayload): string | undefined =>
+  getItemRole(getPayloadItems(payload).at(-1))
+
+const hasAssistantOrToolRole = (payload: ResponsesPayload): boolean =>
+  getPayloadItems(payload).some((item) => {
+    const role = getItemRole(item)
+    return role === "assistant" || role === "tool"
+  })
+
+export const getResponsesRequestOptions = (
+  payload: ResponsesPayload,
+): { vision: boolean; initiator: "agent" | "user" } => {
+  const vision = hasVisionInput(payload)
+  const forceAgent = isForceAgentEnabled()
+  const hasAssistantOrTool = hasAssistantOrToolRole(payload)
+  const isLastUser = getLastRole(payload) === "user"
+  let initiator: "agent" | "user"
+  if (forceAgent) {
+    initiator = hasAssistantOrTool ? "agent" : "user"
+  } else {
+    initiator = isLastUser ? "user" : "agent"
+  }
+
+  return { vision, initiator }
+}
+
+export const hasAgentInitiator = (payload: ResponsesPayload): boolean => {
+  const lastRole = getLastRole(payload)
+  return lastRole !== "user"
+}
+
+export const hasVisionInput = (payload: ResponsesPayload): boolean => {
+  const values = getPayloadItems(payload)
+  return values.some((item) => containsVisionContent(item))
 }
 
 const containsVisionContent = (value: unknown): boolean => {

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -45,31 +45,24 @@ const hasAssistantOrToolRole = (payload: ResponsesPayload): boolean =>
     return role === "assistant" || role === "tool"
   })
 
+const computeInitiator = (payload: ResponsesPayload): "agent" | "user" => {
+  const forceAgent = isForceAgentEnabled()
+  if (forceAgent) {
+    return hasAssistantOrToolRole(payload) ? "agent" : "user"
+  }
+  return getLastRole(payload) === "user" ? "user" : "agent"
+}
+
 export const getResponsesRequestOptions = (
   payload: ResponsesPayload,
 ): { vision: boolean; initiator: "agent" | "user" } => {
   const vision = hasVisionInput(payload)
-  const forceAgent = isForceAgentEnabled()
-  const hasAssistantOrTool = hasAssistantOrToolRole(payload)
-  const isLastUser = getLastRole(payload) === "user"
-  let initiator: "agent" | "user"
-  if (forceAgent) {
-    initiator = hasAssistantOrTool ? "agent" : "user"
-  } else {
-    initiator = isLastUser ? "user" : "agent"
-  }
-
+  const initiator = computeInitiator(payload)
   return { vision, initiator }
 }
 
-export const hasAgentInitiator = (payload: ResponsesPayload): boolean => {
-  const forceAgent = isForceAgentEnabled()
-  if (forceAgent) {
-    return hasAssistantOrToolRole(payload)
-  }
-  const lastRole = getLastRole(payload)
-  return lastRole !== "user"
-}
+export const hasAgentInitiator = (payload: ResponsesPayload): boolean =>
+  computeInitiator(payload) === "agent"
 
 export const hasVisionInput = (payload: ResponsesPayload): boolean => {
   const values = getPayloadItems(payload)

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -63,6 +63,10 @@ export const getResponsesRequestOptions = (
 }
 
 export const hasAgentInitiator = (payload: ResponsesPayload): boolean => {
+  const forceAgent = isForceAgentEnabled()
+  if (forceAgent) {
+    return hasAssistantOrToolRole(payload)
+  }
   const lastRole = getLastRole(payload)
   return lastRole !== "user"
 }

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -4,7 +4,7 @@ import { events } from "fetch-event-stream"
 import type { AccountContext } from "~/lib/types/account"
 
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
-import { getReasoningEffortForModel } from "~/lib/config"
+import { getReasoningEffortForModel, isForceAgentEnabled } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { accountFromState } from "~/lib/state"
 
@@ -44,15 +44,13 @@ export const createChatCompletions = async (
   )
 
   // Agent/user check for X-Initiator header
-  // Determine if any message is from an agent ("assistant" or "tool")
-  // Refactor `isAgentCall` logic to check only the last message in the history rather than any message. This prevents valid user messages from being incorrectly flagged as agent calls due to previous assistant history, ensuring proper credit consumption for multi-turn conversations.
-  let isAgentCall = false
-  if (payload.messages.length > 0) {
-    const lastMessage = payload.messages.at(-1)
-    if (lastMessage) {
-      isAgentCall = ["assistant", "tool"].includes(lastMessage.role)
-    }
-  }
+  const forceAgent = isForceAgentEnabled()
+  const hasAssistantOrTool = payload.messages.some((msg) =>
+    ["assistant", "tool"].includes(msg.role),
+  )
+  const lastMessage = payload.messages.at(-1)
+  const isLastUser = lastMessage?.role === "user"
+  const isAgentCall = forceAgent ? hasAssistantOrTool : !isLastUser
 
   // Build headers and add X-Initiator
   const headers: Record<string, string> = {

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -30,6 +30,20 @@ function applyDefaultReasoningEffort(
   }
 }
 
+function computeInitiatorForMessages(
+  messages: ChatCompletionsPayload["messages"],
+): "agent" | "user" {
+  const forceAgent = isForceAgentEnabled()
+  if (forceAgent) {
+    const hasAssistantOrTool = messages.some((msg) =>
+      ["assistant", "tool"].includes(msg.role),
+    )
+    return hasAssistantOrTool ? "agent" : "user"
+  }
+  const lastMessage = messages.at(-1)
+  return lastMessage?.role === "user" ? "user" : "agent"
+}
+
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
   account?: AccountContext,
@@ -43,19 +57,12 @@ export const createChatCompletions = async (
       && x.content?.some((x) => x.type === "image_url"),
   )
 
-  // Agent/user check for X-Initiator header
-  const forceAgent = isForceAgentEnabled()
-  const hasAssistantOrTool = payload.messages.some((msg) =>
-    ["assistant", "tool"].includes(msg.role),
-  )
-  const lastMessage = payload.messages.at(-1)
-  const isLastUser = lastMessage?.role === "user"
-  const isAgentCall = forceAgent ? hasAssistantOrTool : !isLastUser
+  const initiator = computeInitiatorForMessages(payload.messages)
 
   // Build headers and add X-Initiator
   const headers: Record<string, string> = {
     ...copilotHeaders(ctx, enableVision),
-    "X-Initiator": isAgentCall ? "agent" : "user",
+    "X-Initiator": initiator,
   }
 
   const upstreamPayload = applyDefaultReasoningEffort(payload)

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,0 +1,21 @@
+# Task Plan
+
+## Goal
+- 增加 forceAgent 配置与 X-Initiator 判定逻辑
+- 为 SSE 流增加 ping keepalive
+- 在 stdout 输出流式进度并展示 premium 配额
+
+## Phases
+| Phase | Status | Notes |
+| --- | --- | --- |
+| 1. 初始化规划文件 | complete | task_plan/findings/progress 已创建 |
+| 2. 勘察现有实现 | complete | 定位配置读取、X-Initiator 注入、streaming handler、logger |
+| 3. 实现 forceAgent | complete | 配置默认 false，覆盖全部请求 |
+| 4. 接入 SSE ping | complete | 在 streaming handler 中启用并清理 |
+| 5. 流式日志与 premium | complete | stdout 单行刷新与配额展示 |
+| 6. 收尾与总结 | complete | 更新规划文件、汇总变更 |
+
+## Errors Encountered
+| Error | Attempt | Resolution |
+| --- | --- | --- |
+| 缺少 scripts/set_title.sh | 1 | 记录在 progress，跳过标题设置 |


### PR DESCRIPTION
## Summary
- Add forceAgent-driven initiator inference for chat/responses.
- Add SSE keepalive plus streaming progress/premium logging with improved error visibility.
- Refactor messages streaming helpers and harden request log/quota cleanup.

## Test plan
- [x] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 forceAgent 配置项（默认关闭），可控制 X‑Initiator 的判定方式。
  * 新增 SSE 心跳/保活与周期性流式进度输出，结束时显示 premium 额度信息。
  * 新增工具输出与后续文本合并，改善多工具场景下的消息连贯性。

* **改进**
  * 统一流式与非流式路径的进度、premium 统计与请求/配额日志输出，携带 model 信息。

* **修复**
  * 对日志写入、心跳失败与配额最终化增加容错，避免影响主流程。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->