### PR TITLE
feat: add admin settings config management

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -5,6 +5,7 @@ import { AccountsPage } from "@/pages/accounts-page"
 import { NotFoundPage } from "@/pages/not-found-page"
 import { RequestDetailPage } from "@/pages/request-detail-page"
 import { RequestsPage } from "@/pages/requests-page"
+import { SettingsPage } from "@/pages/settings-page"
 
 export default function App(): React.JSX.Element {
   return (
@@ -13,6 +14,7 @@ export default function App(): React.JSX.Element {
         <Route path="/" element={<Navigate to="/accounts" replace />} />
         <Route path="/accounts" element={<AccountsPage />} />
         <Route path="/requests" element={<RequestsPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
         <Route path="/request/:requestId" element={<RequestDetailPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Route>

--- a/admin-ui/src/components/app-shell.tsx
+++ b/admin-ui/src/components/app-shell.tsx
@@ -37,6 +37,22 @@ function NavItem({
   )
 }
 
+const NAV_ITEMS = [
+  { to: "/accounts", label: "Accounts" },
+  { to: "/requests", label: "Requests" },
+  { to: "/settings", label: "Settings" },
+] as const
+
+function NavList(): React.JSX.Element {
+  return (
+    <>
+      {NAV_ITEMS.map((item) => (
+        <NavItem key={item.to} to={item.to} label={item.label} />
+      ))}
+    </>
+  )
+}
+
 export function AppShell(): React.JSX.Element {
   return (
     <div className="min-h-svh bg-background text-foreground">
@@ -58,8 +74,7 @@ export function AppShell(): React.JSX.Element {
                   </SheetTitle>
                 </SheetHeader>
                 <nav className="mt-4 flex flex-col gap-3">
-                  <NavItem to="/accounts" label="Accounts" />
-                  <NavItem to="/requests" label="Requests" />
+                  <NavList />
                 </nav>
               </SheetContent>
             </Sheet>
@@ -72,8 +87,7 @@ export function AppShell(): React.JSX.Element {
           </div>
 
           <nav className="hidden items-center gap-5 md:flex">
-            <NavItem to="/accounts" label="Accounts" />
-            <NavItem to="/requests" label="Requests" />
+            <NavList />
           </nav>
 
           <div className="ml-auto flex items-center gap-2">

--- a/admin-ui/src/components/ui/switch.tsx
+++ b/admin-ui/src/components/ui/switch.tsx
@@ -1,0 +1,74 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export type SwitchProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "onChange"
+> & {
+  checked?: boolean
+  defaultChecked?: boolean
+  onCheckedChange?: (checked: boolean) => void
+}
+
+function SwitchComponent(
+  {
+    className,
+    checked,
+    defaultChecked,
+    onCheckedChange,
+    disabled,
+    onClick,
+    type = "button",
+    ...props
+  }: SwitchProps,
+  ref: React.ForwardedRef<HTMLButtonElement>,
+): React.JSX.Element {
+  const isControlled = checked !== undefined
+  const [internalChecked, setInternalChecked] = React.useState<boolean>(
+    defaultChecked ?? false,
+  )
+  const isChecked = isControlled ? checked : internalChecked
+
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>): void {
+    onClick?.(event)
+    if (event.defaultPrevented || disabled) return
+    const next = !isChecked
+    if (!isControlled) setInternalChecked(next)
+    onCheckedChange?.(next)
+  }
+
+  return (
+    <button
+      ref={ref}
+      type={type}
+      role="switch"
+      aria-checked={Boolean(isChecked)}
+      data-state={isChecked ? "checked" : "unchecked"}
+      data-disabled={disabled ? "true" : "false"}
+      className={cn(
+        "inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-input bg-input/30 shadow-xs transition-[color,box-shadow] outline-none",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        isChecked ? "bg-primary border-primary" : "bg-input/30",
+        className,
+      )}
+      onClick={handleClick}
+      disabled={disabled}
+      {...props}
+    >
+      <span
+        data-state={isChecked ? "checked" : "unchecked"}
+        className={cn(
+          "pointer-events-none inline-block size-4 rounded-full bg-background shadow-sm transition-transform",
+          isChecked ? "translate-x-5" : "translate-x-1",
+        )}
+      />
+    </button>
+  )
+}
+
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(SwitchComponent)
+Switch.displayName = "Switch"
+
+export { Switch }

--- a/admin-ui/src/components/ui/textarea.tsx
+++ b/admin-ui/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export function Textarea({ className, ...props }: React.ComponentProps<"textarea">): React.JSX.Element {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input min-h-[96px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -73,6 +73,26 @@ export type AdminRequestDetailResponse = {
   item: AdminRequestItem | null
 }
 
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+
+export type AdminConfig = {
+  extraPrompts?: Record<string, string>
+  smallModel?: string
+  freeModelLoadBalancing?: boolean
+  apiKey?: string
+  modelReasoningEfforts?: Record<string, ReasoningEffort>
+  useFunctionApplyPatch?: boolean
+  forceAgent?: boolean
+}
+
+export type AdminConfigResponse = AdminConfig & {
+  _configPath?: string
+}
+
+export type AdminModelsResponse = {
+  items: string[]
+}
+
 export class AdminApiError extends Error {
   readonly status: number
   readonly responseText: string
@@ -85,31 +105,38 @@ export class AdminApiError extends Error {
   }
 }
 
-async function fetchAdminJson<T>(path: string): Promise<T> {
-  const token = readAdminToken()
-  const headers: Record<string, string> = {}
-  if (token) headers["x-admin-token"] = token
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
 
-  const res = await fetch(path, { headers })
+async function fetchAdminJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = readAdminToken()
+  const headers = new Headers(init?.headers ?? undefined)
+
+  if (token) {
+    headers.set("x-admin-token", token)
+  }
+
+  if (init?.body && !headers.has("content-type")) {
+    headers.set("content-type", "application/json")
+  }
+
+  const res = await fetch(path, { ...init, headers })
+
   if (!res.ok) {
     const txt = await res.text().catch(() => "")
     let message = txt
 
     try {
       const parsed = JSON.parse(txt) as unknown
-      if (
-        typeof parsed === "object" &&
-        parsed !== null &&
-        "error" in parsed &&
-        typeof (parsed as { error?: unknown }).error === "object" &&
-        (parsed as { error?: { message?: unknown } }).error !== null &&
-        typeof (parsed as { error?: { message?: unknown } }).error?.message ===
-          "string"
-      ) {
-        message = (parsed as { error: { message: string } }).error.message
+      if (isPlainObject(parsed) && "error" in parsed) {
+        const err = (parsed as { error?: unknown }).error
+        if (isPlainObject(err) && typeof (err as { message?: unknown }).message === "string") {
+          message = (err as { message: string }).message
+        }
       }
     } catch {
-      // ignore JSON parsing
+      // ignore JSON parsing errors and keep raw text
     }
 
     throw new AdminApiError(res.status, message)
@@ -168,4 +195,21 @@ export async function getAdminRequestDetail(
   return fetchAdminJson<AdminRequestDetailResponse>(
     `/api/admin/requests/${encodeURIComponent(requestId)}`
   )
+}
+
+export async function getAdminConfig(): Promise<AdminConfigResponse> {
+  return fetchAdminJson<AdminConfigResponse>("/api/admin/config")
+}
+
+export async function updateAdminConfig(
+  patch: Partial<AdminConfig>
+): Promise<AdminConfigResponse> {
+  return fetchAdminJson<AdminConfigResponse>("/api/admin/config", {
+    method: "POST",
+    body: JSON.stringify(patch),
+  })
+}
+
+export async function getAdminModels(): Promise<AdminModelsResponse> {
+  return fetchAdminJson<AdminModelsResponse>("/api/admin/models")
 }

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -42,11 +42,13 @@ const REASONING_EFFORTS: ReasoningEffort[] = [
 ]
 
 type ExtraPromptItem = {
+  id: string
   model: string
   prompt: string
 }
 
 type ReasoningItem = {
+  id: string
   model: string
   effort: ReasoningEffort
 }
@@ -55,13 +57,29 @@ type ParseResult<T> = { record: T } | { error: string }
 
 type JsonMode = "form" | "json"
 
-function toggleJsonMode<TRecord>(
-  next: boolean,
-  record: TRecord | undefined,
-  setJson: (value: string) => void,
-  setError: (value: string | null) => void,
-  setMode: (mode: JsonMode) => void,
-): void {
+type ToggleJsonModeOptions<TRecord> = {
+  next: boolean
+  record: TRecord | undefined
+  setJson: (value: string) => void
+  setError: (value: string | null) => void
+  setMode: (mode: JsonMode) => void
+}
+
+type UpdateJsonRecordOptions<TRecord> = {
+  value: string
+  parse: (value: string) => ParseResult<TRecord>
+  setJson: (value: string) => void
+  setError: (value: string | null) => void
+  onRecord: (record: TRecord) => void
+}
+
+function toggleJsonMode<TRecord>({
+  next,
+  record,
+  setJson,
+  setError,
+  setMode,
+}: ToggleJsonModeOptions<TRecord>): void {
   if (next) {
     setJson(JSON.stringify(record ?? {}, null, 2))
   }
@@ -69,13 +87,13 @@ function toggleJsonMode<TRecord>(
   setMode(next ? "json" : "form")
 }
 
-function updateJsonRecord<TRecord>(
-  value: string,
-  parse: (value: string) => ParseResult<TRecord>,
-  setJson: (value: string) => void,
-  setError: (value: string | null) => void,
-  onRecord: (record: TRecord) => void,
-): void {
+function updateJsonRecord<TRecord>({
+  value,
+  parse,
+  setJson,
+  setError,
+  onRecord,
+}: UpdateJsonRecordOptions<TRecord>): void {
   setJson(value)
   const result = parse(value)
   if ("error" in result) {
@@ -90,18 +108,33 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+function createItemId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
 function extraPromptItemsFromRecord(
   record: Record<string, string> | undefined
 ): ExtraPromptItem[] {
   if (!record) return []
-  return Object.entries(record).map(([model, prompt]) => ({ model, prompt }))
+  return Object.entries(record).map(([model, prompt]) => ({
+    id: createItemId(),
+    model,
+    prompt,
+  }))
 }
 
 function reasoningItemsFromRecord(
   record: Record<string, ReasoningEffort> | undefined
 ): ReasoningItem[] {
   if (!record) return []
-  return Object.entries(record).map(([model, effort]) => ({ model, effort }))
+  return Object.entries(record).map(([model, effort]) => ({
+    id: createItemId(),
+    model,
+    effort,
+  }))
 }
 
 function extraPromptRecordFromItems(items: ExtraPromptItem[]): Record<string, string> {
@@ -179,6 +212,372 @@ function parseReasoningJson(
   }
 }
 
+type GeneralSettingsCardProps = {
+  hasModels: boolean
+  smallModelLabel: string
+  smallModelValue: string
+  smallModelInputValue: string
+  models: string[]
+  apiKeyValue: string
+  envOverrideNote: string
+  onSmallModelSelect: (value: string) => void
+  onSmallModelInput: (value: string) => void
+  onApiKeyChange: (value: string) => void
+}
+
+function GeneralSettingsCard({
+  hasModels,
+  smallModelLabel,
+  smallModelValue,
+  smallModelInputValue,
+  models,
+  apiKeyValue,
+  envOverrideNote,
+  onSmallModelSelect,
+  onSmallModelInput,
+  onApiKeyChange,
+}: GeneralSettingsCardProps): React.JSX.Element {
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>General</CardTitle>
+        <CardDescription className="hidden sm:block">
+          Default model routing and API key storage.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 px-4">
+        <div className="grid gap-2">
+          <Label className="text-muted-foreground text-xs">{smallModelLabel}</Label>
+          {hasModels ? (
+            <Select value={smallModelValue} onValueChange={onSmallModelSelect}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select small model" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default__">(default)</SelectItem>
+                {models.map((model) => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              placeholder="gpt-5-mini"
+              value={smallModelInputValue}
+              onChange={(e) => onSmallModelInput(e.target.value)}
+            />
+          )}
+          <div className="text-muted-foreground text-xs">
+            Controls which model receives lightweight/free requests when routing.
+          </div>
+        </div>
+
+        <div className="grid gap-2">
+          <Label className="text-muted-foreground text-xs">API key</Label>
+          <Input
+            type="password"
+            autoComplete="new-password"
+            placeholder="sk-..."
+            value={apiKeyValue}
+            onChange={(e) => onApiKeyChange(e.target.value)}
+          />
+          <div className="text-muted-foreground text-xs">
+            {envOverrideNote} Leave empty to clear config value.
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+type LoadBalancingCardProps = {
+  enabled: boolean
+  onToggle: (value: boolean) => void
+}
+
+function LoadBalancingCard({ enabled, onToggle }: LoadBalancingCardProps): React.JSX.Element {
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Load balancing</CardTitle>
+        <CardDescription className="hidden sm:block">
+          Toggle free account load balancing.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">Free model load balancing</div>
+            <div className="text-muted-foreground text-xs">
+              When enabled, distributes free traffic across available accounts.
+            </div>
+          </div>
+          <Switch checked={enabled} onCheckedChange={onToggle} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+type ReasoningEffortsCardProps = {
+  mode: JsonMode
+  json: string
+  jsonIssue: string | null
+  items: ReasoningItem[]
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ReasoningItem>) => void
+}
+
+function ReasoningEffortsCard({
+  mode,
+  json,
+  jsonIssue,
+  items,
+  onToggleMode,
+  onJsonChange,
+  onAddItem,
+  onRemoveItem,
+  onUpdateItem,
+}: ReasoningEffortsCardProps): React.JSX.Element {
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Reasoning efforts</CardTitle>
+        <CardDescription className="hidden sm:block">
+          Override model reasoning effort levels.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-muted-foreground text-xs">
+            Define per-model reasoning effort (optional).
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
+            <Label className="text-muted-foreground text-xs">JSON mode</Label>
+          </div>
+        </div>
+
+        {mode === "json" ? (
+          <div className="space-y-2">
+            <Textarea
+              value={json}
+              onChange={(e) => onJsonChange(e.target.value)}
+              className="min-h-[160px] font-mono text-xs"
+              placeholder='{ "gpt-5-mini": "low" }'
+            />
+            {jsonIssue ? (
+              <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
+            ) : null}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.length === 0 ? (
+              <div className="text-muted-foreground text-sm">
+                No reasoning overrides. Add a model below.
+              </div>
+            ) : (
+              items.map((item) => (
+                <div key={item.id} className="grid gap-2 rounded-lg border p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Input
+                      placeholder="model id"
+                      value={item.model}
+                      onChange={(e) => onUpdateItem(item.id, { model: e.target.value })}
+                    />
+                    <Select
+                      value={item.effort}
+                      onValueChange={(value) =>
+                        onUpdateItem(item.id, { effort: value as ReasoningEffort })
+                      }
+                    >
+                      <SelectTrigger className="w-40">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {REASONING_EFFORTS.map((effort) => (
+                          <SelectItem key={effort} value={effort}>
+                            {effort}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onRemoveItem(item.id)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                  <div className="text-muted-foreground text-xs">
+                    Overrides reasoning effort for this model.
+                  </div>
+                </div>
+              ))
+            )}
+
+            <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
+              Add model override
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+type ExtraPromptsCardProps = {
+  mode: JsonMode
+  json: string
+  jsonIssue: string | null
+  items: ExtraPromptItem[]
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ExtraPromptItem>) => void
+}
+
+function ExtraPromptsCard({
+  mode,
+  json,
+  jsonIssue,
+  items,
+  onToggleMode,
+  onJsonChange,
+  onAddItem,
+  onRemoveItem,
+  onUpdateItem,
+}: ExtraPromptsCardProps): React.JSX.Element {
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Extra prompts</CardTitle>
+        <CardDescription className="hidden sm:block">
+          Inject extra system prompts per model.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-muted-foreground text-xs">
+            Add or edit prompt snippets injected for specific models.
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
+            <Label className="text-muted-foreground text-xs">JSON mode</Label>
+          </div>
+        </div>
+
+        {mode === "json" ? (
+          <div className="space-y-2">
+            <Textarea
+              value={json}
+              onChange={(e) => onJsonChange(e.target.value)}
+              className="min-h-[200px] font-mono text-xs"
+              placeholder='{ "gpt-5-mini": "..." }'
+            />
+            {jsonIssue ? (
+              <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
+            ) : null}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.length === 0 ? (
+              <div className="text-muted-foreground text-sm">No extra prompts configured.</div>
+            ) : (
+              items.map((item) => (
+                <div key={item.id} className="grid gap-2 rounded-lg border p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Input
+                      placeholder="model id"
+                      value={item.model}
+                      onChange={(e) => onUpdateItem(item.id, { model: e.target.value })}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onRemoveItem(item.id)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                  <Textarea
+                    value={item.prompt}
+                    onChange={(e) => onUpdateItem(item.id, { prompt: e.target.value })}
+                    className="min-h-[120px] font-mono text-xs"
+                    placeholder="System prompt snippet..."
+                  />
+                  <div className="text-muted-foreground text-xs">
+                    Adds prompt content before model execution.
+                  </div>
+                </div>
+              ))
+            )}
+
+            <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
+              Add prompt
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+type AdvancedSettingsCardProps = {
+  useFunctionApplyPatch: boolean
+  forceAgent: boolean
+  onToggleUseFunctionApplyPatch: (value: boolean) => void
+  onToggleForceAgent: (value: boolean) => void
+}
+
+function AdvancedSettingsCard({
+  useFunctionApplyPatch,
+  forceAgent,
+  onToggleUseFunctionApplyPatch,
+  onToggleForceAgent,
+}: AdvancedSettingsCardProps): React.JSX.Element {
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Advanced</CardTitle>
+        <CardDescription className="hidden sm:block">
+          Feature flags and experimental toggles.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">Use function apply_patch</div>
+            <div className="text-muted-foreground text-xs">
+              Enables function-level patches in responses routing.
+            </div>
+          </div>
+          <Switch checked={useFunctionApplyPatch} onCheckedChange={onToggleUseFunctionApplyPatch} />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">Force agent header</div>
+            <div className="text-muted-foreground text-xs">
+              Forces agent routing logic even when clients omit hints.
+            </div>
+          </div>
+          <Switch checked={forceAgent} onCheckedChange={onToggleForceAgent} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 export function SettingsPage(): React.JSX.Element {
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -243,6 +642,8 @@ export function SettingsPage(): React.JSX.Element {
     "Environment variable COPILOT_API_KEY overrides this value when set."
 
   const smallModelLabel = hasModels ? "Small model" : "Small model (manual)"
+  const smallModelInputValue = draft.smallModel ?? ""
+  const apiKeyValue = draft.apiKey ?? ""
 
   const extraPromptJsonIssue = useMemo(
     () => (extraJsonError ? `extraPrompts: ${extraJsonError}` : null),
@@ -287,44 +688,103 @@ export function SettingsPage(): React.JSX.Element {
     }))
   }
 
-  function onExtraJsonChange(value: string): void {
-    updateJsonRecord(
-      value,
-      parseExtraPromptsJson,
-      setExtraJson,
-      setExtraJsonError,
-      (record) => updateExtraItems(extraPromptItemsFromRecord(record)),
+  function handleSmallModelSelect(value: string): void {
+    setDraft((prev) => ({
+      ...prev,
+      smallModel: value === "__default__" ? "" : value,
+    }))
+  }
+
+  function handleSmallModelInput(value: string): void {
+    setDraft((prev) => ({ ...prev, smallModel: value }))
+  }
+
+  function handleApiKeyChange(value: string): void {
+    setDraft((prev) => ({ ...prev, apiKey: value }))
+  }
+
+  function handleLoadBalancingToggle(value: boolean): void {
+    setDraft((prev) => ({ ...prev, freeModelLoadBalancing: value }))
+  }
+
+  function handleUseFunctionApplyPatchToggle(value: boolean): void {
+    setDraft((prev) => ({ ...prev, useFunctionApplyPatch: value }))
+  }
+
+  function handleForceAgentToggle(value: boolean): void {
+    setDraft((prev) => ({ ...prev, forceAgent: value }))
+  }
+
+  function handleExtraItemUpdate(id: string, patch: Partial<ExtraPromptItem>): void {
+    const next = extraItems.map((item) =>
+      item.id === id ? { ...item, ...patch } : item,
     )
+    updateExtraItems(next)
+  }
+
+  function handleExtraItemRemove(id: string): void {
+    updateExtraItems(extraItems.filter((item) => item.id !== id))
+  }
+
+  function handleExtraItemAdd(): void {
+    updateExtraItems(extraItems.concat({ id: createItemId(), model: "", prompt: "" }))
+  }
+
+  function handleReasoningItemUpdate(id: string, patch: Partial<ReasoningItem>): void {
+    const next = reasoningItems.map((item) =>
+      item.id === id ? { ...item, ...patch } : item,
+    )
+    updateReasoningItems(next)
+  }
+
+  function handleReasoningItemRemove(id: string): void {
+    updateReasoningItems(reasoningItems.filter((item) => item.id !== id))
+  }
+
+  function handleReasoningItemAdd(): void {
+    updateReasoningItems(
+      reasoningItems.concat({ id: createItemId(), model: "", effort: "high" }),
+    )
+  }
+
+  function onExtraJsonChange(value: string): void {
+    updateJsonRecord({
+      value,
+      parse: parseExtraPromptsJson,
+      setJson: setExtraJson,
+      setError: setExtraJsonError,
+      onRecord: (record) => updateExtraItems(extraPromptItemsFromRecord(record)),
+    })
   }
 
   function onReasoningJsonChange(value: string): void {
-    updateJsonRecord(
+    updateJsonRecord({
       value,
-      parseReasoningJson,
-      setReasoningJson,
-      setReasoningJsonError,
-      (record) => updateReasoningItems(reasoningItemsFromRecord(record)),
-    )
+      parse: parseReasoningJson,
+      setJson: setReasoningJson,
+      setError: setReasoningJsonError,
+      onRecord: (record) => updateReasoningItems(reasoningItemsFromRecord(record)),
+    })
   }
 
   function toggleExtraMode(next: boolean): void {
-    toggleJsonMode(
+    toggleJsonMode({
       next,
-      draft.extraPrompts,
-      setExtraJson,
-      setExtraJsonError,
-      setExtraMode,
-    )
+      record: draft.extraPrompts,
+      setJson: setExtraJson,
+      setError: setExtraJsonError,
+      setMode: setExtraMode,
+    })
   }
 
   function toggleReasoningMode(next: boolean): void {
-    toggleJsonMode(
+    toggleJsonMode({
       next,
-      draft.modelReasoningEfforts,
-      setReasoningJson,
-      setReasoningJsonError,
-      setReasoningMode,
-    )
+      record: draft.modelReasoningEfforts,
+      setJson: setReasoningJson,
+      setError: setReasoningJsonError,
+      setMode: setReasoningMode,
+    })
   }
 
   return (
@@ -367,331 +827,54 @@ export function SettingsPage(): React.JSX.Element {
         />
       ) : null}
 
-      <Card className="gap-4 py-4">
-        <CardHeader className="px-4">
-          <CardTitle>General</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Default model routing and API key storage.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 px-4">
-          <div className="grid gap-2">
-            <Label className="text-muted-foreground text-xs">{smallModelLabel}</Label>
-            {hasModels ? (
-              <Select
-                value={smallModelValue}
-                onValueChange={(value) =>
-                  setDraft((prev) => ({
-                    ...prev,
-                    smallModel: value === "__default__" ? "" : value,
-                  }))
-                }
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select small model" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__default__">(default)</SelectItem>
-                  {models.map((model) => (
-                    <SelectItem key={model} value={model}>
-                      {model}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                placeholder="gpt-5-mini"
-                value={draft.smallModel ?? ""}
-                onChange={(e) =>
-                  setDraft((prev) => ({ ...prev, smallModel: e.target.value }))
-                }
-              />
-            )}
-            <div className="text-muted-foreground text-xs">
-              Controls which model receives lightweight/free requests when routing.
-            </div>
-          </div>
+      <GeneralSettingsCard
+        hasModels={hasModels}
+        smallModelLabel={smallModelLabel}
+        smallModelValue={smallModelValue}
+        smallModelInputValue={smallModelInputValue}
+        models={models}
+        apiKeyValue={apiKeyValue}
+        envOverrideNote={envOverrideNote}
+        onSmallModelSelect={handleSmallModelSelect}
+        onSmallModelInput={handleSmallModelInput}
+        onApiKeyChange={handleApiKeyChange}
+      />
 
-          <div className="grid gap-2">
-            <Label className="text-muted-foreground text-xs">API key</Label>
-            <Input
-              placeholder="sk-..."
-              value={draft.apiKey ?? ""}
-              onChange={(e) => setDraft((prev) => ({ ...prev, apiKey: e.target.value }))}
-            />
-            <div className="text-muted-foreground text-xs">
-              {envOverrideNote} Leave empty to clear config value.
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <LoadBalancingCard
+        enabled={draft.freeModelLoadBalancing ?? true}
+        onToggle={handleLoadBalancingToggle}
+      />
 
-      <Card className="gap-4 py-4">
-        <CardHeader className="px-4">
-          <CardTitle>Load balancing</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Toggle free account load balancing.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 px-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <div className="text-sm font-medium">Free model load balancing</div>
-              <div className="text-muted-foreground text-xs">
-                When enabled, distributes free traffic across available accounts.
-              </div>
-            </div>
-            <Switch
-              checked={draft.freeModelLoadBalancing ?? true}
-              onCheckedChange={(value) =>
-                setDraft((prev) => ({ ...prev, freeModelLoadBalancing: value }))
-              }
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <ReasoningEffortsCard
+        mode={reasoningMode}
+        json={reasoningJson}
+        jsonIssue={reasoningJsonIssue}
+        items={reasoningItems}
+        onToggleMode={toggleReasoningMode}
+        onJsonChange={onReasoningJsonChange}
+        onAddItem={handleReasoningItemAdd}
+        onRemoveItem={handleReasoningItemRemove}
+        onUpdateItem={handleReasoningItemUpdate}
+      />
 
-      <Card className="gap-4 py-4">
-        <CardHeader className="px-4">
-          <CardTitle>Reasoning efforts</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Override model reasoning effort levels.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 px-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="text-muted-foreground text-xs">
-              Define per-model reasoning effort (optional).
-            </div>
-            <div className="flex items-center gap-2">
-              <Switch checked={reasoningMode === "json"} onCheckedChange={toggleReasoningMode} />
-              <Label className="text-muted-foreground text-xs">JSON mode</Label>
-            </div>
-          </div>
+      <ExtraPromptsCard
+        mode={extraMode}
+        json={extraJson}
+        jsonIssue={extraPromptJsonIssue}
+        items={extraItems}
+        onToggleMode={toggleExtraMode}
+        onJsonChange={onExtraJsonChange}
+        onAddItem={handleExtraItemAdd}
+        onRemoveItem={handleExtraItemRemove}
+        onUpdateItem={handleExtraItemUpdate}
+      />
 
-          {reasoningMode === "json" ? (
-            <div className="space-y-2">
-              <Textarea
-                value={reasoningJson}
-                onChange={(e) => onReasoningJsonChange(e.target.value)}
-                className="min-h-[160px] font-mono text-xs"
-                placeholder='{ "gpt-5-mini": "low" }'
-              />
-              {reasoningJsonIssue ? (
-                <InlineAlert
-                  variant="warning"
-                  title="Invalid JSON"
-                  description={reasoningJsonIssue}
-                />
-              ) : null}
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {reasoningItems.length === 0 ? (
-                <div className="text-muted-foreground text-sm">
-                  No reasoning overrides. Add a model below.
-                </div>
-              ) : (
-                reasoningItems.map((item, index) => (
-                  <div key={`${item.model}-${index}`} className="grid gap-2 rounded-lg border p-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Input
-                        placeholder="model id"
-                        value={item.model}
-                        onChange={(e) => {
-                          const next = [...reasoningItems]
-                          next[index] = { ...item, model: e.target.value }
-                          updateReasoningItems(next)
-                        }}
-                      />
-                      <Select
-                        value={item.effort}
-                        onValueChange={(value) => {
-                          const next = [...reasoningItems]
-                          next[index] = { ...item, effort: value as ReasoningEffort }
-                          updateReasoningItems(next)
-                        }}
-                      >
-                        <SelectTrigger className="w-40">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {REASONING_EFFORTS.map((effort) => (
-                            <SelectItem key={effort} value={effort}>
-                              {effort}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          const next = reasoningItems.filter((_, i) => i !== index)
-                          updateReasoningItems(next)
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      Overrides reasoning effort for this model.
-                    </div>
-                  </div>
-                ))
-              )}
-
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() =>
-                  updateReasoningItems(
-                    reasoningItems.concat({ model: "", effort: "high" })
-                  )
-                }
-              >
-                Add model override
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card className="gap-4 py-4">
-        <CardHeader className="px-4">
-          <CardTitle>Extra prompts</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Inject extra system prompts per model.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 px-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="text-muted-foreground text-xs">
-              Add or edit prompt snippets injected for specific models.
-            </div>
-            <div className="flex items-center gap-2">
-              <Switch checked={extraMode === "json"} onCheckedChange={toggleExtraMode} />
-              <Label className="text-muted-foreground text-xs">JSON mode</Label>
-            </div>
-          </div>
-
-          {extraMode === "json" ? (
-            <div className="space-y-2">
-              <Textarea
-                value={extraJson}
-                onChange={(e) => onExtraJsonChange(e.target.value)}
-                className="min-h-[200px] font-mono text-xs"
-                placeholder='{ "gpt-5-mini": "..." }'
-              />
-              {extraPromptJsonIssue ? (
-                <InlineAlert
-                  variant="warning"
-                  title="Invalid JSON"
-                  description={extraPromptJsonIssue}
-                />
-              ) : null}
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {extraItems.length === 0 ? (
-                <div className="text-muted-foreground text-sm">
-                  No extra prompts configured.
-                </div>
-              ) : (
-                extraItems.map((item, index) => (
-                  <div key={`${item.model}-${index}`} className="grid gap-2 rounded-lg border p-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Input
-                        placeholder="model id"
-                        value={item.model}
-                        onChange={(e) => {
-                          const next = [...extraItems]
-                          next[index] = { ...item, model: e.target.value }
-                          updateExtraItems(next)
-                        }}
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          const next = extraItems.filter((_, i) => i !== index)
-                          updateExtraItems(next)
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </div>
-                    <Textarea
-                      value={item.prompt}
-                      onChange={(e) => {
-                        const next = [...extraItems]
-                        next[index] = { ...item, prompt: e.target.value }
-                        updateExtraItems(next)
-                      }}
-                      className="min-h-[120px] font-mono text-xs"
-                      placeholder="System prompt snippet..."
-                    />
-                    <div className="text-muted-foreground text-xs">
-                      Adds prompt content before model execution.
-                    </div>
-                  </div>
-                ))
-              )}
-
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => updateExtraItems(extraItems.concat({ model: "", prompt: "" }))}
-              >
-                Add prompt
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card className="gap-4 py-4">
-        <CardHeader className="px-4">
-          <CardTitle>Advanced</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Feature flags and experimental toggles.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 px-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <div className="text-sm font-medium">Use function apply_patch</div>
-              <div className="text-muted-foreground text-xs">
-                Enables function-level patches in responses routing.
-              </div>
-            </div>
-            <Switch
-              checked={draft.useFunctionApplyPatch ?? true}
-              onCheckedChange={(value) =>
-                setDraft((prev) => ({ ...prev, useFunctionApplyPatch: value }))
-              }
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <div className="text-sm font-medium">Force agent header</div>
-              <div className="text-muted-foreground text-xs">
-                Forces agent routing logic even when clients omit hints.
-              </div>
-            </div>
-            <Switch
-              checked={draft.forceAgent ?? false}
-              onCheckedChange={(value) => setDraft((prev) => ({ ...prev, forceAgent: value }))}
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <AdvancedSettingsCard
+        useFunctionApplyPatch={draft.useFunctionApplyPatch ?? true}
+        forceAgent={draft.forceAgent ?? false}
+        onToggleUseFunctionApplyPatch={handleUseFunctionApplyPatchToggle}
+        onToggleForceAgent={handleForceAgentToggle}
+      />
     </div>
   )
 }

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -13,7 +13,6 @@ import {
 import { Button } from "@/components/ui/button"
 import {
   Card,
-  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
@@ -1175,13 +1174,29 @@ function SettingsPageView({
           </div>
         </div>
 
-        <div className="ml-auto flex flex-wrap items-center gap-2 lg:hidden">
-          <Button type="button" variant="outline" size="sm" onClick={onReload} disabled={loading || saving}>
-            {loading ? "Reloading..." : "Reload"}
-          </Button>
-          <RainbowButton type="button" size="sm" onClick={onSave} disabled={!canSave}>
-            {saving ? "Saving..." : "Save"}
-          </RainbowButton>
+        <div className="ml-auto flex flex-col items-end gap-1 text-right">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onReload}
+              disabled={loading || saving}
+            >
+              {loading ? "Reloading..." : "Reload"}
+            </Button>
+            <RainbowButton type="button" size="sm" onClick={onSave} disabled={!canSave}>
+              {saving ? "Saving..." : "Save"}
+            </RainbowButton>
+          </div>
+          {configPath ? (
+            <div className="text-muted-foreground text-xs leading-tight hidden sm:block">
+              Config path: {configPath}
+            </div>
+          ) : null}
+          <div className="text-muted-foreground text-xs leading-tight hidden sm:block">
+            Changes apply to config.json immediately. Environment variables take precedence.
+          </div>
         </div>
       </div>
 
@@ -1249,35 +1264,6 @@ function SettingsPageView({
             onToggleForceAgent={onForceAgentToggle}
           />
 
-          <Card className="hidden gap-4 py-4 lg:block">
-            <CardHeader className="px-4">
-              <CardTitle>Actions</CardTitle>
-              <CardAction className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={onReload}
-                  disabled={loading || saving}
-                >
-                  {loading ? "Reloading..." : "Reload"}
-                </Button>
-                <RainbowButton type="button" size="sm" onClick={onSave} disabled={!canSave}>
-                  {saving ? "Saving..." : "Save"}
-                </RainbowButton>
-              </CardAction>
-            </CardHeader>
-            <CardContent className="space-y-2 px-4">
-              {configPath ? (
-                <div className="text-muted-foreground text-xs">
-                  Config path: {configPath}
-                </div>
-              ) : null}
-              <div className="text-muted-foreground text-xs">
-                Changes apply to config.json immediately. Environment variables take precedence.
-              </div>
-            </CardContent>
-          </Card>
         </aside>
       </div>
     </div>

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -534,6 +534,7 @@ type ReasoningEffortsCardProps = {
   json: string
   jsonIssue: string | null
   items: ReasoningItem[]
+  models: string[]
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -546,12 +547,16 @@ function ReasoningEffortsCard({
   json,
   jsonIssue,
   items,
+  models,
   onToggleMode,
   onJsonChange,
   onAddItem,
   onRemoveItem,
   onUpdateItem,
 }: ReasoningEffortsCardProps): React.JSX.Element {
+  const defaultModelValue = "__default__"
+  const hasModels = models.length > 0
+
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
@@ -590,45 +595,73 @@ function ReasoningEffortsCard({
                 No reasoning overrides. Add a model below.
               </div>
             ) : (
-              items.map((item) => (
-                <div key={item.id} className="grid gap-2 rounded-lg border p-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Input
-                      placeholder="model id"
-                      value={item.model}
-                      onChange={(e) => onUpdateItem(item.id, { model: e.target.value })}
-                    />
-                    <Select
-                      value={item.effort}
-                      onValueChange={(value) =>
-                        onUpdateItem(item.id, { effort: value as ReasoningEffort })
-                      }
-                    >
-                      <SelectTrigger className="w-40">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {REASONING_EFFORTS.map((effort) => (
-                          <SelectItem key={effort} value={effort}>
-                            {effort}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => onRemoveItem(item.id)}
-                    >
-                      Remove
-                    </Button>
+              items.map((item) => {
+                const modelValue = item.model || defaultModelValue
+                const showCustomModel =
+                  modelValue !== defaultModelValue && !models.includes(modelValue)
+                const disableModelSelect = !hasModels && !showCustomModel
+
+                return (
+                  <div key={item.id} className="grid gap-2 rounded-lg border p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Select
+                        value={modelValue}
+                        onValueChange={(value) =>
+                          onUpdateItem(item.id, {
+                            model: value === defaultModelValue ? "" : value,
+                          })
+                        }
+                        disabled={disableModelSelect}
+                      >
+                        <SelectTrigger className="min-w-[220px]">
+                          <SelectValue
+                            placeholder={hasModels ? "Select model" : "No models available"}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={defaultModelValue}>(default)</SelectItem>
+                          {showCustomModel ? (
+                            <SelectItem value={modelValue}>Custom: {modelValue}</SelectItem>
+                          ) : null}
+                          {models.map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {model}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={item.effort}
+                        onValueChange={(value) =>
+                          onUpdateItem(item.id, { effort: value as ReasoningEffort })
+                        }
+                      >
+                        <SelectTrigger className="w-40">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {REASONING_EFFORTS.map((effort) => (
+                            <SelectItem key={effort} value={effort}>
+                              {effort}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onRemoveItem(item.id)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                      Overrides reasoning effort for this model.
+                    </div>
                   </div>
-                  <div className="text-muted-foreground text-xs">
-                    Overrides reasoning effort for this model.
-                  </div>
-                </div>
-              ))
+                )
+              })
             )}
 
             <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
@@ -646,6 +679,7 @@ type ExtraPromptsCardProps = {
   json: string
   jsonIssue: string | null
   items: ExtraPromptItem[]
+  models: string[]
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -658,12 +692,16 @@ function ExtraPromptsCard({
   json,
   jsonIssue,
   items,
+  models,
   onToggleMode,
   onJsonChange,
   onAddItem,
   onRemoveItem,
   onUpdateItem,
 }: ExtraPromptsCardProps): React.JSX.Element {
+  const defaultModelValue = "__default__"
+  const hasModels = models.length > 0
+
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
@@ -700,34 +738,62 @@ function ExtraPromptsCard({
             {items.length === 0 ? (
               <div className="text-muted-foreground text-sm">No extra prompts configured.</div>
             ) : (
-              items.map((item) => (
-                <div key={item.id} className="grid gap-2 rounded-lg border p-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Input
-                      placeholder="model id"
-                      value={item.model}
-                      onChange={(e) => onUpdateItem(item.id, { model: e.target.value })}
+              items.map((item) => {
+                const modelValue = item.model || defaultModelValue
+                const showCustomModel =
+                  modelValue !== defaultModelValue && !models.includes(modelValue)
+                const disableModelSelect = !hasModels && !showCustomModel
+
+                return (
+                  <div key={item.id} className="grid gap-2 rounded-lg border p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Select
+                        value={modelValue}
+                        onValueChange={(value) =>
+                          onUpdateItem(item.id, {
+                            model: value === defaultModelValue ? "" : value,
+                          })
+                        }
+                        disabled={disableModelSelect}
+                      >
+                        <SelectTrigger className="min-w-[220px]">
+                          <SelectValue
+                            placeholder={hasModels ? "Select model" : "No models available"}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={defaultModelValue}>(default)</SelectItem>
+                          {showCustomModel ? (
+                            <SelectItem value={modelValue}>Custom: {modelValue}</SelectItem>
+                          ) : null}
+                          {models.map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {model}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onRemoveItem(item.id)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                    <Textarea
+                      value={item.prompt}
+                      onChange={(e) => onUpdateItem(item.id, { prompt: e.target.value })}
+                      className="min-h-[120px] font-mono text-xs"
+                      placeholder="System prompt snippet..."
                     />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => onRemoveItem(item.id)}
-                    >
-                      Remove
-                    </Button>
+                    <div className="text-muted-foreground text-xs">
+                      Adds prompt content before model execution.
+                    </div>
                   </div>
-                  <Textarea
-                    value={item.prompt}
-                    onChange={(e) => onUpdateItem(item.id, { prompt: e.target.value })}
-                    className="min-h-[120px] font-mono text-xs"
-                    placeholder="System prompt snippet..."
-                  />
-                  <div className="text-muted-foreground text-xs">
-                    Adds prompt content before model execution.
-                  </div>
-                </div>
-              ))
+                )
+              })
             )}
 
             <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
@@ -1152,6 +1218,7 @@ function SettingsPageView({
         json={reasoningJson}
         jsonIssue={reasoningJsonIssue}
         items={reasoningItems}
+        models={models}
         onToggleMode={onReasoningToggleMode}
         onJsonChange={onReasoningJsonChange}
         onAddItem={onReasoningAddItem}
@@ -1164,6 +1231,7 @@ function SettingsPageView({
         json={extraJson}
         jsonIssue={extraJsonIssue}
         items={extraItems}
+        models={models}
         onToggleMode={onExtraToggleMode}
         onJsonChange={onExtraJsonChange}
         onAddItem={onExtraAddItem}

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -212,6 +212,204 @@ function parseReasoningJson(
   }
 }
 
+type ExtraPromptEditor = {
+  mode: JsonMode
+  items: ExtraPromptItem[]
+  json: string
+  jsonIssue: string | null
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ExtraPromptItem>) => void
+  setFromRecord: (record?: Record<string, string>) => void
+}
+
+type ReasoningEditor = {
+  mode: JsonMode
+  items: ReasoningItem[]
+  json: string
+  jsonIssue: string | null
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ReasoningItem>) => void
+  setFromRecord: (record?: Record<string, ReasoningEffort>) => void
+}
+
+function useExtraPromptEditor(
+  onRecordChange: (record: Record<string, string>) => void,
+): ExtraPromptEditor {
+  const [mode, setMode] = useState<JsonMode>("form")
+  const [items, setItems] = useState<ExtraPromptItem[]>([])
+  const [json, setJson] = useState("")
+  const [jsonError, setJsonError] = useState<string | null>(null)
+
+  const jsonIssue = useMemo(
+    () => (jsonError ? `extraPrompts: ${jsonError}` : null),
+    [jsonError],
+  )
+
+  const setFromRecord = useCallback((record?: Record<string, string>) => {
+    setItems(extraPromptItemsFromRecord(record))
+    setJson(JSON.stringify(record ?? {}, null, 2))
+    setJsonError(null)
+  }, [])
+
+  const updateItems = useCallback(
+    (nextItems: ExtraPromptItem[]) => {
+      setItems(nextItems)
+      onRecordChange(extraPromptRecordFromItems(nextItems))
+    },
+    [onRecordChange],
+  )
+
+  const onJsonChange = useCallback(
+    (value: string) => {
+      updateJsonRecord({
+        value,
+        parse: parseExtraPromptsJson,
+        setJson,
+        setError: setJsonError,
+        onRecord: (record) => updateItems(extraPromptItemsFromRecord(record)),
+      })
+    },
+    [updateItems],
+  )
+
+  const onToggleMode = useCallback(
+    (next: boolean) => {
+      toggleJsonMode({
+        next,
+        record: extraPromptRecordFromItems(items),
+        setJson,
+        setError: setJsonError,
+        setMode,
+      })
+    },
+    [items],
+  )
+
+  const onAddItem = useCallback(() => {
+    updateItems(items.concat({ id: createItemId(), model: "", prompt: "" }))
+  }, [items, updateItems])
+
+  const onRemoveItem = useCallback(
+    (id: string) => {
+      updateItems(items.filter((item) => item.id !== id))
+    },
+    [items, updateItems],
+  )
+
+  const onUpdateItem = useCallback(
+    (id: string, patch: Partial<ExtraPromptItem>) => {
+      const next = items.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  return {
+    mode,
+    items,
+    json,
+    jsonIssue,
+    onToggleMode,
+    onJsonChange,
+    onAddItem,
+    onRemoveItem,
+    onUpdateItem,
+    setFromRecord,
+  }
+}
+
+function useReasoningEditor(
+  onRecordChange: (record: Record<string, ReasoningEffort>) => void,
+): ReasoningEditor {
+  const [mode, setMode] = useState<JsonMode>("form")
+  const [items, setItems] = useState<ReasoningItem[]>([])
+  const [json, setJson] = useState("")
+  const [jsonError, setJsonError] = useState<string | null>(null)
+
+  const jsonIssue = useMemo(
+    () => (jsonError ? `modelReasoningEfforts: ${jsonError}` : null),
+    [jsonError],
+  )
+
+  const setFromRecord = useCallback((record?: Record<string, ReasoningEffort>) => {
+    setItems(reasoningItemsFromRecord(record))
+    setJson(JSON.stringify(record ?? {}, null, 2))
+    setJsonError(null)
+  }, [])
+
+  const updateItems = useCallback(
+    (nextItems: ReasoningItem[]) => {
+      setItems(nextItems)
+      onRecordChange(reasoningRecordFromItems(nextItems))
+    },
+    [onRecordChange],
+  )
+
+  const onJsonChange = useCallback(
+    (value: string) => {
+      updateJsonRecord({
+        value,
+        parse: parseReasoningJson,
+        setJson,
+        setError: setJsonError,
+        onRecord: (record) => updateItems(reasoningItemsFromRecord(record)),
+      })
+    },
+    [updateItems],
+  )
+
+  const onToggleMode = useCallback(
+    (next: boolean) => {
+      toggleJsonMode({
+        next,
+        record: reasoningRecordFromItems(items),
+        setJson,
+        setError: setJsonError,
+        setMode,
+      })
+    },
+    [items],
+  )
+
+  const onAddItem = useCallback(() => {
+    updateItems(items.concat({ id: createItemId(), model: "", effort: "high" }))
+  }, [items, updateItems])
+
+  const onRemoveItem = useCallback(
+    (id: string) => {
+      updateItems(items.filter((item) => item.id !== id))
+    },
+    [items, updateItems],
+  )
+
+  const onUpdateItem = useCallback(
+    (id: string, patch: Partial<ReasoningItem>) => {
+      const next = items.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  return {
+    mode,
+    items,
+    json,
+    jsonIssue,
+    onToggleMode,
+    onJsonChange,
+    onAddItem,
+    onRemoveItem,
+    onUpdateItem,
+    setFromRecord,
+  }
+}
+
 type GeneralSettingsCardProps = {
   hasModels: boolean
   smallModelLabel: string
@@ -237,6 +435,11 @@ function GeneralSettingsCard({
   onSmallModelInput,
   onApiKeyChange,
 }: GeneralSettingsCardProps): React.JSX.Element {
+  const showCustomModel =
+    hasModels
+    && smallModelValue !== "__default__"
+    && !models.includes(smallModelValue)
+
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
@@ -255,6 +458,11 @@ function GeneralSettingsCard({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="__default__">(default)</SelectItem>
+                {showCustomModel ? (
+                  <SelectItem value={smallModelValue}>
+                    Custom: {smallModelValue}
+                  </SelectItem>
+                ) : null}
                 {models.map((model) => (
                   <SelectItem key={model} value={model}>
                     {model}
@@ -587,27 +795,49 @@ export function SettingsPage(): React.JSX.Element {
   const [models, setModels] = useState<string[]>([])
   const [draft, setDraft] = useState<AdminConfig>({})
 
-  const [extraMode, setExtraMode] = useState<JsonMode>("form")
-  const [extraItems, setExtraItems] = useState<ExtraPromptItem[]>([])
-  const [extraJson, setExtraJson] = useState("")
-  const [extraJsonError, setExtraJsonError] = useState<string | null>(null)
+  const extraEditor = useExtraPromptEditor((record) =>
+    setDraft((prev) => ({ ...prev, extraPrompts: record })),
+  )
+  const reasoningEditor = useReasoningEditor((record) =>
+    setDraft((prev) => ({ ...prev, modelReasoningEfforts: record })),
+  )
 
-  const [reasoningMode, setReasoningMode] = useState<JsonMode>("form")
-  const [reasoningItems, setReasoningItems] = useState<ReasoningItem[]>([])
-  const [reasoningJson, setReasoningJson] = useState("")
-  const [reasoningJsonError, setReasoningJsonError] = useState<string | null>(null)
+  const {
+    mode: extraMode,
+    items: extraItems,
+    json: extraJson,
+    jsonIssue: extraPromptJsonIssue,
+    onToggleMode: toggleExtraMode,
+    onJsonChange: onExtraJsonChange,
+    onAddItem: handleExtraItemAdd,
+    onRemoveItem: handleExtraItemRemove,
+    onUpdateItem: handleExtraItemUpdate,
+    setFromRecord: setExtraFromRecord,
+  } = extraEditor
 
-  const applyConfigResponse = useCallback((config: AdminConfigResponse) => {
-    const { _configPath, ...configData } = config
-    setConfigPath(_configPath ?? null)
-    setDraft(configData)
-    setExtraItems(extraPromptItemsFromRecord(configData.extraPrompts))
-    setExtraJson(JSON.stringify(configData.extraPrompts ?? {}, null, 2))
-    setExtraJsonError(null)
-    setReasoningItems(reasoningItemsFromRecord(configData.modelReasoningEfforts))
-    setReasoningJson(JSON.stringify(configData.modelReasoningEfforts ?? {}, null, 2))
-    setReasoningJsonError(null)
-  }, [])
+  const {
+    mode: reasoningMode,
+    items: reasoningItems,
+    json: reasoningJson,
+    jsonIssue: reasoningJsonIssue,
+    onToggleMode: toggleReasoningMode,
+    onJsonChange: onReasoningJsonChange,
+    onAddItem: handleReasoningItemAdd,
+    onRemoveItem: handleReasoningItemRemove,
+    onUpdateItem: handleReasoningItemUpdate,
+    setFromRecord: setReasoningFromRecord,
+  } = reasoningEditor
+
+  const applyConfigResponse = useCallback(
+    (config: AdminConfigResponse) => {
+      const { _configPath, ...configData } = config
+      setConfigPath(_configPath ?? null)
+      setDraft(configData)
+      setExtraFromRecord(configData.extraPrompts)
+      setReasoningFromRecord(configData.modelReasoningEfforts)
+    },
+    [setExtraFromRecord, setReasoningFromRecord],
+  )
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -635,8 +865,8 @@ export function SettingsPage(): React.JSX.Element {
   const canSave =
     !saving
     && !loading
-    && !(extraMode === "json" && extraJsonError)
-    && !(reasoningMode === "json" && reasoningJsonError)
+    && !(extraMode === "json" && extraPromptJsonIssue)
+    && !(reasoningMode === "json" && reasoningJsonIssue)
 
   const envOverrideNote =
     "Environment variable COPILOT_API_KEY overrides this value when set."
@@ -644,16 +874,6 @@ export function SettingsPage(): React.JSX.Element {
   const smallModelLabel = hasModels ? "Small model" : "Small model (manual)"
   const smallModelInputValue = draft.smallModel ?? ""
   const apiKeyValue = draft.apiKey ?? ""
-
-  const extraPromptJsonIssue = useMemo(
-    () => (extraJsonError ? `extraPrompts: ${extraJsonError}` : null),
-    [extraJsonError]
-  )
-
-  const reasoningJsonIssue = useMemo(
-    () => (reasoningJsonError ? `modelReasoningEfforts: ${reasoningJsonError}` : null),
-    [reasoningJsonError]
-  )
 
   async function save(): Promise<void> {
     setSaving(true)
@@ -670,22 +890,6 @@ export function SettingsPage(): React.JSX.Element {
     } finally {
       setSaving(false)
     }
-  }
-
-  function updateExtraItems(nextItems: ExtraPromptItem[]): void {
-    setExtraItems(nextItems)
-    setDraft((prev) => ({
-      ...prev,
-      extraPrompts: extraPromptRecordFromItems(nextItems),
-    }))
-  }
-
-  function updateReasoningItems(nextItems: ReasoningItem[]): void {
-    setReasoningItems(nextItems)
-    setDraft((prev) => ({
-      ...prev,
-      modelReasoningEfforts: reasoningRecordFromItems(nextItems),
-    }))
   }
 
   function handleSmallModelSelect(value: string): void {
@@ -713,78 +917,6 @@ export function SettingsPage(): React.JSX.Element {
 
   function handleForceAgentToggle(value: boolean): void {
     setDraft((prev) => ({ ...prev, forceAgent: value }))
-  }
-
-  function handleExtraItemUpdate(id: string, patch: Partial<ExtraPromptItem>): void {
-    const next = extraItems.map((item) =>
-      item.id === id ? { ...item, ...patch } : item,
-    )
-    updateExtraItems(next)
-  }
-
-  function handleExtraItemRemove(id: string): void {
-    updateExtraItems(extraItems.filter((item) => item.id !== id))
-  }
-
-  function handleExtraItemAdd(): void {
-    updateExtraItems(extraItems.concat({ id: createItemId(), model: "", prompt: "" }))
-  }
-
-  function handleReasoningItemUpdate(id: string, patch: Partial<ReasoningItem>): void {
-    const next = reasoningItems.map((item) =>
-      item.id === id ? { ...item, ...patch } : item,
-    )
-    updateReasoningItems(next)
-  }
-
-  function handleReasoningItemRemove(id: string): void {
-    updateReasoningItems(reasoningItems.filter((item) => item.id !== id))
-  }
-
-  function handleReasoningItemAdd(): void {
-    updateReasoningItems(
-      reasoningItems.concat({ id: createItemId(), model: "", effort: "high" }),
-    )
-  }
-
-  function onExtraJsonChange(value: string): void {
-    updateJsonRecord({
-      value,
-      parse: parseExtraPromptsJson,
-      setJson: setExtraJson,
-      setError: setExtraJsonError,
-      onRecord: (record) => updateExtraItems(extraPromptItemsFromRecord(record)),
-    })
-  }
-
-  function onReasoningJsonChange(value: string): void {
-    updateJsonRecord({
-      value,
-      parse: parseReasoningJson,
-      setJson: setReasoningJson,
-      setError: setReasoningJsonError,
-      onRecord: (record) => updateReasoningItems(reasoningItemsFromRecord(record)),
-    })
-  }
-
-  function toggleExtraMode(next: boolean): void {
-    toggleJsonMode({
-      next,
-      record: draft.extraPrompts,
-      setJson: setExtraJson,
-      setError: setExtraJsonError,
-      setMode: setExtraMode,
-    })
-  }
-
-  function toggleReasoningMode(next: boolean): void {
-    toggleJsonMode({
-      next,
-      record: draft.modelReasoningEfforts,
-      setJson: setReasoningJson,
-      setError: setReasoningJsonError,
-      setMode: setReasoningMode,
-    })
   }
 
   return (

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -844,9 +844,26 @@ export function SettingsPage(): React.JSX.Element {
     setError(null)
 
     try {
-      const [configRes, modelsRes] = await Promise.all([getAdminConfig(), getAdminModels()])
-      applyConfigResponse(configRes)
-      setModels(modelsRes.items ?? [])
+      const [configRes, modelsRes] = await Promise.allSettled([
+        getAdminConfig(),
+        getAdminModels(),
+      ])
+
+      if (configRes.status === "fulfilled") {
+        applyConfigResponse(configRes.value)
+      } else {
+        throw configRes.reason
+      }
+
+      if (modelsRes.status === "fulfilled") {
+        setModels(modelsRes.value.items ?? [])
+      } else {
+        setModels([])
+        toast.error("Failed to load models", {
+          description:
+            modelsRes.reason instanceof Error ? modelsRes.reason.message : String(modelsRes.reason),
+        })
+      }
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
       setError(msg)

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button"
 import {
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
@@ -581,7 +582,7 @@ function ReasoningEffortsCard({
             <Textarea
               value={json}
               onChange={(e) => onJsonChange(e.target.value)}
-              className="min-h-[160px] font-mono text-xs"
+              className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
               placeholder='{ "gpt-5-mini": "low" }'
             />
             {jsonIssue ? (
@@ -726,7 +727,7 @@ function ExtraPromptsCard({
             <Textarea
               value={json}
               onChange={(e) => onJsonChange(e.target.value)}
-              className="min-h-[200px] font-mono text-xs"
+              className="min-h-[200px] lg:min-h-[140px] max-h-[40vh] overflow-auto font-mono text-xs"
               placeholder='{ "gpt-5-mini": "..." }'
             />
             {jsonIssue ? (
@@ -785,7 +786,7 @@ function ExtraPromptsCard({
                     <Textarea
                       value={item.prompt}
                       onChange={(e) => onUpdateItem(item.id, { prompt: e.target.value })}
-                      className="min-h-[120px] font-mono text-xs"
+                      className="min-h-[120px] lg:min-h-[96px] max-h-[30vh] overflow-auto font-mono text-xs"
                       placeholder="System prompt snippet..."
                     />
                     <div className="text-muted-foreground text-xs">
@@ -1165,7 +1166,7 @@ function SettingsPageView({
   onForceAgentToggle,
 }: SettingsPageViewProps): React.JSX.Element {
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-3">
         <div className="min-w-0">
           <div className="text-lg font-semibold">Settings</div>
@@ -1174,7 +1175,7 @@ function SettingsPageView({
           </div>
         </div>
 
-        <div className="ml-auto flex flex-wrap items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center gap-2 lg:hidden">
           <Button type="button" variant="outline" size="sm" onClick={onReload} disabled={loading || saving}>
             {loading ? "Reloading..." : "Reload"}
           </Button>
@@ -1183,10 +1184,6 @@ function SettingsPageView({
           </RainbowButton>
         </div>
       </div>
-
-      {configPath ? (
-        <div className="text-muted-foreground text-xs">Config path: {configPath}</div>
-      ) : null}
 
       {error ? (
         <InlineAlert
@@ -1198,53 +1195,91 @@ function SettingsPageView({
         />
       ) : null}
 
-      <GeneralSettingsCard
-        hasModels={hasModels}
-        smallModelLabel={smallModelLabel}
-        smallModelValue={smallModelValue}
-        smallModelInputValue={smallModelInputValue}
-        models={models}
-        apiKeyValue={apiKeyValue}
-        envOverrideNote={envOverrideNote}
-        onSmallModelSelect={onSmallModelSelect}
-        onSmallModelInput={onSmallModelInput}
-        onApiKeyChange={onApiKeyChange}
-      />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-12 auto-rows-min">
+        <div className="space-y-4 lg:col-span-8">
+          <GeneralSettingsCard
+            hasModels={hasModels}
+            smallModelLabel={smallModelLabel}
+            smallModelValue={smallModelValue}
+            smallModelInputValue={smallModelInputValue}
+            models={models}
+            apiKeyValue={apiKeyValue}
+            envOverrideNote={envOverrideNote}
+            onSmallModelSelect={onSmallModelSelect}
+            onSmallModelInput={onSmallModelInput}
+            onApiKeyChange={onApiKeyChange}
+          />
 
-      <LoadBalancingCard enabled={loadBalancingEnabled} onToggle={onLoadBalancingToggle} />
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <ReasoningEffortsCard
+              mode={reasoningMode}
+              json={reasoningJson}
+              jsonIssue={reasoningJsonIssue}
+              items={reasoningItems}
+              models={models}
+              onToggleMode={onReasoningToggleMode}
+              onJsonChange={onReasoningJsonChange}
+              onAddItem={onReasoningAddItem}
+              onRemoveItem={onReasoningRemoveItem}
+              onUpdateItem={onReasoningUpdateItem}
+            />
 
-      <ReasoningEffortsCard
-        mode={reasoningMode}
-        json={reasoningJson}
-        jsonIssue={reasoningJsonIssue}
-        items={reasoningItems}
-        models={models}
-        onToggleMode={onReasoningToggleMode}
-        onJsonChange={onReasoningJsonChange}
-        onAddItem={onReasoningAddItem}
-        onRemoveItem={onReasoningRemoveItem}
-        onUpdateItem={onReasoningUpdateItem}
-      />
+            <ExtraPromptsCard
+              mode={extraMode}
+              json={extraJson}
+              jsonIssue={extraJsonIssue}
+              items={extraItems}
+              models={models}
+              onToggleMode={onExtraToggleMode}
+              onJsonChange={onExtraJsonChange}
+              onAddItem={onExtraAddItem}
+              onRemoveItem={onExtraRemoveItem}
+              onUpdateItem={onExtraUpdateItem}
+            />
+          </div>
+        </div>
 
-      <ExtraPromptsCard
-        mode={extraMode}
-        json={extraJson}
-        jsonIssue={extraJsonIssue}
-        items={extraItems}
-        models={models}
-        onToggleMode={onExtraToggleMode}
-        onJsonChange={onExtraJsonChange}
-        onAddItem={onExtraAddItem}
-        onRemoveItem={onExtraRemoveItem}
-        onUpdateItem={onExtraUpdateItem}
-      />
+        <aside className="space-y-4 self-start lg:col-span-4 lg:sticky lg:top-6">
+          <LoadBalancingCard enabled={loadBalancingEnabled} onToggle={onLoadBalancingToggle} />
 
-      <AdvancedSettingsCard
-        useFunctionApplyPatch={useFunctionApplyPatch}
-        forceAgent={forceAgent}
-        onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
-        onToggleForceAgent={onForceAgentToggle}
-      />
+          <AdvancedSettingsCard
+            useFunctionApplyPatch={useFunctionApplyPatch}
+            forceAgent={forceAgent}
+            onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
+            onToggleForceAgent={onForceAgentToggle}
+          />
+
+          <Card className="hidden gap-4 py-4 lg:block">
+            <CardHeader className="px-4">
+              <CardTitle>Actions</CardTitle>
+              <CardAction className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onReload}
+                  disabled={loading || saving}
+                >
+                  {loading ? "Reloading..." : "Reload"}
+                </Button>
+                <RainbowButton type="button" size="sm" onClick={onSave} disabled={!canSave}>
+                  {saving ? "Saving..." : "Save"}
+                </RainbowButton>
+              </CardAction>
+            </CardHeader>
+            <CardContent className="space-y-2 px-4">
+              {configPath ? (
+                <div className="text-muted-foreground text-xs">
+                  Config path: {configPath}
+                </div>
+              ) : null}
+              <div className="text-muted-foreground text-xs">
+                Changes apply to config.json immediately. Environment variables take precedence.
+              </div>
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
     </div>
   )
 }

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -786,7 +786,51 @@ function AdvancedSettingsCard({
   )
 }
 
-export function SettingsPage(): React.JSX.Element {
+type SettingsPageViewProps = {
+  loading: boolean
+  saving: boolean
+  error: string | null
+  configPath: string | null
+  canSave: boolean
+  onReload: () => void
+  onSave: () => void
+  hasModels: boolean
+  smallModelLabel: string
+  smallModelValue: string
+  smallModelInputValue: string
+  models: string[]
+  apiKeyValue: string
+  envOverrideNote: string
+  onSmallModelSelect: (value: string) => void
+  onSmallModelInput: (value: string) => void
+  onApiKeyChange: (value: string) => void
+  loadBalancingEnabled: boolean
+  onLoadBalancingToggle: (value: boolean) => void
+  reasoningMode: JsonMode
+  reasoningJson: string
+  reasoningJsonIssue: string | null
+  reasoningItems: ReasoningItem[]
+  onReasoningToggleMode: (next: boolean) => void
+  onReasoningJsonChange: (value: string) => void
+  onReasoningAddItem: () => void
+  onReasoningRemoveItem: (id: string) => void
+  onReasoningUpdateItem: (id: string, value: Partial<ReasoningItem>) => void
+  extraMode: JsonMode
+  extraJson: string
+  extraJsonIssue: string | null
+  extraItems: ExtraPromptItem[]
+  onExtraToggleMode: (next: boolean) => void
+  onExtraJsonChange: (value: string) => void
+  onExtraAddItem: () => void
+  onExtraRemoveItem: (id: string) => void
+  onExtraUpdateItem: (id: string, value: Partial<ExtraPromptItem>) => void
+  useFunctionApplyPatch: boolean
+  forceAgent: boolean
+  onUseFunctionApplyPatchToggle: (value: boolean) => void
+  onForceAgentToggle: (value: boolean) => void
+}
+
+function useSettingsPageState(): SettingsPageViewProps {
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -806,12 +850,12 @@ export function SettingsPage(): React.JSX.Element {
     mode: extraMode,
     items: extraItems,
     json: extraJson,
-    jsonIssue: extraPromptJsonIssue,
-    onToggleMode: toggleExtraMode,
+    jsonIssue: extraJsonIssue,
+    onToggleMode: onExtraToggleMode,
     onJsonChange: onExtraJsonChange,
-    onAddItem: handleExtraItemAdd,
-    onRemoveItem: handleExtraItemRemove,
-    onUpdateItem: handleExtraItemUpdate,
+    onAddItem: onExtraAddItem,
+    onRemoveItem: onExtraRemoveItem,
+    onUpdateItem: onExtraUpdateItem,
     setFromRecord: setExtraFromRecord,
   } = extraEditor
 
@@ -820,11 +864,11 @@ export function SettingsPage(): React.JSX.Element {
     items: reasoningItems,
     json: reasoningJson,
     jsonIssue: reasoningJsonIssue,
-    onToggleMode: toggleReasoningMode,
+    onToggleMode: onReasoningToggleMode,
     onJsonChange: onReasoningJsonChange,
-    onAddItem: handleReasoningItemAdd,
-    onRemoveItem: handleReasoningItemRemove,
-    onUpdateItem: handleReasoningItemUpdate,
+    onAddItem: onReasoningAddItem,
+    onRemoveItem: onReasoningRemoveItem,
+    onUpdateItem: onReasoningUpdateItem,
     setFromRecord: setReasoningFromRecord,
   } = reasoningEditor
 
@@ -877,22 +921,7 @@ export function SettingsPage(): React.JSX.Element {
     void load()
   }, [load])
 
-  const hasModels = models.length > 0
-  const smallModelValue = draft.smallModel ? draft.smallModel : "__default__"
-  const canSave =
-    !saving
-    && !loading
-    && !(extraMode === "json" && extraPromptJsonIssue)
-    && !(reasoningMode === "json" && reasoningJsonIssue)
-
-  const envOverrideNote =
-    "Environment variable COPILOT_API_KEY overrides this value when set."
-
-  const smallModelLabel = hasModels ? "Small model" : "Small model (manual)"
-  const smallModelInputValue = draft.smallModel ?? ""
-  const apiKeyValue = draft.apiKey ?? ""
-
-  async function save(): Promise<void> {
+  const save = useCallback(async () => {
     setSaving(true)
     setError(null)
 
@@ -907,35 +936,168 @@ export function SettingsPage(): React.JSX.Element {
     } finally {
       setSaving(false)
     }
-  }
+  }, [applyConfigResponse, draft])
 
-  function handleSmallModelSelect(value: string): void {
-    setDraft((prev) => ({
-      ...prev,
-      smallModel: value === "__default__" ? "" : value,
-    }))
-  }
+  const onReload = useCallback(() => {
+    void load()
+  }, [load])
 
-  function handleSmallModelInput(value: string): void {
-    setDraft((prev) => ({ ...prev, smallModel: value }))
-  }
+  const onSave = useCallback(() => {
+    void save()
+  }, [save])
 
-  function handleApiKeyChange(value: string): void {
-    setDraft((prev) => ({ ...prev, apiKey: value }))
-  }
+  const handleSmallModelSelect = useCallback(
+    (value: string) => {
+      setDraft((prev) => ({
+        ...prev,
+        smallModel: value === "__default__" ? "" : value,
+      }))
+    },
+    [setDraft],
+  )
 
-  function handleLoadBalancingToggle(value: boolean): void {
-    setDraft((prev) => ({ ...prev, freeModelLoadBalancing: value }))
-  }
+  const handleSmallModelInput = useCallback(
+    (value: string) => {
+      setDraft((prev) => ({ ...prev, smallModel: value }))
+    },
+    [setDraft],
+  )
 
-  function handleUseFunctionApplyPatchToggle(value: boolean): void {
-    setDraft((prev) => ({ ...prev, useFunctionApplyPatch: value }))
-  }
+  const handleApiKeyChange = useCallback(
+    (value: string) => {
+      setDraft((prev) => ({ ...prev, apiKey: value }))
+    },
+    [setDraft],
+  )
 
-  function handleForceAgentToggle(value: boolean): void {
-    setDraft((prev) => ({ ...prev, forceAgent: value }))
-  }
+  const handleLoadBalancingToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, freeModelLoadBalancing: value }))
+    },
+    [setDraft],
+  )
 
+  const handleUseFunctionApplyPatchToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, useFunctionApplyPatch: value }))
+    },
+    [setDraft],
+  )
+
+  const handleForceAgentToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, forceAgent: value }))
+    },
+    [setDraft],
+  )
+
+  const hasModels = models.length > 0
+  const smallModelValue = draft.smallModel ? draft.smallModel : "__default__"
+  const canSave =
+    !saving
+    && !loading
+    && !(extraMode === "json" && extraJsonIssue)
+    && !(reasoningMode === "json" && reasoningJsonIssue)
+
+  const envOverrideNote =
+    "Environment variable COPILOT_API_KEY overrides this value when set."
+
+  const smallModelLabel = hasModels ? "Small model" : "Small model (manual)"
+  const smallModelInputValue = draft.smallModel ?? ""
+  const apiKeyValue = draft.apiKey ?? ""
+
+  const loadBalancingEnabled = draft.freeModelLoadBalancing ?? true
+  const useFunctionApplyPatch = draft.useFunctionApplyPatch ?? true
+  const forceAgent = draft.forceAgent ?? false
+
+  return {
+    loading,
+    saving,
+    error,
+    configPath,
+    canSave,
+    onReload,
+    onSave,
+    hasModels,
+    smallModelLabel,
+    smallModelValue,
+    smallModelInputValue,
+    models,
+    apiKeyValue,
+    envOverrideNote,
+    onSmallModelSelect: handleSmallModelSelect,
+    onSmallModelInput: handleSmallModelInput,
+    onApiKeyChange: handleApiKeyChange,
+    loadBalancingEnabled,
+    onLoadBalancingToggle: handleLoadBalancingToggle,
+    reasoningMode,
+    reasoningJson,
+    reasoningJsonIssue,
+    reasoningItems,
+    onReasoningToggleMode,
+    onReasoningJsonChange,
+    onReasoningAddItem,
+    onReasoningRemoveItem,
+    onReasoningUpdateItem,
+    extraMode,
+    extraJson,
+    extraJsonIssue,
+    extraItems,
+    onExtraToggleMode,
+    onExtraJsonChange,
+    onExtraAddItem,
+    onExtraRemoveItem,
+    onExtraUpdateItem,
+    useFunctionApplyPatch,
+    forceAgent,
+    onUseFunctionApplyPatchToggle: handleUseFunctionApplyPatchToggle,
+    onForceAgentToggle: handleForceAgentToggle,
+  }
+}
+
+function SettingsPageView({
+  loading,
+  saving,
+  error,
+  configPath,
+  canSave,
+  onReload,
+  onSave,
+  hasModels,
+  smallModelLabel,
+  smallModelValue,
+  smallModelInputValue,
+  models,
+  apiKeyValue,
+  envOverrideNote,
+  onSmallModelSelect,
+  onSmallModelInput,
+  onApiKeyChange,
+  loadBalancingEnabled,
+  onLoadBalancingToggle,
+  reasoningMode,
+  reasoningJson,
+  reasoningJsonIssue,
+  reasoningItems,
+  onReasoningToggleMode,
+  onReasoningJsonChange,
+  onReasoningAddItem,
+  onReasoningRemoveItem,
+  onReasoningUpdateItem,
+  extraMode,
+  extraJson,
+  extraJsonIssue,
+  extraItems,
+  onExtraToggleMode,
+  onExtraJsonChange,
+  onExtraAddItem,
+  onExtraRemoveItem,
+  onExtraUpdateItem,
+  useFunctionApplyPatch,
+  forceAgent,
+  onUseFunctionApplyPatchToggle,
+  onForceAgentToggle,
+}: SettingsPageViewProps): React.JSX.Element {
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
@@ -947,16 +1109,10 @@ export function SettingsPage(): React.JSX.Element {
         </div>
 
         <div className="ml-auto flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => void load()}
-            disabled={loading || saving}
-          >
+          <Button type="button" variant="outline" size="sm" onClick={onReload} disabled={loading || saving}>
             {loading ? "Reloading..." : "Reload"}
           </Button>
-          <RainbowButton type="button" size="sm" onClick={() => void save()} disabled={!canSave}>
+          <RainbowButton type="button" size="sm" onClick={onSave} disabled={!canSave}>
             {saving ? "Saving..." : "Save"}
           </RainbowButton>
         </div>
@@ -972,7 +1128,7 @@ export function SettingsPage(): React.JSX.Element {
           title="Settings error"
           description={error}
           actionLabel="Retry"
-          onAction={() => void load()}
+          onAction={onReload}
         />
       ) : null}
 
@@ -984,46 +1140,48 @@ export function SettingsPage(): React.JSX.Element {
         models={models}
         apiKeyValue={apiKeyValue}
         envOverrideNote={envOverrideNote}
-        onSmallModelSelect={handleSmallModelSelect}
-        onSmallModelInput={handleSmallModelInput}
-        onApiKeyChange={handleApiKeyChange}
+        onSmallModelSelect={onSmallModelSelect}
+        onSmallModelInput={onSmallModelInput}
+        onApiKeyChange={onApiKeyChange}
       />
 
-      <LoadBalancingCard
-        enabled={draft.freeModelLoadBalancing ?? true}
-        onToggle={handleLoadBalancingToggle}
-      />
+      <LoadBalancingCard enabled={loadBalancingEnabled} onToggle={onLoadBalancingToggle} />
 
       <ReasoningEffortsCard
         mode={reasoningMode}
         json={reasoningJson}
         jsonIssue={reasoningJsonIssue}
         items={reasoningItems}
-        onToggleMode={toggleReasoningMode}
+        onToggleMode={onReasoningToggleMode}
         onJsonChange={onReasoningJsonChange}
-        onAddItem={handleReasoningItemAdd}
-        onRemoveItem={handleReasoningItemRemove}
-        onUpdateItem={handleReasoningItemUpdate}
+        onAddItem={onReasoningAddItem}
+        onRemoveItem={onReasoningRemoveItem}
+        onUpdateItem={onReasoningUpdateItem}
       />
 
       <ExtraPromptsCard
         mode={extraMode}
         json={extraJson}
-        jsonIssue={extraPromptJsonIssue}
+        jsonIssue={extraJsonIssue}
         items={extraItems}
-        onToggleMode={toggleExtraMode}
+        onToggleMode={onExtraToggleMode}
         onJsonChange={onExtraJsonChange}
-        onAddItem={handleExtraItemAdd}
-        onRemoveItem={handleExtraItemRemove}
-        onUpdateItem={handleExtraItemUpdate}
+        onAddItem={onExtraAddItem}
+        onRemoveItem={onExtraRemoveItem}
+        onUpdateItem={onExtraUpdateItem}
       />
 
       <AdvancedSettingsCard
-        useFunctionApplyPatch={draft.useFunctionApplyPatch ?? true}
-        forceAgent={draft.forceAgent ?? false}
-        onToggleUseFunctionApplyPatch={handleUseFunctionApplyPatchToggle}
-        onToggleForceAgent={handleForceAgentToggle}
+        useFunctionApplyPatch={useFunctionApplyPatch}
+        forceAgent={forceAgent}
+        onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
+        onToggleForceAgent={onForceAgentToggle}
       />
     </div>
   )
+}
+
+export function SettingsPage(): React.JSX.Element {
+  const state = useSettingsPageState()
+  return <SettingsPageView {...state} />
 }

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1,0 +1,697 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import {
+  AdminApiError,
+  type AdminConfig,
+  type AdminConfigResponse,
+  type ReasoningEffort,
+  getAdminConfig,
+  getAdminModels,
+  updateAdminConfig,
+} from "@/lib/admin-api"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { InlineAlert } from "@/components/ui/inline-alert"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RainbowButton } from "@/components/ui/rainbow-button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+
+const REASONING_EFFORTS: ReasoningEffort[] = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]
+
+type ExtraPromptItem = {
+  model: string
+  prompt: string
+}
+
+type ReasoningItem = {
+  model: string
+  effort: ReasoningEffort
+}
+
+type ParseResult<T> = { record: T } | { error: string }
+
+type JsonMode = "form" | "json"
+
+function toggleJsonMode<TRecord>(
+  next: boolean,
+  record: TRecord | undefined,
+  setJson: (value: string) => void,
+  setError: (value: string | null) => void,
+  setMode: (mode: JsonMode) => void,
+): void {
+  if (next) {
+    setJson(JSON.stringify(record ?? {}, null, 2))
+  }
+  setError(null)
+  setMode(next ? "json" : "form")
+}
+
+function updateJsonRecord<TRecord>(
+  value: string,
+  parse: (value: string) => ParseResult<TRecord>,
+  setJson: (value: string) => void,
+  setError: (value: string | null) => void,
+  onRecord: (record: TRecord) => void,
+): void {
+  setJson(value)
+  const result = parse(value)
+  if ("error" in result) {
+    setError(result.error)
+    return
+  }
+  setError(null)
+  onRecord(result.record)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function extraPromptItemsFromRecord(
+  record: Record<string, string> | undefined
+): ExtraPromptItem[] {
+  if (!record) return []
+  return Object.entries(record).map(([model, prompt]) => ({ model, prompt }))
+}
+
+function reasoningItemsFromRecord(
+  record: Record<string, ReasoningEffort> | undefined
+): ReasoningItem[] {
+  if (!record) return []
+  return Object.entries(record).map(([model, effort]) => ({ model, effort }))
+}
+
+function extraPromptRecordFromItems(items: ExtraPromptItem[]): Record<string, string> {
+  const record: Record<string, string> = {}
+  for (const item of items) {
+    const key = item.model.trim()
+    if (!key) continue
+    record[key] = item.prompt
+  }
+  return record
+}
+
+function reasoningRecordFromItems(items: ReasoningItem[]): Record<string, ReasoningEffort> {
+  const record: Record<string, ReasoningEffort> = {}
+  for (const item of items) {
+    const key = item.model.trim()
+    if (!key) continue
+    record[key] = item.effort
+  }
+  return record
+}
+
+function parseExtraPromptsJson(
+  value: string,
+): ParseResult<Record<string, string>> {
+  if (!value.trim()) return { record: {} }
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (!isPlainObject(parsed)) {
+      return { error: "extraPrompts JSON must be an object of string values." }
+    }
+
+    const record: Record<string, string> = {}
+    for (const [key, prompt] of Object.entries(parsed)) {
+      if (typeof prompt !== "string") {
+        return { error: `extraPrompts.${key} must be a string.` }
+      }
+      record[key] = prompt
+    }
+
+    return { record }
+  } catch {
+    return { error: "extraPrompts JSON is not valid." }
+  }
+}
+
+function parseReasoningJson(
+  value: string,
+): ParseResult<Record<string, ReasoningEffort>> {
+  if (!value.trim()) return { record: {} }
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (!isPlainObject(parsed)) {
+      return { error: "modelReasoningEfforts JSON must be an object." }
+    }
+
+    const record: Record<string, ReasoningEffort> = {}
+    for (const [key, effort] of Object.entries(parsed)) {
+      if (typeof effort !== "string") {
+        return { error: `modelReasoningEfforts.${key} must be a string.` }
+      }
+      if (!REASONING_EFFORTS.includes(effort as ReasoningEffort)) {
+        return {
+          error: `modelReasoningEfforts.${key} must be one of ${REASONING_EFFORTS.join(", ")}.`,
+        }
+      }
+      record[key] = effort as ReasoningEffort
+    }
+
+    return { record }
+  } catch {
+    return { error: "modelReasoningEfforts JSON is not valid." }
+  }
+}
+
+export function SettingsPage(): React.JSX.Element {
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [configPath, setConfigPath] = useState<string | null>(null)
+
+  const [models, setModels] = useState<string[]>([])
+  const [draft, setDraft] = useState<AdminConfig>({})
+
+  const [extraMode, setExtraMode] = useState<JsonMode>("form")
+  const [extraItems, setExtraItems] = useState<ExtraPromptItem[]>([])
+  const [extraJson, setExtraJson] = useState("")
+  const [extraJsonError, setExtraJsonError] = useState<string | null>(null)
+
+  const [reasoningMode, setReasoningMode] = useState<JsonMode>("form")
+  const [reasoningItems, setReasoningItems] = useState<ReasoningItem[]>([])
+  const [reasoningJson, setReasoningJson] = useState("")
+  const [reasoningJsonError, setReasoningJsonError] = useState<string | null>(null)
+
+  const applyConfigResponse = useCallback((config: AdminConfigResponse) => {
+    const { _configPath, ...configData } = config
+    setConfigPath(_configPath ?? null)
+    setDraft(configData)
+    setExtraItems(extraPromptItemsFromRecord(configData.extraPrompts))
+    setExtraJson(JSON.stringify(configData.extraPrompts ?? {}, null, 2))
+    setExtraJsonError(null)
+    setReasoningItems(reasoningItemsFromRecord(configData.modelReasoningEfforts))
+    setReasoningJson(JSON.stringify(configData.modelReasoningEfforts ?? {}, null, 2))
+    setReasoningJsonError(null)
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const [configRes, modelsRes] = await Promise.all([getAdminConfig(), getAdminModels()])
+      applyConfigResponse(configRes)
+      setModels(modelsRes.items ?? [])
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      setError(msg)
+      toast.error("Failed to load config", { description: msg })
+    } finally {
+      setLoading(false)
+    }
+  }, [applyConfigResponse])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const hasModels = models.length > 0
+  const smallModelValue = draft.smallModel ? draft.smallModel : "__default__"
+  const canSave =
+    !saving
+    && !loading
+    && !(extraMode === "json" && extraJsonError)
+    && !(reasoningMode === "json" && reasoningJsonError)
+
+  const envOverrideNote =
+    "Environment variable COPILOT_API_KEY overrides this value when set."
+
+  const smallModelLabel = hasModels ? "Small model" : "Small model (manual)"
+
+  const extraPromptJsonIssue = useMemo(
+    () => (extraJsonError ? `extraPrompts: ${extraJsonError}` : null),
+    [extraJsonError]
+  )
+
+  const reasoningJsonIssue = useMemo(
+    () => (reasoningJsonError ? `modelReasoningEfforts: ${reasoningJsonError}` : null),
+    [reasoningJsonError]
+  )
+
+  async function save(): Promise<void> {
+    setSaving(true)
+    setError(null)
+
+    try {
+      const updated = await updateAdminConfig(draft)
+      applyConfigResponse(updated)
+      toast.success("Config saved")
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      setError(msg)
+      toast.error("Failed to save config", { description: msg })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function updateExtraItems(nextItems: ExtraPromptItem[]): void {
+    setExtraItems(nextItems)
+    setDraft((prev) => ({
+      ...prev,
+      extraPrompts: extraPromptRecordFromItems(nextItems),
+    }))
+  }
+
+  function updateReasoningItems(nextItems: ReasoningItem[]): void {
+    setReasoningItems(nextItems)
+    setDraft((prev) => ({
+      ...prev,
+      modelReasoningEfforts: reasoningRecordFromItems(nextItems),
+    }))
+  }
+
+  function onExtraJsonChange(value: string): void {
+    updateJsonRecord(
+      value,
+      parseExtraPromptsJson,
+      setExtraJson,
+      setExtraJsonError,
+      (record) => updateExtraItems(extraPromptItemsFromRecord(record)),
+    )
+  }
+
+  function onReasoningJsonChange(value: string): void {
+    updateJsonRecord(
+      value,
+      parseReasoningJson,
+      setReasoningJson,
+      setReasoningJsonError,
+      (record) => updateReasoningItems(reasoningItemsFromRecord(record)),
+    )
+  }
+
+  function toggleExtraMode(next: boolean): void {
+    toggleJsonMode(
+      next,
+      draft.extraPrompts,
+      setExtraJson,
+      setExtraJsonError,
+      setExtraMode,
+    )
+  }
+
+  function toggleReasoningMode(next: boolean): void {
+    toggleJsonMode(
+      next,
+      draft.modelReasoningEfforts,
+      setReasoningJson,
+      setReasoningJsonError,
+      setReasoningMode,
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="min-w-0">
+          <div className="text-lg font-semibold">Settings</div>
+          <div className="text-muted-foreground text-sm">
+            Manage config.json and apply updates instantly.
+          </div>
+        </div>
+
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void load()}
+            disabled={loading || saving}
+          >
+            {loading ? "Reloading..." : "Reload"}
+          </Button>
+          <RainbowButton type="button" size="sm" onClick={() => void save()} disabled={!canSave}>
+            {saving ? "Saving..." : "Save"}
+          </RainbowButton>
+        </div>
+      </div>
+
+      {configPath ? (
+        <div className="text-muted-foreground text-xs">Config path: {configPath}</div>
+      ) : null}
+
+      {error ? (
+        <InlineAlert
+          variant="error"
+          title="Settings error"
+          description={error}
+          actionLabel="Retry"
+          onAction={() => void load()}
+        />
+      ) : null}
+
+      <Card className="gap-4 py-4">
+        <CardHeader className="px-4">
+          <CardTitle>General</CardTitle>
+          <CardDescription className="hidden sm:block">
+            Default model routing and API key storage.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 px-4">
+          <div className="grid gap-2">
+            <Label className="text-muted-foreground text-xs">{smallModelLabel}</Label>
+            {hasModels ? (
+              <Select
+                value={smallModelValue}
+                onValueChange={(value) =>
+                  setDraft((prev) => ({
+                    ...prev,
+                    smallModel: value === "__default__" ? "" : value,
+                  }))
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select small model" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__default__">(default)</SelectItem>
+                  {models.map((model) => (
+                    <SelectItem key={model} value={model}>
+                      {model}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                placeholder="gpt-5-mini"
+                value={draft.smallModel ?? ""}
+                onChange={(e) =>
+                  setDraft((prev) => ({ ...prev, smallModel: e.target.value }))
+                }
+              />
+            )}
+            <div className="text-muted-foreground text-xs">
+              Controls which model receives lightweight/free requests when routing.
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label className="text-muted-foreground text-xs">API key</Label>
+            <Input
+              placeholder="sk-..."
+              value={draft.apiKey ?? ""}
+              onChange={(e) => setDraft((prev) => ({ ...prev, apiKey: e.target.value }))}
+            />
+            <div className="text-muted-foreground text-xs">
+              {envOverrideNote} Leave empty to clear config value.
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="gap-4 py-4">
+        <CardHeader className="px-4">
+          <CardTitle>Load balancing</CardTitle>
+          <CardDescription className="hidden sm:block">
+            Toggle free account load balancing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <div className="text-sm font-medium">Free model load balancing</div>
+              <div className="text-muted-foreground text-xs">
+                When enabled, distributes free traffic across available accounts.
+              </div>
+            </div>
+            <Switch
+              checked={draft.freeModelLoadBalancing ?? true}
+              onCheckedChange={(value) =>
+                setDraft((prev) => ({ ...prev, freeModelLoadBalancing: value }))
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="gap-4 py-4">
+        <CardHeader className="px-4">
+          <CardTitle>Reasoning efforts</CardTitle>
+          <CardDescription className="hidden sm:block">
+            Override model reasoning effort levels.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-muted-foreground text-xs">
+              Define per-model reasoning effort (optional).
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch checked={reasoningMode === "json"} onCheckedChange={toggleReasoningMode} />
+              <Label className="text-muted-foreground text-xs">JSON mode</Label>
+            </div>
+          </div>
+
+          {reasoningMode === "json" ? (
+            <div className="space-y-2">
+              <Textarea
+                value={reasoningJson}
+                onChange={(e) => onReasoningJsonChange(e.target.value)}
+                className="min-h-[160px] font-mono text-xs"
+                placeholder='{ "gpt-5-mini": "low" }'
+              />
+              {reasoningJsonIssue ? (
+                <InlineAlert
+                  variant="warning"
+                  title="Invalid JSON"
+                  description={reasoningJsonIssue}
+                />
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {reasoningItems.length === 0 ? (
+                <div className="text-muted-foreground text-sm">
+                  No reasoning overrides. Add a model below.
+                </div>
+              ) : (
+                reasoningItems.map((item, index) => (
+                  <div key={`${item.model}-${index}`} className="grid gap-2 rounded-lg border p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        placeholder="model id"
+                        value={item.model}
+                        onChange={(e) => {
+                          const next = [...reasoningItems]
+                          next[index] = { ...item, model: e.target.value }
+                          updateReasoningItems(next)
+                        }}
+                      />
+                      <Select
+                        value={item.effort}
+                        onValueChange={(value) => {
+                          const next = [...reasoningItems]
+                          next[index] = { ...item, effort: value as ReasoningEffort }
+                          updateReasoningItems(next)
+                        }}
+                      >
+                        <SelectTrigger className="w-40">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {REASONING_EFFORTS.map((effort) => (
+                            <SelectItem key={effort} value={effort}>
+                              {effort}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          const next = reasoningItems.filter((_, i) => i !== index)
+                          updateReasoningItems(next)
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                      Overrides reasoning effort for this model.
+                    </div>
+                  </div>
+                ))
+              )}
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  updateReasoningItems(
+                    reasoningItems.concat({ model: "", effort: "high" })
+                  )
+                }
+              >
+                Add model override
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="gap-4 py-4">
+        <CardHeader className="px-4">
+          <CardTitle>Extra prompts</CardTitle>
+          <CardDescription className="hidden sm:block">
+            Inject extra system prompts per model.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-muted-foreground text-xs">
+              Add or edit prompt snippets injected for specific models.
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch checked={extraMode === "json"} onCheckedChange={toggleExtraMode} />
+              <Label className="text-muted-foreground text-xs">JSON mode</Label>
+            </div>
+          </div>
+
+          {extraMode === "json" ? (
+            <div className="space-y-2">
+              <Textarea
+                value={extraJson}
+                onChange={(e) => onExtraJsonChange(e.target.value)}
+                className="min-h-[200px] font-mono text-xs"
+                placeholder='{ "gpt-5-mini": "..." }'
+              />
+              {extraPromptJsonIssue ? (
+                <InlineAlert
+                  variant="warning"
+                  title="Invalid JSON"
+                  description={extraPromptJsonIssue}
+                />
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {extraItems.length === 0 ? (
+                <div className="text-muted-foreground text-sm">
+                  No extra prompts configured.
+                </div>
+              ) : (
+                extraItems.map((item, index) => (
+                  <div key={`${item.model}-${index}`} className="grid gap-2 rounded-lg border p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        placeholder="model id"
+                        value={item.model}
+                        onChange={(e) => {
+                          const next = [...extraItems]
+                          next[index] = { ...item, model: e.target.value }
+                          updateExtraItems(next)
+                        }}
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          const next = extraItems.filter((_, i) => i !== index)
+                          updateExtraItems(next)
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                    <Textarea
+                      value={item.prompt}
+                      onChange={(e) => {
+                        const next = [...extraItems]
+                        next[index] = { ...item, prompt: e.target.value }
+                        updateExtraItems(next)
+                      }}
+                      className="min-h-[120px] font-mono text-xs"
+                      placeholder="System prompt snippet..."
+                    />
+                    <div className="text-muted-foreground text-xs">
+                      Adds prompt content before model execution.
+                    </div>
+                  </div>
+                ))
+              )}
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => updateExtraItems(extraItems.concat({ model: "", prompt: "" }))}
+              >
+                Add prompt
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="gap-4 py-4">
+        <CardHeader className="px-4">
+          <CardTitle>Advanced</CardTitle>
+          <CardDescription className="hidden sm:block">
+            Feature flags and experimental toggles.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <div className="text-sm font-medium">Use function apply_patch</div>
+              <div className="text-muted-foreground text-xs">
+                Enables function-level patches in responses routing.
+              </div>
+            </div>
+            <Switch
+              checked={draft.useFunctionApplyPatch ?? true}
+              onCheckedChange={(value) =>
+                setDraft((prev) => ({ ...prev, useFunctionApplyPatch: value }))
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <div className="text-sm font-medium">Force agent header</div>
+              <div className="text-muted-foreground text-xs">
+                Forces agent routing logic even when clients omit hints.
+              </div>
+            </div>
+            <Switch
+              checked={draft.forceAgent ?? false}
+              onCheckedChange={(value) => setDraft((prev) => ({ ...prev, forceAgent: value }))}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -372,13 +372,18 @@ async function writeConfigFile(config: AppConfig): Promise<void> {
   const content = `${JSON.stringify(config, null, 2)}\n`
   const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${randomUUID()}`
 
-  await fs.writeFile(tmpPath, content, "utf8")
   try {
-    await fs.chmod(tmpPath, 0o600)
-  } catch {
-    // Ignore chmod errors (e.g. unsupported filesystem).
+    await fs.writeFile(tmpPath, content, "utf8")
+    try {
+      await fs.chmod(tmpPath, 0o600)
+    } catch {
+      // Ignore chmod errors (e.g. unsupported filesystem).
+    }
+    await fs.rename(tmpPath, PATHS.CONFIG_PATH)
+  } catch (error) {
+    await fs.rm(tmpPath, { force: true }).catch(() => {})
+    throw error
   }
-  await fs.rename(tmpPath, PATHS.CONFIG_PATH)
 }
 
 export const adminApiRoutes = new Hono()
@@ -461,7 +466,12 @@ adminApiRoutes.post("/config", async (c) => {
 adminApiRoutes.get("/models", (c) => {
   try {
     const accountModels = accountsManager.getFirstAccountModels()
-    const items = accountModels?.data.map((model) => model.id) ?? []
+    const items =
+      accountModels?.data
+        .map((model) => model.id)
+        .filter(
+          (id): id is string => typeof id === "string" && id.trim().length > 0,
+        ) ?? []
     const uniqueItems = Array.from(new Set(items)).sort()
     return c.json({ items: uniqueItems })
   } catch {

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,7 +1,15 @@
 import { Hono, type Context } from "hono"
+import fs from "node:fs/promises"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { listAccountsFromRegistry } from "~/lib/accounts-registry"
+import {
+  getConfig,
+  isFreeModelLoadBalancingEnabled,
+  mergeConfigWithDefaults,
+  type AppConfig,
+} from "~/lib/config"
+import { PATHS } from "~/lib/paths"
 import {
   getRequestHistoryStore,
   type AccountStatsRow,
@@ -27,7 +35,8 @@ function isLoopbackHostname(hostname: string): boolean {
 function getBearerToken(value: string): string | undefined {
   const trimmed = value.trim()
   if (!trimmed.toLowerCase().startsWith("bearer ")) return undefined
-  return trimmed.slice("bearer ".length).trim() || undefined
+  const token = trimmed.slice("bearer ".length).trim()
+  return token || undefined
 }
 
 function getRequestAdminToken(c: Context): string | undefined {
@@ -36,8 +45,7 @@ function getRequestAdminToken(c: Context): string | undefined {
 
   const bearer = c.req.header("authorization")
   if (bearer) {
-    const token = getBearerToken(bearer)
-    if (token) return token
+    return getBearerToken(bearer)
   }
 
   return undefined
@@ -67,8 +75,7 @@ function decideAdminAccess(c: Context): AdminAccessDecision {
     }
   }
 
-  const loopback = isLoopbackHostname(url.hostname)
-  if (loopback || tokenOk) {
+  if (isLoopbackHostname(url.hostname) || tokenOk) {
     return { ok: true }
   }
 
@@ -123,6 +130,248 @@ function parseTriStateBool(value: string | null): boolean | undefined {
   return undefined
 }
 
+type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+
+type ConfigErrorType = "bad_request" | "internal_error"
+
+type ConfigErrorPayload = {
+  message: string
+  type: ConfigErrorType
+}
+
+const CONFIG_KEYS = new Set<keyof AppConfig>([
+  "extraPrompts",
+  "smallModel",
+  "freeModelLoadBalancing",
+  "apiKey",
+  "modelReasoningEfforts",
+  "useFunctionApplyPatch",
+  "forceAgent",
+])
+
+const REASONING_EFFORTS = new Set<ReasoningEffort>([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+])
+
+function jsonError(
+  c: Context,
+  status: 400 | 500,
+  error: ConfigErrorPayload,
+): Response {
+  return c.json(
+    {
+      error,
+    },
+    status,
+  )
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+type ParseFieldResult<T> = { clear: true } | { value: T } | { error: string }
+
+function parseOptionalString(
+  value: unknown,
+  field: string,
+): ParseFieldResult<string> {
+  if (value === null || value === undefined) return { clear: true }
+  if (typeof value !== "string") return { error: `${field} must be a string` }
+
+  const trimmed = value.trim()
+  if (!trimmed) return { clear: true }
+
+  return { value: trimmed }
+}
+
+function parseOptionalBoolean(
+  value: unknown,
+  field: string,
+): ParseFieldResult<boolean> {
+  if (value === null || value === undefined) return { clear: true }
+  if (typeof value !== "boolean") return { error: `${field} must be a boolean` }
+  return { value }
+}
+
+function parseStringRecord(
+  value: unknown,
+  field: string,
+): ParseFieldResult<Record<string, string>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: `${field} must be an object with string values` }
+  }
+
+  const record: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") {
+      return { error: `${field}.${key} must be a string` }
+    }
+    record[key] = entry
+  }
+
+  return { value: record }
+}
+
+function parseReasoningRecord(
+  value: unknown,
+): ParseFieldResult<Record<string, ReasoningEffort>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: "modelReasoningEfforts must be an object" }
+  }
+
+  const record: Record<string, ReasoningEffort> = {}
+  for (const [model, effort] of Object.entries(value)) {
+    if (typeof effort !== "string") {
+      return { error: `modelReasoningEfforts.${model} must be a string` }
+    }
+    if (!REASONING_EFFORTS.has(effort as ReasoningEffort)) {
+      return {
+        error: `modelReasoningEfforts.${model} must be one of ${[
+          ...REASONING_EFFORTS,
+        ].join(", ")}`,
+      }
+    }
+    record[model] = effort as ReasoningEffort
+  }
+
+  return { value: record }
+}
+
+function applyOptionalString(
+  next: AppConfig,
+  key: "smallModel" | "apiKey",
+  value: unknown,
+): string | undefined {
+  const parsed = parseOptionalString(value, key)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    next[key] = undefined
+    return undefined
+  }
+  next[key] = parsed.value
+  return undefined
+}
+
+function applyOptionalBoolean(
+  next: AppConfig,
+  key: "freeModelLoadBalancing" | "useFunctionApplyPatch" | "forceAgent",
+  value: unknown,
+): string | undefined {
+  const parsed = parseOptionalBoolean(value, key)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    next[key] = undefined
+    return undefined
+  }
+  next[key] = parsed.value
+  return undefined
+}
+
+function applyExtraPrompts(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseStringRecord(value, "extraPrompts")
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.extraPrompts
+    return undefined
+  }
+  next.extraPrompts = parsed.value
+  return undefined
+}
+
+function applyReasoningEfforts(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseReasoningRecord(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.modelReasoningEfforts
+    return undefined
+  }
+  next.modelReasoningEfforts = parsed.value
+  return undefined
+}
+
+function applyConfigPatch(
+  base: AppConfig,
+  input: Record<string, unknown>,
+): { config?: AppConfig; error?: string } {
+  const next: AppConfig = { ...base }
+
+  for (const [rawKey, value] of Object.entries(input)) {
+    const key = rawKey as keyof AppConfig
+    if (!CONFIG_KEYS.has(key)) {
+      return { error: `Unknown config key: ${rawKey}` }
+    }
+
+    let error: string | undefined
+
+    switch (rawKey) {
+      case "extraPrompts": {
+        error = applyExtraPrompts(next, value)
+        break
+      }
+      case "smallModel": {
+        error = applyOptionalString(next, "smallModel", value)
+        break
+      }
+      case "freeModelLoadBalancing": {
+        error = applyOptionalBoolean(next, "freeModelLoadBalancing", value)
+        break
+      }
+      case "apiKey": {
+        error = applyOptionalString(next, "apiKey", value)
+        break
+      }
+      case "modelReasoningEfforts": {
+        error = applyReasoningEfforts(next, value)
+        break
+      }
+      case "useFunctionApplyPatch": {
+        error = applyOptionalBoolean(next, "useFunctionApplyPatch", value)
+        break
+      }
+      case "forceAgent": {
+        error = applyOptionalBoolean(next, "forceAgent", value)
+        break
+      }
+      default: {
+        return { error: `Unsupported config key: ${rawKey}` }
+      }
+    }
+
+    if (error) return { error }
+  }
+
+  return { config: next }
+}
+
+async function writeConfigFile(config: AppConfig): Promise<void> {
+  await fs.mkdir(PATHS.APP_DIR, { recursive: true })
+
+  const content = `${JSON.stringify(config, null, 2)}\n`
+  const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+  await fs.writeFile(tmpPath, content, "utf8")
+  try {
+    await fs.chmod(tmpPath, 0o600)
+  } catch {
+    // Ignore chmod errors (e.g. unsupported filesystem).
+  }
+  await fs.rename(tmpPath, PATHS.CONFIG_PATH)
+}
+
 export const adminApiRoutes = new Hono()
 
 adminApiRoutes.use("*", async (c, next) => {
@@ -147,15 +396,82 @@ adminApiRoutes.get("/meta", (c) => {
   return c.json(store.meta())
 })
 
+adminApiRoutes.get("/config", (c) => {
+  try {
+    const config = mergeConfigWithDefaults()
+    return c.json({ ...config, _configPath: PATHS.CONFIG_PATH })
+  } catch {
+    return jsonError(c, 500, {
+      message: "Failed to load config.",
+      type: "internal_error",
+    })
+  }
+})
+
+adminApiRoutes.post("/config", async (c) => {
+  let payload: unknown
+  try {
+    payload = await c.req.json()
+  } catch {
+    return jsonError(c, 400, {
+      message: "Config payload must be valid JSON.",
+      type: "bad_request",
+    })
+  }
+
+  if (!isPlainObject(payload)) {
+    return jsonError(c, 400, {
+      message: "Config payload must be an object.",
+      type: "bad_request",
+    })
+  }
+
+  const result = applyConfigPatch(getConfig(), payload)
+  if (!result.config) {
+    return jsonError(c, 400, {
+      message: result.error ?? "Invalid config payload.",
+      type: "bad_request",
+    })
+  }
+
+  try {
+    await writeConfigFile(result.config)
+    const merged = mergeConfigWithDefaults()
+    accountsManager.setFreeModelLoadBalancingEnabled(
+      isFreeModelLoadBalancingEnabled(),
+    )
+    return c.json(merged)
+  } catch {
+    return jsonError(c, 500, {
+      message: "Failed to write config.",
+      type: "internal_error",
+    })
+  }
+})
+
+adminApiRoutes.get("/models", (c) => {
+  try {
+    const accountModels = accountsManager.getFirstAccountModels()
+    const items = accountModels?.data.map((model) => model.id) ?? []
+    const uniqueItems = Array.from(new Set(items)).sort()
+    return c.json({ items: uniqueItems })
+  } catch {
+    return jsonError(c, 500, {
+      message: "Failed to load models.",
+      type: "internal_error",
+    })
+  }
+})
+
 adminApiRoutes.get("/accounts", async (c) => {
   const url = new URL(c.req.url, "http://local")
   const sinceMs = Number(url.searchParams.get("since_ms") ?? "")
   const includeStats = url.searchParams.get("include_stats") !== "0"
 
-  const since =
-    Number.isFinite(sinceMs) && sinceMs > 0 ?
-      sinceMs
-    : Date.now() - 24 * 60 * 60 * 1000
+  let since = Date.now() - 24 * 60 * 60 * 1000
+  if (Number.isFinite(sinceMs) && sinceMs > 0) {
+    since = sinceMs
+  }
 
   const registry = await listAccountsFromRegistry().catch(() => [])
   const registryTypeById = new Map(registry.map((a) => [a.id, a.accountType]))

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -454,7 +454,7 @@ adminApiRoutes.post("/config", async (c) => {
     accountsManager.setFreeModelLoadBalancingEnabled(
       isFreeModelLoadBalancingEnabled(),
     )
-    return c.json(merged)
+    return c.json({ ...merged, _configPath: PATHS.CONFIG_PATH })
   } catch {
     return jsonError(c, 500, {
       message: "Failed to write config.",

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -213,7 +213,9 @@ function parseStringRecord(
 
   const record = Object.create(null) as Record<string, string>
   for (const [key, entry] of Object.entries(value)) {
-    if (BLOCKED_KEYS.has(key)) continue
+    if (BLOCKED_KEYS.has(key)) {
+      return { error: `${field}.${key} is not allowed` }
+    }
     if (typeof entry !== "string") {
       return { error: `${field}.${key} must be a string` }
     }
@@ -233,7 +235,9 @@ function parseReasoningRecord(
 
   const record = Object.create(null) as Record<string, ReasoningEffort>
   for (const [model, effort] of Object.entries(value)) {
-    if (BLOCKED_KEYS.has(model)) continue
+    if (BLOCKED_KEYS.has(model)) {
+      return { error: `modelReasoningEfforts.${model} is not allowed` }
+    }
     if (typeof effort !== "string") {
       return { error: `modelReasoningEfforts.${model} must be a string` }
     }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from "hono"
+import { randomUUID } from "node:crypto"
 import fs from "node:fs/promises"
 
 import { accountsManager } from "~/lib/accounts-manager"
@@ -158,6 +159,8 @@ const REASONING_EFFORTS = new Set<ReasoningEffort>([
   "xhigh",
 ])
 
+const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"])
+
 function jsonError(
   c: Context,
   status: 400 | 500,
@@ -208,8 +211,9 @@ function parseStringRecord(
     return { error: `${field} must be an object with string values` }
   }
 
-  const record: Record<string, string> = {}
+  const record = Object.create(null) as Record<string, string>
   for (const [key, entry] of Object.entries(value)) {
+    if (BLOCKED_KEYS.has(key)) continue
     if (typeof entry !== "string") {
       return { error: `${field}.${key} must be a string` }
     }
@@ -227,8 +231,9 @@ function parseReasoningRecord(
     return { error: "modelReasoningEfforts must be an object" }
   }
 
-  const record: Record<string, ReasoningEffort> = {}
+  const record = Object.create(null) as Record<string, ReasoningEffort>
   for (const [model, effort] of Object.entries(value)) {
+    if (BLOCKED_KEYS.has(model)) continue
     if (typeof effort !== "string") {
       return { error: `modelReasoningEfforts.${model} must be a string` }
     }
@@ -361,7 +366,7 @@ async function writeConfigFile(config: AppConfig): Promise<void> {
   await fs.mkdir(PATHS.APP_DIR, { recursive: true })
 
   const content = `${JSON.stringify(config, null, 2)}\n`
-  const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${randomUUID()}`
 
   await fs.writeFile(tmpPath, content, "utf8")
   try {


### PR DESCRIPTION
## Summary
- add admin config/models endpoints with validation and atomic write-back
- add Settings page with switches, JSON editors, and model selector
- expose Settings navigation in Admin UI

## Test plan
- [x] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增设置页面：可加载、编辑并保存管理配置与模型列表，支持表单/JSON 双模式、实时校验、分区编辑与保存提示。
  * 新增路由 /settings，向管理界面公开设置页。
  * 导航集中化：统一配置并渲染导航项，简化移动端与桌面菜单。
  * 新增可复用表单组件：可访问的开关组件与多行文本域，支持受控/非受控用法与 ref 转发。
  * 后端管理接口扩展：新增获取/更新配置及获取模型列表的 API，改进请求头与错误解析。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->