### PR TITLE
feat: add forceAgent config option to control X-Initiator header logic

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
     "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
   >
   useFunctionApplyPatch?: boolean
+  forceAgent?: boolean
 }
 
 const gpt5ExplorationPrompt = `## Exploration and reading files
@@ -197,4 +198,9 @@ export function getReasoningEffortForModel(
 ): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" {
   const config = getConfig()
   return config.modelReasoningEfforts?.[model] ?? "high"
+}
+
+export function isForceAgentEnabled(): boolean {
+  const config = getConfig()
+  return config.forceAgent ?? false
 }

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -3,6 +3,8 @@ import type {
   ResponsesPayload,
 } from "~/services/copilot/create-responses"
 
+import { isForceAgentEnabled } from "~/lib/config"
+
 export const getResponsesRequestOptions = (
   payload: ResponsesPayload,
 ): { vision: boolean; initiator: "agent" | "user" } => {
@@ -13,16 +15,27 @@ export const getResponsesRequestOptions = (
 }
 
 export const hasAgentInitiator = (payload: ResponsesPayload): boolean => {
-  // Refactor `isAgentCall` logic to check only the last message in the history rather than any message. This prevents valid user messages from being incorrectly flagged as agent calls due to previous assistant history, ensuring proper credit consumption for multi-turn conversations.
-  const lastItem = getPayloadItems(payload).at(-1)
+  const items = getPayloadItems(payload)
+
+  if (isForceAgentEnabled()) {
+    // forceAgent mode: check if ANY item has assistant role
+    return items.some((item) => isAgentRole(item))
+  }
+
+  // Default mode: only check the last item
+  const lastItem = items.at(-1)
   if (!lastItem) {
     return false
   }
-  if (!("role" in lastItem) || !lastItem.role) {
-    return true
+  return isAgentRole(lastItem)
+}
+
+// Helper function: check if a single item has agent role
+const isAgentRole = (item: ResponseInputItem): boolean => {
+  if (!("role" in item) || !item.role) {
+    return true // No role means agent (preserve original logic)
   }
-  const role =
-    typeof lastItem.role === "string" ? lastItem.role.toLowerCase() : ""
+  const role = typeof item.role === "string" ? item.role.toLowerCase() : ""
   return role === "assistant"
 }
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -46,18 +46,16 @@ export const createChatCompletions = async (
   // Agent/user check for X-Initiator header
   // Determine if any message is from an agent ("assistant" or "tool")
   let isAgentCall = false
-  if (payload.messages.length > 0) {
-    if (isForceAgentEnabled()) {
-      // forceAgent mode: check if ANY message has assistant/tool role
-      isAgentCall = payload.messages.some((msg) =>
-        ["assistant", "tool"].includes(msg.role),
-      )
-    } else {
-      // Default mode: only check the last message
-      const lastMessage = payload.messages.at(-1)
-      if (lastMessage) {
-        isAgentCall = ["assistant", "tool"].includes(lastMessage.role)
-      }
+  if (isForceAgentEnabled()) {
+    // forceAgent mode: check if ANY message has assistant/tool role
+    isAgentCall = payload.messages.some((msg) =>
+      ["assistant", "tool"].includes(msg.role),
+    )
+  } else {
+    // Default mode: only check the last message
+    const lastMessage = payload.messages.at(-1)
+    if (lastMessage) {
+      isAgentCall = ["assistant", "tool"].includes(lastMessage.role)
     }
   }
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -4,7 +4,7 @@ import { events } from "fetch-event-stream"
 import type { AccountContext } from "~/lib/types/account"
 
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
-import { getReasoningEffortForModel } from "~/lib/config"
+import { getReasoningEffortForModel, isForceAgentEnabled } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { accountFromState } from "~/lib/state"
 
@@ -45,12 +45,19 @@ export const createChatCompletions = async (
 
   // Agent/user check for X-Initiator header
   // Determine if any message is from an agent ("assistant" or "tool")
-  // Refactor `isAgentCall` logic to check only the last message in the history rather than any message. This prevents valid user messages from being incorrectly flagged as agent calls due to previous assistant history, ensuring proper credit consumption for multi-turn conversations.
   let isAgentCall = false
   if (payload.messages.length > 0) {
-    const lastMessage = payload.messages.at(-1)
-    if (lastMessage) {
-      isAgentCall = ["assistant", "tool"].includes(lastMessage.role)
+    if (isForceAgentEnabled()) {
+      // forceAgent mode: check if ANY message has assistant/tool role
+      isAgentCall = payload.messages.some((msg) =>
+        ["assistant", "tool"].includes(msg.role),
+      )
+    } else {
+      // Default mode: only check the last message
+      const lastMessage = payload.messages.at(-1)
+      if (lastMessage) {
+        isAgentCall = ["assistant", "tool"].includes(lastMessage.role)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Add `forceAgent` configuration option (default: false) to control how the X-Initiator header is determined for upstream GitHub Copilot API requests.

### Changes

- **Config**: Added `forceAgent?: boolean` to `AppConfig` interface and `isForceAgentEnabled()` helper function
- **Chat Completions**: Modified X-Initiator logic to support both modes
- **Responses API**: Refactored `hasAgentInitiator()` with new `isAgentRole()` helper function

### Behavior

| forceAgent | Logic |
|------------|-------|
| `false` (default) | Check only the **last message's** role |
| `true` | Check if **ANY message** has assistant/tool role |

### Files Modified

- `src/lib/config.ts` - Added config option and helper function
- `src/services/copilot/create-chat-completions.ts` - Updated X-Initiator logic
- `src/routes/responses/utils.ts` - Refactored with helper function

### Testing

✅ All existing tests pass (85 tests)
✅ Lint checks pass
✅ Backward compatible (default behavior unchanged)

## Test Plan

- [x] Run `bun run lint` - passes
- [x] Run `bun test` - all 85 tests pass
- [ ] Manual testing with `forceAgent=false` (default)
- [ ] Manual testing with `forceAgent=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 增加可选配置以强制启用 Agent 模式，并提供对应开关用于读取该配置

* **优化改进**
  * 在启用强制模式时，改进了 Agent 识别逻辑以支持基于消息集合的更全面判断；未启用时保留原有基于最后一条消息的行为

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->