### PR TITLE
fix: estimate message_start input tokens

### DIFF
--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -201,6 +201,7 @@ export interface AnthropicStreamState {
   contentBlockIndex: number
   contentBlockOpen: boolean
   thinkingBlockOpen: boolean
+  estimatedInputTokens?: number
   toolCalls: {
     [openAIToolIndex: number]: {
       id: string

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -4,6 +4,7 @@ import { streamSSE } from "hono/streaming"
 import { randomUUID } from "node:crypto"
 
 import type { AccountRuntime } from "~/lib/types/account"
+import type { Model } from "~/services/copilot/get-models"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
@@ -24,6 +25,7 @@ import {
   type NormalizedUsage,
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
+import { getTokenCount } from "~/lib/tokenizer"
 import {
   buildErrorEvent,
   createResponsesStreamState,
@@ -49,14 +51,13 @@ import {
 import {
   type AnthropicMessagesPayload,
   type AnthropicStreamState,
-  type AnthropicTextBlock,
-  type AnthropicToolResultBlock,
 } from "./anthropic-types"
 import {
   translateToAnthropic,
   translateToOpenAI,
 } from "./non-stream-translation"
 import { translateChunkToAnthropicEvents } from "./stream-translation"
+import { mergeToolResultForClaude } from "./utils"
 
 const logger = createHandlerLogger("messages-handler")
 
@@ -68,6 +69,23 @@ type AccountSelection = Awaited<
 >
 
 type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
+
+type AccountSelectionFailure = Extract<AccountSelection, { ok: false }>
+
+type SelectionFailureContext = {
+  c: Context
+  store: ReturnType<typeof getRequestHistoryStore>
+  requestId: string
+  startedAtMs: number
+  method: string
+  path: string
+  streamRequested: boolean
+  clientModel: string
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+  selection: AccountSelectionFailure
+}
 
 type InstrumentationContext = {
   store: ReturnType<typeof getRequestHistoryStore>
@@ -153,46 +171,20 @@ export async function handleCompletion(c: Context) {
   ])
 
   if (!selection.ok) {
-    const finishedAtMs = Date.now()
-
-    store.insert({
+    return handleSelectionFailure({
+      c,
+      store,
       requestId,
       startedAtMs,
-      finishedAtMs,
-      durationMs: finishedAtMs - startedAtMs,
       method,
       path,
-      stream: streamRequested,
+      streamRequested,
       clientModel: anthropicPayload.model,
       clientIp,
       clientIpSource,
       userAgent,
-      httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
-      selectionFailureReason: selection.reason,
+      selection,
     })
-
-    if (selection.reason === "MODEL_NOT_SUPPORTED") {
-      return c.json(
-        {
-          error: {
-            message: `Model "${anthropicPayload.model}" is not available for any configured account.`,
-            type: "invalid_request_error",
-          },
-        },
-        400,
-      )
-    }
-
-    return c.json(
-      {
-        error: {
-          message:
-            "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
-          type: "rate_limit_error",
-        },
-      },
-      429,
-    )
   }
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
@@ -229,17 +221,87 @@ export async function handleCompletion(c: Context) {
   }
 
   if (endpoint === RESPONSES_ENDPOINT) {
-    return await handleWithResponsesApi(c, anthropicPayload, instr)
+    return await handleWithResponsesApi({
+      c,
+      anthropicPayload,
+      openAIPayload,
+      selectedModel,
+      instr,
+    })
   }
 
-  return await handleWithChatCompletions(c, openAIPayload, instr)
+  return await handleWithChatCompletions({
+    c,
+    openAIPayload,
+    selectedModel,
+    instr,
+  })
 }
 
-const handleWithChatCompletions = async (
-  c: Context,
-  openAIPayload: ChatCompletionsPayload,
-  instr: InstrumentationContext,
-): Promise<Response> => {
+const handleSelectionFailure = (context: SelectionFailureContext): Response => {
+  const {
+    c,
+    store,
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    streamRequested,
+    clientModel,
+    clientIp,
+    clientIpSource,
+    userAgent,
+    selection,
+  } = context
+  const finishedAtMs = Date.now()
+
+  store.insert({
+    requestId,
+    startedAtMs,
+    finishedAtMs,
+    durationMs: finishedAtMs - startedAtMs,
+    method,
+    path,
+    stream: streamRequested,
+    clientModel,
+    clientIp,
+    clientIpSource,
+    userAgent,
+    httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
+    selectionFailureReason: selection.reason,
+  })
+
+  if (selection.reason === "MODEL_NOT_SUPPORTED") {
+    return c.json(
+      {
+        error: {
+          message: `Model "${clientModel}" is not available for any configured account.`,
+          type: "invalid_request_error",
+        },
+      },
+      400,
+    )
+  }
+
+  return c.json(
+    {
+      error: {
+        message:
+          "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
+        type: "rate_limit_error",
+      },
+    },
+    429,
+  )
+}
+
+const handleWithChatCompletions = async (params: {
+  c: Context
+  openAIPayload: ChatCompletionsPayload
+  selectedModel: Model
+  instr: InstrumentationContext
+}): Promise<Response> => {
+  const { c, openAIPayload, selectedModel, instr } = params
   logger.debug(
     "Translated OpenAI request payload:",
     JSON.stringify(openAIPayload),
@@ -269,20 +331,32 @@ const handleWithChatCompletions = async (
 
   logger.debug("Streaming response from Copilot")
 
+  let estimatedInputTokens: number | undefined
+  try {
+    const tokenCount = await getTokenCount(openAIPayload, selectedModel)
+    estimatedInputTokens = tokenCount.input
+  } catch (error) {
+    logger.warn("Failed to estimate input tokens for message_start", error)
+  }
+
   return streamSSE(c, (stream) =>
     streamChatCompletionsAndLog({
       stream,
       response,
       instr,
+      estimatedInputTokens,
     }),
   )
 }
 
-const handleWithResponsesApi = async (
-  c: Context,
-  anthropicPayload: AnthropicMessagesPayload,
-  instr: InstrumentationContext,
-): Promise<Response> => {
+const handleWithResponsesApi = async (params: {
+  c: Context
+  anthropicPayload: AnthropicMessagesPayload
+  openAIPayload: ChatCompletionsPayload
+  selectedModel: Model
+  instr: InstrumentationContext
+}): Promise<Response> => {
+  const { c, anthropicPayload, openAIPayload, selectedModel, instr } = params
   const responsesPayload =
     translateAnthropicMessagesToResponsesPayload(anthropicPayload)
   logger.debug(
@@ -315,11 +389,20 @@ const handleWithResponsesApi = async (
   if (responsesPayload.stream && isAsyncIterable(response)) {
     logger.debug("Streaming response from Copilot (Responses API)")
 
+    let estimatedInputTokens: number | undefined
+    try {
+      const tokenCount = await getTokenCount(openAIPayload, selectedModel)
+      estimatedInputTokens = tokenCount.input
+    } catch (error) {
+      logger.warn("Failed to estimate input tokens for message_start", error)
+    }
+
     return streamSSE(c, (stream) =>
       streamResponsesAndLog({
         stream,
         response,
         instr,
+        estimatedInputTokens,
       }),
     )
   }
@@ -528,8 +611,9 @@ async function streamChatCompletionsAndLog(params: {
   stream: StreamSseStream
   response: ChatCompletionsStream
   instr: InstrumentationContext
+  estimatedInputTokens?: number
 }): Promise<void> {
-  const { stream, response, instr } = params
+  const { stream, response, instr, estimatedInputTokens } = params
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
@@ -544,6 +628,7 @@ async function streamChatCompletionsAndLog(params: {
     contentBlockOpen: false,
     toolCalls: {},
     thinkingBlockOpen: false,
+    estimatedInputTokens,
   }
 
   try {
@@ -749,8 +834,9 @@ async function streamResponsesAndLog(params: {
   stream: StreamSseStream
   response: AsyncIterable<unknown>
   instr: InstrumentationContext
+  estimatedInputTokens?: number
 }): Promise<void> {
-  const { stream, response, instr } = params
+  const { stream, response, instr, estimatedInputTokens } = params
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
@@ -760,6 +846,7 @@ async function streamResponsesAndLog(params: {
   let errorMessage: string | undefined
 
   const streamState = createResponsesStreamState()
+  streamState.estimatedInputTokens = estimatedInputTokens
 
   try {
     for await (const chunk of response) {
@@ -855,73 +942,3 @@ const isNonStreaming = (
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
   Boolean(value)
   && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
-
-const mergeContentWithText = (
-  tr: AnthropicToolResultBlock,
-  textBlock: AnthropicTextBlock,
-): AnthropicToolResultBlock => {
-  if (typeof tr.content === "string") {
-    return { ...tr, content: `${tr.content}\n\n${textBlock.text}` }
-  }
-  return {
-    ...tr,
-    content: [...tr.content, textBlock],
-  }
-}
-
-const mergeContentWithTexts = (
-  tr: AnthropicToolResultBlock,
-  textBlocks: Array<AnthropicTextBlock>,
-): AnthropicToolResultBlock => {
-  if (typeof tr.content === "string") {
-    const appendedTexts = textBlocks.map((tb) => tb.text).join("\n\n")
-    return { ...tr, content: `${tr.content}\n\n${appendedTexts}` }
-  }
-  return { ...tr, content: [...tr.content, ...textBlocks] }
-}
-
-const mergeToolResultForClaude = (
-  anthropicBeta: string | undefined,
-  anthropicPayload: AnthropicMessagesPayload,
-): void => {
-  if (!anthropicBeta) return
-
-  for (const msg of anthropicPayload.messages) {
-    if (msg.role !== "user" || !Array.isArray(msg.content)) continue
-
-    const toolResults: Array<AnthropicToolResultBlock> = []
-    const textBlocks: Array<AnthropicTextBlock> = []
-    let valid = true
-
-    for (const block of msg.content) {
-      if (block.type === "tool_result") {
-        toolResults.push(block)
-      } else if (block.type === "text") {
-        textBlocks.push(block)
-      } else {
-        valid = false
-        break
-      }
-    }
-
-    if (!valid || toolResults.length === 0 || textBlocks.length === 0) continue
-
-    msg.content = mergeToolResult(toolResults, textBlocks)
-  }
-}
-
-const mergeToolResult = (
-  toolResults: Array<AnthropicToolResultBlock>,
-  textBlocks: Array<AnthropicTextBlock>,
-): Array<AnthropicToolResultBlock> => {
-  // equal lengths -> pairwise merge
-  if (toolResults.length === textBlocks.length) {
-    return toolResults.map((tr, i) => mergeContentWithText(tr, textBlocks[i]))
-  }
-
-  // lengths differ -> append all textBlocks to the last tool_result
-  const lastIndex = toolResults.length - 1
-  return toolResults.map((tr, i) =>
-    i === lastIndex ? mergeContentWithTexts(tr, textBlocks) : tr,
-  )
-}

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -295,6 +295,19 @@ const handleSelectionFailure = (context: SelectionFailureContext): Response => {
   )
 }
 
+const estimateInputTokens = async (
+  payload: ChatCompletionsPayload,
+  selectedModel: Model,
+): Promise<number | undefined> => {
+  try {
+    const tokenCount = await getTokenCount(payload, selectedModel)
+    return tokenCount.input
+  } catch (error) {
+    logger.warn("Failed to estimate input tokens for message_start", error)
+    return undefined
+  }
+}
+
 const handleWithChatCompletions = async (params: {
   c: Context
   openAIPayload: ChatCompletionsPayload
@@ -331,13 +344,10 @@ const handleWithChatCompletions = async (params: {
 
   logger.debug("Streaming response from Copilot")
 
-  let estimatedInputTokens: number | undefined
-  try {
-    const tokenCount = await getTokenCount(openAIPayload, selectedModel)
-    estimatedInputTokens = tokenCount.input
-  } catch (error) {
-    logger.warn("Failed to estimate input tokens for message_start", error)
-  }
+  const estimatedInputTokens = await estimateInputTokens(
+    openAIPayload,
+    selectedModel,
+  )
 
   return streamSSE(c, (stream) =>
     streamChatCompletionsAndLog({
@@ -389,13 +399,10 @@ const handleWithResponsesApi = async (params: {
   if (responsesPayload.stream && isAsyncIterable(response)) {
     logger.debug("Streaming response from Copilot (Responses API)")
 
-    let estimatedInputTokens: number | undefined
-    try {
-      const tokenCount = await getTokenCount(openAIPayload, selectedModel)
-      estimatedInputTokens = tokenCount.input
-    } catch (error) {
-      logger.warn("Failed to estimate input tokens for message_start", error)
-    }
+    const estimatedInputTokens = await estimateInputTokens(
+      openAIPayload,
+      selectedModel,
+    )
 
     return streamSSE(c, (stream) =>
       streamResponsesAndLog({

--- a/src/routes/messages/responses-stream-translation.ts
+++ b/src/routes/messages/responses-stream-translation.ts
@@ -62,6 +62,7 @@ export interface ResponsesStreamState {
   openBlocks: Set<number>
   blockHasDelta: Set<number>
   functionCallStateByOutputIndex: Map<number, FunctionCallStreamState>
+  estimatedInputTokens?: number
 }
 
 type FunctionCallStreamState = {
@@ -482,8 +483,11 @@ const messageStart = (
 ): Array<AnthropicStreamEventData> => {
   state.messageStartSent = true
   const inputCachedTokens = response.usage?.input_tokens_details?.cached_tokens
+  const upstreamInputTokens = response.usage?.input_tokens
   const inputTokens =
-    (response.usage?.input_tokens ?? 0) - (inputCachedTokens ?? 0)
+    upstreamInputTokens !== undefined ?
+      upstreamInputTokens - (inputCachedTokens ?? 0)
+    : (state.estimatedInputTokens ?? 0)
   return [
     {
       type: "message_start",

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -245,6 +245,13 @@ function handleMessageStart(
   chunk: ChatCompletionChunk,
 ) {
   if (!state.messageStartSent) {
+    const cachedTokens = chunk.usage?.prompt_tokens_details?.cached_tokens
+    const upstreamPromptTokens = chunk.usage?.prompt_tokens
+    const inputTokens =
+      upstreamPromptTokens !== undefined ?
+        upstreamPromptTokens - (cachedTokens ?? 0)
+      : (state.estimatedInputTokens ?? 0)
+
     events.push({
       type: "message_start",
       message: {
@@ -256,14 +263,10 @@ function handleMessageStart(
         stop_reason: null,
         stop_sequence: null,
         usage: {
-          input_tokens:
-            (chunk.usage?.prompt_tokens ?? 0)
-            - (chunk.usage?.prompt_tokens_details?.cached_tokens ?? 0),
+          input_tokens: inputTokens,
           output_tokens: 0, // Will be updated in message_delta when finished
-          ...(chunk.usage?.prompt_tokens_details?.cached_tokens
-            !== undefined && {
-            cache_read_input_tokens:
-              chunk.usage.prompt_tokens_details.cached_tokens,
+          ...(cachedTokens !== undefined && {
+            cache_read_input_tokens: cachedTokens,
           }),
         },
       },

--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -1,4 +1,9 @@
-import { type AnthropicResponse } from "./anthropic-types"
+import type {
+  AnthropicMessagesPayload,
+  AnthropicResponse,
+  AnthropicTextBlock,
+  AnthropicToolResultBlock,
+} from "./anthropic-types"
 
 export function mapOpenAIStopReasonToAnthropic(
   finishReason: "stop" | "length" | "tool_calls" | "content_filter" | null,
@@ -13,4 +18,82 @@ export function mapOpenAIStopReasonToAnthropic(
     content_filter: "end_turn",
   } as const
   return stopReasonMap[finishReason]
+}
+
+const mergeContentWithText = (
+  toolResult: AnthropicToolResultBlock,
+  textBlock: AnthropicTextBlock,
+): AnthropicToolResultBlock => {
+  if (typeof toolResult.content === "string") {
+    return {
+      ...toolResult,
+      content: `${toolResult.content}\n\n${textBlock.text}`,
+    }
+  }
+  return {
+    ...toolResult,
+    content: [...toolResult.content, textBlock],
+  }
+}
+
+const mergeContentWithTexts = (
+  toolResult: AnthropicToolResultBlock,
+  textBlocks: Array<AnthropicTextBlock>,
+): AnthropicToolResultBlock => {
+  if (typeof toolResult.content === "string") {
+    const appendedTexts = textBlocks.map((tb) => tb.text).join("\n\n")
+    return {
+      ...toolResult,
+      content: `${toolResult.content}\n\n${appendedTexts}`,
+    }
+  }
+  return { ...toolResult, content: [...toolResult.content, ...textBlocks] }
+}
+
+const mergeToolResult = (
+  toolResults: Array<AnthropicToolResultBlock>,
+  textBlocks: Array<AnthropicTextBlock>,
+): Array<AnthropicToolResultBlock> => {
+  if (toolResults.length === textBlocks.length) {
+    return toolResults.map((toolResult, index) =>
+      mergeContentWithText(toolResult, textBlocks[index]),
+    )
+  }
+
+  const lastIndex = toolResults.length - 1
+  return toolResults.map((toolResult, index) =>
+    index === lastIndex ?
+      mergeContentWithTexts(toolResult, textBlocks)
+    : toolResult,
+  )
+}
+
+export const mergeToolResultForClaude = (
+  anthropicBeta: string | undefined,
+  anthropicPayload: AnthropicMessagesPayload,
+): void => {
+  if (!anthropicBeta) return
+
+  for (const msg of anthropicPayload.messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue
+
+    const toolResults: Array<AnthropicToolResultBlock> = []
+    const textBlocks: Array<AnthropicTextBlock> = []
+    let valid = true
+
+    for (const block of msg.content) {
+      if (block.type === "tool_result") {
+        toolResults.push(block)
+      } else if (block.type === "text") {
+        textBlocks.push(block)
+      } else {
+        valid = false
+        break
+      }
+    }
+
+    if (!valid || toolResults.length === 0 || textBlocks.length === 0) continue
+
+    msg.content = mergeToolResult(toolResults, textBlocks)
+  }
 }


### PR DESCRIPTION
## Summary
- estimate input tokens for message_start when stream usage is absent
- pass estimated tokens through stream state for chat and responses

## Test plan
- [ ] Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在流式响应中添加可选的估算输入令牌字段，可在调试和日志中看到令牌估算信息。

* **改进**
  * 优化令牌计数逻辑：优先使用上游返回的令牌数据，缺失时回退到估算值，并在有缓存时正确调整计数。
  * 改进工具结果与文本块的合并，提升消息内容的完整性和准确性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->