### PR TITLE
feat: add alias-only model name toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
       "gpt-5-mini": "low"
     },
     "modelAliases": {
-      "fast": "gpt-5-mini"
+      "fast": { "target": "gpt-5-mini", "allowOriginal": false },
+      "draft": { "target": "gpt-5.1-codex-max" }
     },
     "allowOriginalModelNamesForAliases": false
   }
@@ -261,8 +262,8 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
 - **freeModelLoadBalancing:** Enable round-robin routing for free-model requests across multiple accounts. Defaults to `true`. Set to `false` to route free-model requests sequentially (same ordering strategy as premium models).
 - **apiKey (optional):** API key used to protect selected endpoints (see **API Key authentication** below). Prefer setting the `COPILOT_API_KEY` environment variable (takes precedence over `config.json`). The server does not generate an API key automatically — you must provide one. If no key is configured, protected endpoints remain publicly accessible (fail-open). **Do not commit secrets.**
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
-- **modelAliases:** Map of `alias -> upstream model ID`. Aliases are case-insensitive and can be used in downstream requests.
-- **allowOriginalModelNamesForAliases:** When `false` (default), any model that is the target of an alias can only be called by its alias, and `/models` hides the original name. When `true`, both the original model name and its aliases are accepted.
+- **modelAliases:** Map of `alias -> { target, allowOriginal? }` (legacy string values are still accepted). `allowOriginal` overrides the global default per alias. If multiple aliases map to the same target, original names are allowed when any alias sets `allowOriginal: true` (allow-wins). Aliases are case-insensitive and can be used in downstream requests.
+- **allowOriginalModelNamesForAliases:** Global default for aliases that omit `allowOriginal`. When `false` (default), targets are blocked unless an alias explicitly allows them; when `true`, targets are allowed unless all aliases explicitly block them.
 
 Edit this file to customize prompts or swap in your own fast model. Restart the server (or rerun the command) after changes so the cached config is refreshed.
 

--- a/README.md
+++ b/README.md
@@ -249,14 +249,20 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
     "apiKey": "<your_api_key_here>",
     "modelReasoningEfforts": {
       "gpt-5-mini": "low"
-    }
+    },
+    "modelAliases": {
+      "fast": "gpt-5-mini"
+    },
+    "allowOriginalModelNamesForAliases": false
   }
   ```
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Copilot. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts.
-- **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests) to avoid spending premium requests; defaults to `gpt-5-mini`.
+- **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests) to avoid spending premium requests; defaults to `gpt-5-mini`. If original names are blocked and this points to an aliased target, it resolves to the first alias.
 - **freeModelLoadBalancing:** Enable round-robin routing for free-model requests across multiple accounts. Defaults to `true`. Set to `false` to route free-model requests sequentially (same ordering strategy as premium models).
 - **apiKey (optional):** API key used to protect selected endpoints (see **API Key authentication** below). Prefer setting the `COPILOT_API_KEY` environment variable (takes precedence over `config.json`). The server does not generate an API key automatically — you must provide one. If no key is configured, protected endpoints remain publicly accessible (fail-open). **Do not commit secrets.**
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
+- **modelAliases:** Map of `alias -> upstream model ID`. Aliases are case-insensitive and can be used in downstream requests.
+- **allowOriginalModelNamesForAliases:** When `false` (default), any model that is the target of an alias can only be called by its alias, and `/models` hides the original name. When `true`, both the original model name and its aliases are accepted.
 
 Edit this file to customize prompts or swap in your own fast model. Restart the server (or rerun the command) after changes so the cached config is refreshed.
 

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -75,13 +75,18 @@ export type AdminRequestDetailResponse = {
 
 export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
 
+export type ModelAliasSpec = {
+  target: string
+  allowOriginal?: boolean
+}
+
 export type AdminConfig = {
   extraPrompts?: Record<string, string>
   smallModel?: string
   freeModelLoadBalancing?: boolean
   apiKey?: string
   modelReasoningEfforts?: Record<string, ReasoningEffort>
-  modelAliases?: Record<string, string>
+  modelAliases?: Record<string, ModelAliasSpec | string>
   allowOriginalModelNamesForAliases?: boolean
   useFunctionApplyPatch?: boolean
   forceAgent?: boolean

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -81,6 +81,8 @@ export type AdminConfig = {
   freeModelLoadBalancing?: boolean
   apiKey?: string
   modelReasoningEfforts?: Record<string, ReasoningEffort>
+  modelAliases?: Record<string, string>
+  allowOriginalModelNamesForAliases?: boolean
   useFunctionApplyPatch?: boolean
   forceAgent?: boolean
 }

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -5,6 +5,7 @@ import {
   AdminApiError,
   type AdminConfig,
   type AdminConfigResponse,
+  type ModelAliasSpec,
   type ReasoningEffort,
   getAdminConfig,
   getAdminModels,
@@ -57,7 +58,12 @@ type ModelAliasItem = {
   id: string
   alias: string
   target: string
+  allowOriginal?: boolean
 }
+
+type ModelAliasRecord = Record<string, ModelAliasSpec>
+
+type ModelAliasRecordInput = Record<string, ModelAliasSpec | string>
 
 type ParseResult<T> = { record: T } | { error: string }
 
@@ -144,14 +150,25 @@ function reasoningItemsFromRecord(
 }
 
 function aliasItemsFromRecord(
-  record: Record<string, string> | undefined
+  record: ModelAliasRecordInput | undefined
 ): ModelAliasItem[] {
   if (!record) return []
-  return Object.entries(record).map(([alias, target]) => ({
-    id: createItemId(),
-    alias,
-    target,
-  }))
+  return Object.entries(record).map(([alias, spec]) => {
+    if (typeof spec === "string") {
+      return {
+        id: createItemId(),
+        alias,
+        target: spec,
+        allowOriginal: undefined,
+      }
+    }
+    return {
+      id: createItemId(),
+      alias,
+      target: spec.target,
+      allowOriginal: spec.allowOriginal,
+    }
+  })
 }
 
 function extraPromptRecordFromItems(items: ExtraPromptItem[]): Record<string, string> {
@@ -174,8 +191,8 @@ function reasoningRecordFromItems(items: ReasoningItem[]): Record<string, Reason
   return record
 }
 
-function aliasRecordFromItems(items: ModelAliasItem[]): Record<string, string> {
-  const record: Record<string, string> = {}
+function aliasRecordFromItems(items: ModelAliasItem[]): ModelAliasRecord {
+  const record: ModelAliasRecord = {}
   const seen = new Set<string>()
 
   for (const item of items) {
@@ -188,7 +205,10 @@ function aliasRecordFromItems(items: ModelAliasItem[]): Record<string, string> {
     if (seen.has(normalizedAlias)) continue
 
     seen.add(normalizedAlias)
-    record[alias] = target
+    record[alias] =
+      item.allowOriginal === undefined
+        ? { target }
+        : { target, allowOriginal: item.allowOriginal }
   }
 
   return record
@@ -251,28 +271,48 @@ function parseReasoningJson(
 
 function parseModelAliasesJson(
   value: string,
-): ParseResult<Record<string, string>> {
+): ParseResult<ModelAliasRecord> {
   if (!value.trim()) return { record: {} }
 
   try {
     const parsed = JSON.parse(value) as unknown
     if (!isPlainObject(parsed)) {
-      return { error: "modelAliases JSON must be an object of string values." }
+      return { error: "modelAliases JSON must be an object." }
     }
 
-    const record: Record<string, string> = {}
+    const record: ModelAliasRecord = {}
     const seen = new Set<string>()
 
     for (const [rawAlias, rawTarget] of Object.entries(parsed)) {
-      if (typeof rawTarget !== "string") {
-        return { error: `modelAliases.${rawAlias} must be a string.` }
-      }
-
       const alias = rawAlias.trim()
-      const target = rawTarget.trim()
       if (!alias) {
         return { error: "modelAliases keys must be non-empty strings." }
       }
+
+      let target: string | undefined
+      let allowOriginal: boolean | undefined
+
+      if (typeof rawTarget === "string") {
+        target = rawTarget.trim()
+      } else if (isPlainObject(rawTarget)) {
+        const rawTargetValue = rawTarget.target
+        if (typeof rawTargetValue !== "string") {
+          return { error: `modelAliases.${rawAlias}.target must be a string.` }
+        }
+        target = rawTargetValue.trim()
+
+        if ("allowOriginal" in rawTarget) {
+          if (typeof rawTarget.allowOriginal !== "boolean") {
+            return {
+              error: `modelAliases.${rawAlias}.allowOriginal must be a boolean.`,
+            }
+          }
+          allowOriginal = rawTarget.allowOriginal
+        }
+      } else {
+        return { error: `modelAliases.${rawAlias} must be a string or object.` }
+      }
+
       if (!target) {
         return { error: `modelAliases.${rawAlias} must be a non-empty string.` }
       }
@@ -286,7 +326,8 @@ function parseModelAliasesJson(
       }
 
       seen.add(normalizedAlias)
-      record[alias] = target
+      record[alias] =
+        allowOriginal === undefined ? { target } : { target, allowOriginal }
     }
 
     return { record }
@@ -331,7 +372,7 @@ type ModelAliasEditor = {
   onAddItem: () => void
   onRemoveItem: (id: string) => void
   onUpdateItem: (id: string, patch: Partial<ModelAliasItem>) => void
-  setFromRecord: (record?: Record<string, string>) => void
+  setFromRecord: (record?: ModelAliasRecordInput) => void
 }
 
 function useExtraPromptEditor(
@@ -507,7 +548,7 @@ function useReasoningEditor(
 }
 
 function useModelAliasEditor(
-  onRecordChange: (record: Record<string, string>) => void,
+  onRecordChange: (record: ModelAliasRecord) => void,
 ): ModelAliasEditor {
   const [mode, setMode] = useState<JsonMode>("form")
   const [items, setItems] = useState<ModelAliasItem[]>([])
@@ -519,9 +560,11 @@ function useModelAliasEditor(
     [jsonError],
   )
 
-  const setFromRecord = useCallback((record?: Record<string, string>) => {
-    setItems(aliasItemsFromRecord(record))
-    setJson(JSON.stringify(record ?? {}, null, 2))
+  const setFromRecord = useCallback((record?: ModelAliasRecordInput) => {
+    const nextItems = aliasItemsFromRecord(record)
+    const normalizedRecord = aliasRecordFromItems(nextItems)
+    setItems(nextItems)
+    setJson(JSON.stringify(normalizedRecord, null, 2))
     setJsonError(null)
   }, [])
 
@@ -560,7 +603,9 @@ function useModelAliasEditor(
   )
 
   const onAddItem = useCallback(() => {
-    updateItems(items.concat({ id: createItemId(), alias: "", target: "" }))
+    updateItems(
+      items.concat({ id: createItemId(), alias: "", target: "", allowOriginal: undefined }),
+    )
   }, [items, updateItems])
 
   const onRemoveItem = useCallback(
@@ -1016,6 +1061,7 @@ function ModelAliasesCard({
   onUpdateItem,
 }: ModelAliasesCardProps): React.JSX.Element {
   const emptyTargetValue = "__target__"
+  const allowOriginalDefaultValue = "__allow_original_default__"
   const hasModels = models.length > 0
 
   return (
@@ -1029,9 +1075,8 @@ function ModelAliasesCard({
       <CardContent className="space-y-3 px-4">
         <div className="flex items-center justify-between gap-3">
           <div className="text-muted-foreground text-xs">
-            {allowOriginalModelNamesForAliases
-              ? "Requests can use either the alias or the original model name."
-              : "Requests must use aliases; original model names are blocked."}
+            Default behavior: {allowOriginalModelNamesForAliases ? "allow" : "block"} original
+            model IDs. Each alias can override this setting.
           </div>
           <div className="flex items-center gap-2">
             <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
@@ -1045,7 +1090,7 @@ function ModelAliasesCard({
               value={json}
               onChange={(e) => onJsonChange(e.target.value)}
               className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
-              placeholder='{ "fast": "gpt-5-mini" }'
+              placeholder='{ "fast": { "target": "gpt-5-mini", "allowOriginal": true } }'
             />
             {jsonIssue ? (
               <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
@@ -1061,6 +1106,12 @@ function ModelAliasesCard({
                 const showCustomTarget =
                   targetValue !== emptyTargetValue && !models.includes(targetValue)
                 const disableTargetSelect = !hasModels && !showCustomTarget
+                const allowOriginalValue =
+                  item.allowOriginal === undefined
+                    ? allowOriginalDefaultValue
+                    : item.allowOriginal
+                      ? "allow"
+                      : "block"
 
                 return (
                   <div key={item.id} className="grid gap-2 rounded-lg border p-3">
@@ -1095,6 +1146,26 @@ function ModelAliasesCard({
                               {model}
                             </SelectItem>
                           ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={allowOriginalValue}
+                        onValueChange={(value) =>
+                          onUpdateItem(item.id, {
+                            allowOriginal:
+                              value === allowOriginalDefaultValue
+                                ? undefined
+                                : value === "allow",
+                          })
+                        }
+                      >
+                        <SelectTrigger className="min-w-[200px]">
+                          <SelectValue placeholder="Original model ID" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={allowOriginalDefaultValue}>Use default</SelectItem>
+                          <SelectItem value="allow">Allow original model ID</SelectItem>
+                          <SelectItem value="block">Block original model ID</SelectItem>
                         </SelectContent>
                       </Select>
                       <Button
@@ -1151,7 +1222,7 @@ function AdvancedSettingsCard({
           <div className="space-y-1">
             <div className="text-sm font-medium">Allow original model names</div>
             <div className="text-muted-foreground text-xs">
-              Keeps original model IDs callable when aliases exist.
+              Default behavior when aliases do not override original model IDs.
             </div>
           </div>
           <Switch
@@ -1301,11 +1372,14 @@ function useSettingsPageState(): SettingsPageViewProps {
   const applyConfigResponse = useCallback(
     (config: AdminConfigResponse) => {
       const { _configPath, ...configData } = config
+      const aliasItems = aliasItemsFromRecord(configData.modelAliases)
+      const normalizedAliases = aliasRecordFromItems(aliasItems)
+
       setConfigPath(_configPath ?? null)
-      setDraft(configData)
+      setDraft({ ...configData, modelAliases: normalizedAliases })
       setExtraFromRecord(configData.extraPrompts)
       setReasoningFromRecord(configData.modelReasoningEfforts)
-      setAliasFromRecord(configData.modelAliases)
+      setAliasFromRecord(normalizedAliases)
     },
     [setExtraFromRecord, setReasoningFromRecord, setAliasFromRecord],
   )

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -53,6 +53,12 @@ type ReasoningItem = {
   effort: ReasoningEffort
 }
 
+type ModelAliasItem = {
+  id: string
+  alias: string
+  target: string
+}
+
 type ParseResult<T> = { record: T } | { error: string }
 
 type JsonMode = "form" | "json"
@@ -137,6 +143,17 @@ function reasoningItemsFromRecord(
   }))
 }
 
+function aliasItemsFromRecord(
+  record: Record<string, string> | undefined
+): ModelAliasItem[] {
+  if (!record) return []
+  return Object.entries(record).map(([alias, target]) => ({
+    id: createItemId(),
+    alias,
+    target,
+  }))
+}
+
 function extraPromptRecordFromItems(items: ExtraPromptItem[]): Record<string, string> {
   const record: Record<string, string> = {}
   for (const item of items) {
@@ -154,6 +171,26 @@ function reasoningRecordFromItems(items: ReasoningItem[]): Record<string, Reason
     if (!key) continue
     record[key] = item.effort
   }
+  return record
+}
+
+function aliasRecordFromItems(items: ModelAliasItem[]): Record<string, string> {
+  const record: Record<string, string> = {}
+  const seen = new Set<string>()
+
+  for (const item of items) {
+    const alias = item.alias.trim()
+    const target = item.target.trim()
+    if (!alias || !target) continue
+
+    const normalizedAlias = alias.toLowerCase()
+    if (normalizedAlias === target.toLowerCase()) continue
+    if (seen.has(normalizedAlias)) continue
+
+    seen.add(normalizedAlias)
+    record[alias] = target
+  }
+
   return record
 }
 
@@ -212,6 +249,52 @@ function parseReasoningJson(
   }
 }
 
+function parseModelAliasesJson(
+  value: string,
+): ParseResult<Record<string, string>> {
+  if (!value.trim()) return { record: {} }
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (!isPlainObject(parsed)) {
+      return { error: "modelAliases JSON must be an object of string values." }
+    }
+
+    const record: Record<string, string> = {}
+    const seen = new Set<string>()
+
+    for (const [rawAlias, rawTarget] of Object.entries(parsed)) {
+      if (typeof rawTarget !== "string") {
+        return { error: `modelAliases.${rawAlias} must be a string.` }
+      }
+
+      const alias = rawAlias.trim()
+      const target = rawTarget.trim()
+      if (!alias) {
+        return { error: "modelAliases keys must be non-empty strings." }
+      }
+      if (!target) {
+        return { error: `modelAliases.${rawAlias} must be a non-empty string.` }
+      }
+
+      const normalizedAlias = alias.toLowerCase()
+      if (normalizedAlias === target.toLowerCase()) {
+        return { error: `modelAliases.${rawAlias} cannot map to itself.` }
+      }
+      if (seen.has(normalizedAlias)) {
+        return { error: `modelAliases.${rawAlias} conflicts with another alias.` }
+      }
+
+      seen.add(normalizedAlias)
+      record[alias] = target
+    }
+
+    return { record }
+  } catch {
+    return { error: "modelAliases JSON is not valid." }
+  }
+}
+
 type ExtraPromptEditor = {
   mode: JsonMode
   items: ExtraPromptItem[]
@@ -236,6 +319,19 @@ type ReasoningEditor = {
   onRemoveItem: (id: string) => void
   onUpdateItem: (id: string, patch: Partial<ReasoningItem>) => void
   setFromRecord: (record?: Record<string, ReasoningEffort>) => void
+}
+
+type ModelAliasEditor = {
+  mode: JsonMode
+  items: ModelAliasItem[]
+  json: string
+  jsonIssue: string | null
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ModelAliasItem>) => void
+  setFromRecord: (record?: Record<string, string>) => void
 }
 
 function useExtraPromptEditor(
@@ -390,6 +486,92 @@ function useReasoningEditor(
 
   const onUpdateItem = useCallback(
     (id: string, patch: Partial<ReasoningItem>) => {
+      const next = items.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  return {
+    mode,
+    items,
+    json,
+    jsonIssue,
+    onToggleMode,
+    onJsonChange,
+    onAddItem,
+    onRemoveItem,
+    onUpdateItem,
+    setFromRecord,
+  }
+}
+
+function useModelAliasEditor(
+  onRecordChange: (record: Record<string, string>) => void,
+): ModelAliasEditor {
+  const [mode, setMode] = useState<JsonMode>("form")
+  const [items, setItems] = useState<ModelAliasItem[]>([])
+  const [json, setJson] = useState("")
+  const [jsonError, setJsonError] = useState<string | null>(null)
+
+  const jsonIssue = useMemo(
+    () => (jsonError ? `modelAliases: ${jsonError}` : null),
+    [jsonError],
+  )
+
+  const setFromRecord = useCallback((record?: Record<string, string>) => {
+    setItems(aliasItemsFromRecord(record))
+    setJson(JSON.stringify(record ?? {}, null, 2))
+    setJsonError(null)
+  }, [])
+
+  const updateItems = useCallback(
+    (nextItems: ModelAliasItem[]) => {
+      setItems(nextItems)
+      onRecordChange(aliasRecordFromItems(nextItems))
+    },
+    [onRecordChange],
+  )
+
+  const onJsonChange = useCallback(
+    (value: string) => {
+      updateJsonRecord({
+        value,
+        parse: parseModelAliasesJson,
+        setJson,
+        setError: setJsonError,
+        onRecord: (record) => updateItems(aliasItemsFromRecord(record)),
+      })
+    },
+    [updateItems],
+  )
+
+  const onToggleMode = useCallback(
+    (next: boolean) => {
+      toggleJsonMode({
+        next,
+        record: aliasRecordFromItems(items),
+        setJson,
+        setError: setJsonError,
+        setMode,
+      })
+    },
+    [items],
+  )
+
+  const onAddItem = useCallback(() => {
+    updateItems(items.concat({ id: createItemId(), alias: "", target: "" }))
+  }, [items, updateItems])
+
+  const onRemoveItem = useCallback(
+    (id: string) => {
+      updateItems(items.filter((item) => item.id !== id))
+    },
+    [items, updateItems],
+  )
+
+  const onUpdateItem = useCallback(
+    (id: string, patch: Partial<ModelAliasItem>) => {
       const next = items.map((item) => (item.id === id ? { ...item, ...patch } : item))
       updateItems(next)
     },
@@ -806,16 +988,156 @@ function ExtraPromptsCard({
   )
 }
 
+type ModelAliasesCardProps = {
+  allowOriginalModelNamesForAliases: boolean
+  mode: JsonMode
+  json: string
+  jsonIssue: string | null
+  items: ModelAliasItem[]
+  models: string[]
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ModelAliasItem>) => void
+}
+
+function ModelAliasesCard({
+  allowOriginalModelNamesForAliases,
+  mode,
+  json,
+  jsonIssue,
+  items,
+  models,
+  onToggleMode,
+  onJsonChange,
+  onAddItem,
+  onRemoveItem,
+  onUpdateItem,
+}: ModelAliasesCardProps): React.JSX.Element {
+  const emptyTargetValue = "__target__"
+  const hasModels = models.length > 0
+
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Model aliases</CardTitle>
+        <CardDescription className="hidden sm:block">
+          Map friendly alias names to upstream model IDs.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-muted-foreground text-xs">
+            {allowOriginalModelNamesForAliases
+              ? "Requests can use either the alias or the original model name."
+              : "Requests must use aliases; original model names are blocked."}
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
+            <Label className="text-muted-foreground text-xs">JSON mode</Label>
+          </div>
+        </div>
+
+        {mode === "json" ? (
+          <div className="space-y-2">
+            <Textarea
+              value={json}
+              onChange={(e) => onJsonChange(e.target.value)}
+              className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
+              placeholder='{ "fast": "gpt-5-mini" }'
+            />
+            {jsonIssue ? (
+              <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
+            ) : null}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.length === 0 ? (
+              <div className="text-muted-foreground text-sm">No model aliases configured.</div>
+            ) : (
+              items.map((item) => {
+                const targetValue = item.target || emptyTargetValue
+                const showCustomTarget =
+                  targetValue !== emptyTargetValue && !models.includes(targetValue)
+                const disableTargetSelect = !hasModels && !showCustomTarget
+
+                return (
+                  <div key={item.id} className="grid gap-2 rounded-lg border p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        className="min-w-[180px]"
+                        placeholder="Alias"
+                        value={item.alias}
+                        onChange={(e) => onUpdateItem(item.id, { alias: e.target.value })}
+                      />
+                      <Select
+                        value={targetValue}
+                        onValueChange={(value) =>
+                          onUpdateItem(item.id, {
+                            target: value === emptyTargetValue ? "" : value,
+                          })
+                        }
+                        disabled={disableTargetSelect}
+                      >
+                        <SelectTrigger className="min-w-[220px]">
+                          <SelectValue
+                            placeholder={hasModels ? "Select target model" : "No models available"}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={emptyTargetValue}>(select)</SelectItem>
+                          {showCustomTarget ? (
+                            <SelectItem value={targetValue}>Custom: {targetValue}</SelectItem>
+                          ) : null}
+                          {models.map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {model}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onRemoveItem(item.id)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                      Requests can use either the alias or the original model name.
+                    </div>
+                  </div>
+                )
+              })
+            )}
+
+            <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
+              Add alias
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
 type AdvancedSettingsCardProps = {
+  allowOriginalModelNamesForAliases: boolean
   useFunctionApplyPatch: boolean
   forceAgent: boolean
+  onToggleAllowOriginalModelNamesForAliases: (value: boolean) => void
   onToggleUseFunctionApplyPatch: (value: boolean) => void
   onToggleForceAgent: (value: boolean) => void
 }
 
 function AdvancedSettingsCard({
+  allowOriginalModelNamesForAliases,
   useFunctionApplyPatch,
   forceAgent,
+  onToggleAllowOriginalModelNamesForAliases,
   onToggleUseFunctionApplyPatch,
   onToggleForceAgent,
 }: AdvancedSettingsCardProps): React.JSX.Element {
@@ -828,6 +1150,19 @@ function AdvancedSettingsCard({
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">Allow original model names</div>
+            <div className="text-muted-foreground text-xs">
+              Keeps original model IDs callable when aliases exist.
+            </div>
+          </div>
+          <Switch
+            checked={allowOriginalModelNamesForAliases}
+            onCheckedChange={onToggleAllowOriginalModelNamesForAliases}
+          />
+        </div>
+
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
             <div className="text-sm font-medium">Use function apply_patch</div>
@@ -890,8 +1225,19 @@ type SettingsPageViewProps = {
   onExtraAddItem: () => void
   onExtraRemoveItem: (id: string) => void
   onExtraUpdateItem: (id: string, value: Partial<ExtraPromptItem>) => void
+  aliasMode: JsonMode
+  aliasJson: string
+  aliasJsonIssue: string | null
+  aliasItems: ModelAliasItem[]
+  onAliasToggleMode: (next: boolean) => void
+  onAliasJsonChange: (value: string) => void
+  onAliasAddItem: () => void
+  onAliasRemoveItem: (id: string) => void
+  onAliasUpdateItem: (id: string, value: Partial<ModelAliasItem>) => void
+  allowOriginalModelNamesForAliases: boolean
   useFunctionApplyPatch: boolean
   forceAgent: boolean
+  onAllowOriginalModelNamesForAliasesToggle: (value: boolean) => void
   onUseFunctionApplyPatchToggle: (value: boolean) => void
   onForceAgentToggle: (value: boolean) => void
 }
@@ -910,6 +1256,10 @@ function useSettingsPageState(): SettingsPageViewProps {
   )
   const reasoningEditor = useReasoningEditor((record) =>
     setDraft((prev) => ({ ...prev, modelReasoningEfforts: record })),
+  )
+
+  const aliasEditor = useModelAliasEditor((record) =>
+    setDraft((prev) => ({ ...prev, modelAliases: record })),
   )
 
   const {
@@ -938,6 +1288,19 @@ function useSettingsPageState(): SettingsPageViewProps {
     setFromRecord: setReasoningFromRecord,
   } = reasoningEditor
 
+  const {
+    mode: aliasMode,
+    items: aliasItems,
+    json: aliasJson,
+    jsonIssue: aliasJsonIssue,
+    onToggleMode: onAliasToggleMode,
+    onJsonChange: onAliasJsonChange,
+    onAddItem: onAliasAddItem,
+    onRemoveItem: onAliasRemoveItem,
+    onUpdateItem: onAliasUpdateItem,
+    setFromRecord: setAliasFromRecord,
+  } = aliasEditor
+
   const applyConfigResponse = useCallback(
     (config: AdminConfigResponse) => {
       const { _configPath, ...configData } = config
@@ -945,8 +1308,9 @@ function useSettingsPageState(): SettingsPageViewProps {
       setDraft(configData)
       setExtraFromRecord(configData.extraPrompts)
       setReasoningFromRecord(configData.modelReasoningEfforts)
+      setAliasFromRecord(configData.modelAliases)
     },
-    [setExtraFromRecord, setReasoningFromRecord],
+    [setExtraFromRecord, setReasoningFromRecord, setAliasFromRecord],
   )
 
   const load = useCallback(async () => {
@@ -1043,6 +1407,13 @@ function useSettingsPageState(): SettingsPageViewProps {
     [setDraft],
   )
 
+  const handleAllowOriginalModelNamesForAliasesToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, allowOriginalModelNamesForAliases: value }))
+    },
+    [setDraft],
+  )
+
   const handleUseFunctionApplyPatchToggle = useCallback(
     (value: boolean) => {
       setDraft((prev) => ({ ...prev, useFunctionApplyPatch: value }))
@@ -1064,6 +1435,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     && !loading
     && !(extraMode === "json" && extraJsonIssue)
     && !(reasoningMode === "json" && reasoningJsonIssue)
+    && !(aliasMode === "json" && aliasJsonIssue)
 
   const envOverrideNote =
     "Environment variable COPILOT_API_KEY overrides this value when set."
@@ -1073,6 +1445,8 @@ function useSettingsPageState(): SettingsPageViewProps {
   const apiKeyValue = draft.apiKey ?? ""
 
   const loadBalancingEnabled = draft.freeModelLoadBalancing ?? true
+  const allowOriginalModelNamesForAliases =
+    draft.allowOriginalModelNamesForAliases ?? false
   const useFunctionApplyPatch = draft.useFunctionApplyPatch ?? true
   const forceAgent = draft.forceAgent ?? false
 
@@ -1096,6 +1470,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     onApiKeyChange: handleApiKeyChange,
     loadBalancingEnabled,
     onLoadBalancingToggle: handleLoadBalancingToggle,
+    allowOriginalModelNamesForAliases,
     reasoningMode,
     reasoningJson,
     reasoningJsonIssue,
@@ -1114,8 +1489,20 @@ function useSettingsPageState(): SettingsPageViewProps {
     onExtraAddItem,
     onExtraRemoveItem,
     onExtraUpdateItem,
+    aliasMode,
+    aliasJson,
+    aliasJsonIssue,
+    aliasItems,
+    onAliasToggleMode,
+    onAliasJsonChange,
+    onAliasAddItem,
+    onAliasRemoveItem,
+    onAliasUpdateItem,
+    allowOriginalModelNamesForAliases,
     useFunctionApplyPatch,
     forceAgent,
+    onAllowOriginalModelNamesForAliasesToggle:
+      handleAllowOriginalModelNamesForAliasesToggle,
     onUseFunctionApplyPatchToggle: handleUseFunctionApplyPatchToggle,
     onForceAgentToggle: handleForceAgentToggle,
   }
@@ -1159,8 +1546,19 @@ function SettingsPageView({
   onExtraAddItem,
   onExtraRemoveItem,
   onExtraUpdateItem,
+  aliasMode,
+  aliasJson,
+  aliasJsonIssue,
+  aliasItems,
+  onAliasToggleMode,
+  onAliasJsonChange,
+  onAliasAddItem,
+  onAliasRemoveItem,
+  onAliasUpdateItem,
+  allowOriginalModelNamesForAliases,
   useFunctionApplyPatch,
   forceAgent,
+  onAllowOriginalModelNamesForAliasesToggle,
   onUseFunctionApplyPatchToggle,
   onForceAgentToggle,
 }: SettingsPageViewProps): React.JSX.Element {
@@ -1251,6 +1649,20 @@ function SettingsPageView({
               onRemoveItem={onExtraRemoveItem}
               onUpdateItem={onExtraUpdateItem}
             />
+
+            <ModelAliasesCard
+              allowOriginalModelNamesForAliases={allowOriginalModelNamesForAliases}
+              mode={aliasMode}
+              json={aliasJson}
+              jsonIssue={aliasJsonIssue}
+              items={aliasItems}
+              models={models}
+              onToggleMode={onAliasToggleMode}
+              onJsonChange={onAliasJsonChange}
+              onAddItem={onAliasAddItem}
+              onRemoveItem={onAliasRemoveItem}
+              onUpdateItem={onAliasUpdateItem}
+            />
           </div>
         </div>
 
@@ -1258,8 +1670,12 @@ function SettingsPageView({
           <LoadBalancingCard enabled={loadBalancingEnabled} onToggle={onLoadBalancingToggle} />
 
           <AdvancedSettingsCard
+            allowOriginalModelNamesForAliases={allowOriginalModelNamesForAliases}
             useFunctionApplyPatch={useFunctionApplyPatch}
             forceAgent={forceAgent}
+            onToggleAllowOriginalModelNamesForAliases={
+              onAllowOriginalModelNamesForAliasesToggle
+            }
             onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
             onToggleForceAgent={onForceAgentToggle}
           />

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -33,7 +33,7 @@ import {
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 
-const REASONING_EFFORTS: ReasoningEffort[] = [
+const REASONING_EFFORTS: Array<ReasoningEffort> = [
   "none",
   "minimal",
   "low",
@@ -129,7 +129,7 @@ function createItemId(): string {
 
 function extraPromptItemsFromRecord(
   record: Record<string, string> | undefined
-): ExtraPromptItem[] {
+): Array<ExtraPromptItem> {
   if (!record) return []
   return Object.entries(record).map(([model, prompt]) => ({
     id: createItemId(),
@@ -140,7 +140,7 @@ function extraPromptItemsFromRecord(
 
 function reasoningItemsFromRecord(
   record: Record<string, ReasoningEffort> | undefined
-): ReasoningItem[] {
+): Array<ReasoningItem> {
   if (!record) return []
   return Object.entries(record).map(([model, effort]) => ({
     id: createItemId(),
@@ -151,7 +151,7 @@ function reasoningItemsFromRecord(
 
 function aliasItemsFromRecord(
   record: ModelAliasRecordInput | undefined
-): ModelAliasItem[] {
+): Array<ModelAliasItem> {
   if (!record) return []
   return Object.entries(record).map(([alias, spec]) => {
     if (typeof spec === "string") {
@@ -171,7 +171,9 @@ function aliasItemsFromRecord(
   })
 }
 
-function extraPromptRecordFromItems(items: ExtraPromptItem[]): Record<string, string> {
+function extraPromptRecordFromItems(
+  items: Array<ExtraPromptItem>
+): Record<string, string> {
   const record: Record<string, string> = {}
   for (const item of items) {
     const key = item.model.trim()
@@ -181,7 +183,9 @@ function extraPromptRecordFromItems(items: ExtraPromptItem[]): Record<string, st
   return record
 }
 
-function reasoningRecordFromItems(items: ReasoningItem[]): Record<string, ReasoningEffort> {
+function reasoningRecordFromItems(
+  items: Array<ReasoningItem>
+): Record<string, ReasoningEffort> {
   const record: Record<string, ReasoningEffort> = {}
   for (const item of items) {
     const key = item.model.trim()
@@ -191,8 +195,10 @@ function reasoningRecordFromItems(items: ReasoningItem[]): Record<string, Reason
   return record
 }
 
-function aliasRecordFromItems(items: ModelAliasItem[]): ModelAliasRecord {
-  const record: ModelAliasRecord = {}
+const BLOCKED_ALIAS_KEYS = new Set(["__proto__", "constructor", "prototype"])
+
+function aliasRecordFromItems(items: Array<ModelAliasItem>): ModelAliasRecord {
+  const record: ModelAliasRecord = Object.create(null) as ModelAliasRecord
   const seen = new Set<string>()
 
   for (const item of items) {
@@ -201,6 +207,7 @@ function aliasRecordFromItems(items: ModelAliasItem[]): ModelAliasRecord {
     if (!alias || !target) continue
 
     const normalizedAlias = alias.toLowerCase()
+    if (BLOCKED_ALIAS_KEYS.has(normalizedAlias)) continue
     if (normalizedAlias === target.toLowerCase()) continue
     if (seen.has(normalizedAlias)) continue
 
@@ -280,13 +287,18 @@ function parseModelAliasesJson(
       return { error: "modelAliases JSON must be an object." }
     }
 
-    const record: ModelAliasRecord = {}
+    const record: ModelAliasRecord = Object.create(null) as ModelAliasRecord
     const seen = new Set<string>()
 
     for (const [rawAlias, rawTarget] of Object.entries(parsed)) {
       const alias = rawAlias.trim()
       if (!alias) {
         return { error: "modelAliases keys must be non-empty strings." }
+      }
+
+      const normalizedAlias = alias.toLowerCase()
+      if (BLOCKED_ALIAS_KEYS.has(normalizedAlias)) {
+        return { error: `modelAliases.${rawAlias} is not allowed.` }
       }
 
       let target: string | undefined
@@ -317,7 +329,6 @@ function parseModelAliasesJson(
         return { error: `modelAliases.${rawAlias} must be a non-empty string.` }
       }
 
-      const normalizedAlias = alias.toLowerCase()
       if (normalizedAlias === target.toLowerCase()) {
         return { error: `modelAliases.${rawAlias} cannot map to itself.` }
       }
@@ -338,7 +349,7 @@ function parseModelAliasesJson(
 
 type ExtraPromptEditor = {
   mode: JsonMode
-  items: ExtraPromptItem[]
+  items: Array<ExtraPromptItem>
   json: string
   jsonIssue: string | null
   onToggleMode: (next: boolean) => void
@@ -351,7 +362,7 @@ type ExtraPromptEditor = {
 
 type ReasoningEditor = {
   mode: JsonMode
-  items: ReasoningItem[]
+  items: Array<ReasoningItem>
   json: string
   jsonIssue: string | null
   onToggleMode: (next: boolean) => void
@@ -364,7 +375,7 @@ type ReasoningEditor = {
 
 type ModelAliasEditor = {
   mode: JsonMode
-  items: ModelAliasItem[]
+  items: Array<ModelAliasItem>
   json: string
   jsonIssue: string | null
   onToggleMode: (next: boolean) => void
@@ -379,7 +390,7 @@ function useExtraPromptEditor(
   onRecordChange: (record: Record<string, string>) => void,
 ): ExtraPromptEditor {
   const [mode, setMode] = useState<JsonMode>("form")
-  const [items, setItems] = useState<ExtraPromptItem[]>([])
+  const [items, setItems] = useState<Array<ExtraPromptItem>>([])
   const [json, setJson] = useState("")
   const [jsonError, setJsonError] = useState<string | null>(null)
 
@@ -395,7 +406,7 @@ function useExtraPromptEditor(
   }, [])
 
   const updateItems = useCallback(
-    (nextItems: ExtraPromptItem[]) => {
+    (nextItems: Array<ExtraPromptItem>) => {
       setItems(nextItems)
       onRecordChange(extraPromptRecordFromItems(nextItems))
     },
@@ -465,7 +476,7 @@ function useReasoningEditor(
   onRecordChange: (record: Record<string, ReasoningEffort>) => void,
 ): ReasoningEditor {
   const [mode, setMode] = useState<JsonMode>("form")
-  const [items, setItems] = useState<ReasoningItem[]>([])
+  const [items, setItems] = useState<Array<ReasoningItem>>([])
   const [json, setJson] = useState("")
   const [jsonError, setJsonError] = useState<string | null>(null)
 
@@ -481,7 +492,7 @@ function useReasoningEditor(
   }, [])
 
   const updateItems = useCallback(
-    (nextItems: ReasoningItem[]) => {
+    (nextItems: Array<ReasoningItem>) => {
       setItems(nextItems)
       onRecordChange(reasoningRecordFromItems(nextItems))
     },
@@ -551,7 +562,7 @@ function useModelAliasEditor(
   onRecordChange: (record: ModelAliasRecord) => void,
 ): ModelAliasEditor {
   const [mode, setMode] = useState<JsonMode>("form")
-  const [items, setItems] = useState<ModelAliasItem[]>([])
+  const [items, setItems] = useState<Array<ModelAliasItem>>([])
   const [json, setJson] = useState("")
   const [jsonError, setJsonError] = useState<string | null>(null)
 
@@ -569,7 +580,7 @@ function useModelAliasEditor(
   }, [])
 
   const updateItems = useCallback(
-    (nextItems: ModelAliasItem[]) => {
+    (nextItems: Array<ModelAliasItem>) => {
       setItems(nextItems)
       onRecordChange(aliasRecordFromItems(nextItems))
     },
@@ -642,7 +653,7 @@ type GeneralSettingsCardProps = {
   smallModelLabel: string
   smallModelValue: string
   smallModelInputValue: string
-  models: string[]
+  models: Array<string>
   apiKeyValue: string
   envOverrideNote: string
   onSmallModelSelect: (value: string) => void
@@ -760,8 +771,8 @@ type ReasoningEffortsCardProps = {
   mode: JsonMode
   json: string
   jsonIssue: string | null
-  items: ReasoningItem[]
-  models: string[]
+  items: Array<ReasoningItem>
+  models: Array<string>
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -905,8 +916,8 @@ type ExtraPromptsCardProps = {
   mode: JsonMode
   json: string
   jsonIssue: string | null
-  items: ExtraPromptItem[]
-  models: string[]
+  items: Array<ExtraPromptItem>
+  models: Array<string>
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -1038,13 +1049,210 @@ type ModelAliasesCardProps = {
   mode: JsonMode
   json: string
   jsonIssue: string | null
-  items: ModelAliasItem[]
-  models: string[]
+  items: Array<ModelAliasItem>
+  models: Array<string>
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
   onRemoveItem: (id: string) => void
   onUpdateItem: (id: string, patch: Partial<ModelAliasItem>) => void
+}
+
+type ModelAliasesHeaderProps = {
+  allowOriginalModelNamesForAliases: boolean
+  mode: JsonMode
+  onToggleMode: (next: boolean) => void
+}
+
+type ModelAliasesJsonEditorProps = {
+  json: string
+  jsonIssue: string | null
+  onJsonChange: (value: string) => void
+}
+
+type ModelAliasItemCardProps = {
+  item: ModelAliasItem
+  models: Array<string>
+  emptyTargetValue: string
+  allowOriginalDefaultValue: string
+  hasModels: boolean
+  onUpdateItem: (id: string, patch: Partial<ModelAliasItem>) => void
+  onRemoveItem: (id: string) => void
+}
+
+type ModelAliasesListProps = {
+  items: Array<ModelAliasItem>
+  models: Array<string>
+  emptyTargetValue: string
+  allowOriginalDefaultValue: string
+  hasModels: boolean
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<ModelAliasItem>) => void
+}
+
+function ModelAliasesHeader({
+  allowOriginalModelNamesForAliases,
+  mode,
+  onToggleMode,
+}: ModelAliasesHeaderProps): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="text-muted-foreground text-xs">
+        Default behavior: {allowOriginalModelNamesForAliases ? "allow" : "block"} original model
+        IDs. Each alias can override this setting.
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
+        <Label className="text-muted-foreground text-xs">JSON mode</Label>
+      </div>
+    </div>
+  )
+}
+
+function ModelAliasesJsonEditor({
+  json,
+  jsonIssue,
+  onJsonChange,
+}: ModelAliasesJsonEditorProps): React.JSX.Element {
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={json}
+        onChange={(e) => onJsonChange(e.target.value)}
+        className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
+        placeholder='{ "fast": { "target": "gpt-5-mini", "allowOriginal": true } }'
+      />
+      {jsonIssue ? (
+        <InlineAlert
+          variant="warning"
+          title="Invalid JSON"
+          description={jsonIssue}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function ModelAliasItemCard({
+  item,
+  models,
+  emptyTargetValue,
+  allowOriginalDefaultValue,
+  hasModels,
+  onUpdateItem,
+  onRemoveItem,
+}: ModelAliasItemCardProps): React.JSX.Element {
+  const targetValue = item.target || emptyTargetValue
+  const showCustomTarget = targetValue !== emptyTargetValue && !models.includes(targetValue)
+  const disableTargetSelect = !hasModels && !showCustomTarget
+  const allowOriginalValue =
+    item.allowOriginal === undefined
+      ? allowOriginalDefaultValue
+      : item.allowOriginal
+        ? "allow"
+        : "block"
+
+  return (
+    <div className="grid gap-2 rounded-lg border p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          className="min-w-[180px]"
+          placeholder="Alias"
+          value={item.alias}
+          onChange={(e) => onUpdateItem(item.id, { alias: e.target.value })}
+        />
+        <Select
+          value={targetValue}
+          onValueChange={(value) =>
+            onUpdateItem(item.id, {
+              target: value === emptyTargetValue ? "" : value,
+            })
+          }
+          disabled={disableTargetSelect}
+        >
+          <SelectTrigger className="min-w-[220px]">
+            <SelectValue placeholder={hasModels ? "Select target model" : "No models available"} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={emptyTargetValue}>(select)</SelectItem>
+            {showCustomTarget ? (
+              <SelectItem value={targetValue}>Custom: {targetValue}</SelectItem>
+            ) : null}
+            {models.map((model) => (
+              <SelectItem key={model} value={model}>
+                {model}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={allowOriginalValue}
+          onValueChange={(value) =>
+            onUpdateItem(item.id, {
+              allowOriginal:
+                value === allowOriginalDefaultValue
+                  ? undefined
+                  : value === "allow",
+            })
+          }
+        >
+          <SelectTrigger className="min-w-[200px]">
+            <SelectValue placeholder="Original model ID" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={allowOriginalDefaultValue}>Use default</SelectItem>
+            <SelectItem value="allow">Allow original model ID</SelectItem>
+            <SelectItem value="block">Block original model ID</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onRemoveItem(item.id)}
+        >
+          Remove
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function ModelAliasesList({
+  items,
+  models,
+  emptyTargetValue,
+  allowOriginalDefaultValue,
+  hasModels,
+  onAddItem,
+  onRemoveItem,
+  onUpdateItem,
+}: ModelAliasesListProps): React.JSX.Element {
+  return (
+    <div className="space-y-2">
+      {items.length === 0 ? (
+        <div className="text-muted-foreground text-sm">No model aliases configured.</div>
+      ) : (
+        items.map((item) => (
+          <ModelAliasItemCard
+            key={item.id}
+            item={item}
+            models={models}
+            emptyTargetValue={emptyTargetValue}
+            allowOriginalDefaultValue={allowOriginalDefaultValue}
+            hasModels={hasModels}
+            onUpdateItem={onUpdateItem}
+            onRemoveItem={onRemoveItem}
+          />
+        ))
+      )}
+
+      <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
+        Add alias
+      </Button>
+    </div>
+  )
 }
 
 function ModelAliasesCard({
@@ -1073,119 +1281,29 @@ function ModelAliasesCard({
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
-        <div className="flex items-center justify-between gap-3">
-          <div className="text-muted-foreground text-xs">
-            Default behavior: {allowOriginalModelNamesForAliases ? "allow" : "block"} original
-            model IDs. Each alias can override this setting.
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
-            <Label className="text-muted-foreground text-xs">JSON mode</Label>
-          </div>
-        </div>
+        <ModelAliasesHeader
+          allowOriginalModelNamesForAliases={allowOriginalModelNamesForAliases}
+          mode={mode}
+          onToggleMode={onToggleMode}
+        />
 
         {mode === "json" ? (
-          <div className="space-y-2">
-            <Textarea
-              value={json}
-              onChange={(e) => onJsonChange(e.target.value)}
-              className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
-              placeholder='{ "fast": { "target": "gpt-5-mini", "allowOriginal": true } }'
-            />
-            {jsonIssue ? (
-              <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
-            ) : null}
-          </div>
+          <ModelAliasesJsonEditor
+            json={json}
+            jsonIssue={jsonIssue}
+            onJsonChange={onJsonChange}
+          />
         ) : (
-          <div className="space-y-2">
-            {items.length === 0 ? (
-              <div className="text-muted-foreground text-sm">No model aliases configured.</div>
-            ) : (
-              items.map((item) => {
-                const targetValue = item.target || emptyTargetValue
-                const showCustomTarget =
-                  targetValue !== emptyTargetValue && !models.includes(targetValue)
-                const disableTargetSelect = !hasModels && !showCustomTarget
-                const allowOriginalValue =
-                  item.allowOriginal === undefined
-                    ? allowOriginalDefaultValue
-                    : item.allowOriginal
-                      ? "allow"
-                      : "block"
-
-                return (
-                  <div key={item.id} className="grid gap-2 rounded-lg border p-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Input
-                        className="min-w-[180px]"
-                        placeholder="Alias"
-                        value={item.alias}
-                        onChange={(e) => onUpdateItem(item.id, { alias: e.target.value })}
-                      />
-                      <Select
-                        value={targetValue}
-                        onValueChange={(value) =>
-                          onUpdateItem(item.id, {
-                            target: value === emptyTargetValue ? "" : value,
-                          })
-                        }
-                        disabled={disableTargetSelect}
-                      >
-                        <SelectTrigger className="min-w-[220px]">
-                          <SelectValue
-                            placeholder={hasModels ? "Select target model" : "No models available"}
-                          />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value={emptyTargetValue}>(select)</SelectItem>
-                          {showCustomTarget ? (
-                            <SelectItem value={targetValue}>Custom: {targetValue}</SelectItem>
-                          ) : null}
-                          {models.map((model) => (
-                            <SelectItem key={model} value={model}>
-                              {model}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Select
-                        value={allowOriginalValue}
-                        onValueChange={(value) =>
-                          onUpdateItem(item.id, {
-                            allowOriginal:
-                              value === allowOriginalDefaultValue
-                                ? undefined
-                                : value === "allow",
-                          })
-                        }
-                      >
-                        <SelectTrigger className="min-w-[200px]">
-                          <SelectValue placeholder="Original model ID" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value={allowOriginalDefaultValue}>Use default</SelectItem>
-                          <SelectItem value="allow">Allow original model ID</SelectItem>
-                          <SelectItem value="block">Block original model ID</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => onRemoveItem(item.id)}
-                      >
-                        Remove
-                      </Button>
-                    </div>
-                  </div>
-                )
-              })
-            )}
-
-            <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
-              Add alias
-            </Button>
-          </div>
+          <ModelAliasesList
+            items={items}
+            models={models}
+            emptyTargetValue={emptyTargetValue}
+            allowOriginalDefaultValue={allowOriginalDefaultValue}
+            hasModels={hasModels}
+            onAddItem={onAddItem}
+            onRemoveItem={onRemoveItem}
+            onUpdateItem={onUpdateItem}
+          />
         )}
       </CardContent>
     </Card>
@@ -1267,7 +1385,7 @@ type SettingsPageViewProps = {
   smallModelLabel: string
   smallModelValue: string
   smallModelInputValue: string
-  models: string[]
+  models: Array<string>
   apiKeyValue: string
   envOverrideNote: string
   onSmallModelSelect: (value: string) => void
@@ -1278,7 +1396,7 @@ type SettingsPageViewProps = {
   reasoningMode: JsonMode
   reasoningJson: string
   reasoningJsonIssue: string | null
-  reasoningItems: ReasoningItem[]
+  reasoningItems: Array<ReasoningItem>
   onReasoningToggleMode: (next: boolean) => void
   onReasoningJsonChange: (value: string) => void
   onReasoningAddItem: () => void
@@ -1287,7 +1405,7 @@ type SettingsPageViewProps = {
   extraMode: JsonMode
   extraJson: string
   extraJsonIssue: string | null
-  extraItems: ExtraPromptItem[]
+  extraItems: Array<ExtraPromptItem>
   onExtraToggleMode: (next: boolean) => void
   onExtraJsonChange: (value: string) => void
   onExtraAddItem: () => void
@@ -1296,7 +1414,7 @@ type SettingsPageViewProps = {
   aliasMode: JsonMode
   aliasJson: string
   aliasJsonIssue: string | null
-  aliasItems: ModelAliasItem[]
+  aliasItems: Array<ModelAliasItem>
   onAliasToggleMode: (next: boolean) => void
   onAliasJsonChange: (value: string) => void
   onAliasAddItem: () => void
@@ -1316,7 +1434,7 @@ function useSettingsPageState(): SettingsPageViewProps {
   const [error, setError] = useState<string | null>(null)
   const [configPath, setConfigPath] = useState<string | null>(null)
 
-  const [models, setModels] = useState<string[]>([])
+  const [models, setModels] = useState<Array<string>>([])
   const [draft, setDraft] = useState<AdminConfig>({})
 
   const extraEditor = useExtraPromptEditor((record) =>

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1106,9 +1106,6 @@ function ModelAliasesCard({
                         Remove
                       </Button>
                     </div>
-                    <div className="text-muted-foreground text-xs">
-                      Requests can use either the alias or the original model name.
-                    </div>
                   </div>
                 )
               })
@@ -1498,7 +1495,6 @@ function useSettingsPageState(): SettingsPageViewProps {
     onAliasAddItem,
     onAliasRemoveItem,
     onAliasUpdateItem,
-    allowOriginalModelNamesForAliases,
     useFunctionApplyPatch,
     forceAgent,
     onAllowOriginalModelNamesForAliasesToggle:

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -7,6 +7,7 @@ import type {
   AccountType,
 } from "~/lib/types/account"
 
+import { resolveModelAlias } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { getModels, type Model } from "~/services/copilot/get-models"
 import { getCopilotToken } from "~/services/github/get-copilot-token"
@@ -477,31 +478,10 @@ export class AccountsManager {
     return { ok: false, reason: "NO_QUOTA" }
   }
 
-  /**
-   * Select an available account for a specific request (model + endpoint).
-   * Uses reservation to avoid oversubscribing premium quota under concurrency.
-   */
-  // eslint-disable-next-line complexity
-  async selectAccountForRequest(
+  private async selectAccountForCandidates(
+    orderedAccounts: Array<AccountRuntime>,
     candidates: Array<AccountRequestCandidate>,
   ): Promise<SelectAccountForRequestResult> {
-    if (candidates.length === 0) {
-      throw new Error("selectAccountForRequest requires at least one candidate")
-    }
-
-    const orderedAccounts: Array<AccountRuntime> = []
-
-    if (this.temporaryAccount) {
-      orderedAccounts.push(this.temporaryAccount)
-    }
-
-    for (const id of this.accountOrder) {
-      const account = this.accounts.get(id)
-      if (account) {
-        orderedAccounts.push(account)
-      }
-    }
-
     if (orderedAccounts.length === 0) {
       return { ok: false, reason: "NO_ACCOUNTS" }
     }
@@ -579,6 +559,46 @@ export class AccountsManager {
     }
 
     return { ok: false, reason: "NO_QUOTA" }
+  }
+
+  /**
+   * Select an available account for a specific request (model + endpoint).
+   * Uses reservation to avoid oversubscribing premium quota under concurrency.
+   */
+  async selectAccountForRequest(
+    candidates: Array<AccountRequestCandidate>,
+  ): Promise<SelectAccountForRequestResult> {
+    if (candidates.length === 0) {
+      throw new Error("selectAccountForRequest requires at least one candidate")
+    }
+
+    const orderedAccounts = [
+      ...(this.temporaryAccount ? [this.temporaryAccount] : []),
+      ...this.accountOrder
+        .map((id) => this.accounts.get(id))
+        .filter((account): account is AccountRuntime => account !== undefined),
+    ]
+    const primary = await this.selectAccountForCandidates(
+      orderedAccounts,
+      candidates,
+    )
+    if (primary.ok || primary.reason !== "MODEL_NOT_SUPPORTED") {
+      return primary
+    }
+
+    const aliasCandidates = candidates.map((candidate) => {
+      const modelId = resolveModelAlias(candidate.modelId)
+      if (modelId === candidate.modelId) return candidate
+      return { ...candidate, modelId }
+    })
+    const aliasChanged = aliasCandidates.some(
+      (candidate, index) => candidate.modelId !== candidates[index].modelId,
+    )
+    if (!aliasChanged) {
+      return primary
+    }
+
+    return this.selectAccountForCandidates(orderedAccounts, aliasCandidates)
   }
 
   /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,7 +12,7 @@ export interface AppConfig {
     string,
     "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
   >
-  modelAliases?: Record<string, string>
+  modelAliases?: Record<string, { target: string; allowOriginal?: boolean }>
   allowOriginalModelNamesForAliases?: boolean
   useFunctionApplyPatch?: boolean
   forceAgent?: boolean
@@ -181,7 +181,16 @@ export function getConfig(): AppConfig {
   return cachedConfig
 }
 
+type ModelAliasSpec = {
+  target: string
+  allowOriginal?: boolean
+}
+
 type ModelAliasMap = Record<string, string>
+
+type ModelAliasInfoMap = Record<string, ModelAliasSpec>
+
+type ModelAliasRawMap = Record<string, unknown>
 
 function normalizeAliasKey(value: string): string | null {
   const trimmed = value.trim().toLowerCase()
@@ -193,20 +202,57 @@ function normalizeAliasTarget(value: string): string | null {
   return trimmed.length > 0 ? trimmed : null
 }
 
-export function getModelAliases(): ModelAliasMap {
-  const config = getConfig()
-  const raw = config.modelAliases ?? {}
-  const normalized: ModelAliasMap = {}
+function normalizeAliasSpec(value: unknown): ModelAliasSpec | null {
+  if (typeof value === "string") {
+    const normalizedTarget = normalizeAliasTarget(value)
+    return normalizedTarget ? { target: normalizedTarget } : null
+  }
+  if (!value || typeof value !== "object") {
+    return null
+  }
 
-  for (const [alias, target] of Object.entries(raw)) {
+  const targetValue = (value as { target?: unknown }).target
+  if (typeof targetValue !== "string") {
+    return null
+  }
+
+  const normalizedTarget = normalizeAliasTarget(targetValue)
+  if (!normalizedTarget) {
+    return null
+  }
+
+  const allowOriginalValue = (value as { allowOriginal?: unknown })
+    .allowOriginal
+  const allowOriginal =
+    typeof allowOriginalValue === "boolean" ? allowOriginalValue : undefined
+  return { target: normalizedTarget, allowOriginal }
+}
+
+export function getModelAliasesInfo(): ModelAliasInfoMap {
+  const config = getConfig()
+  const raw = (config.modelAliases ?? {}) as ModelAliasRawMap
+  const normalized: ModelAliasInfoMap = {}
+
+  for (const [alias, rawSpec] of Object.entries(raw)) {
     const normalizedAlias = normalizeAliasKey(alias)
-    const normalizedTarget = normalizeAliasTarget(target)
-    if (!normalizedAlias || !normalizedTarget) {
+    const normalizedSpec = normalizeAliasSpec(rawSpec)
+    if (!normalizedAlias || !normalizedSpec) {
       continue
     }
     if (!Object.hasOwn(normalized, normalizedAlias)) {
-      normalized[normalizedAlias] = normalizedTarget
+      normalized[normalizedAlias] = normalizedSpec
     }
+  }
+
+  return normalized
+}
+
+export function getModelAliases(): ModelAliasMap {
+  const info = getModelAliasesInfo()
+  const normalized: ModelAliasMap = {}
+
+  for (const [alias, spec] of Object.entries(info)) {
+    normalized[alias] = spec.target
   }
 
   return normalized
@@ -225,14 +271,39 @@ export function isOriginalModelNameAllowedForAliases(): boolean {
 }
 
 export function getAliasTargetSet(): Set<string> {
-  const aliases = getModelAliases()
-  const targets = new Set<string>()
+  const aliases = getModelAliasesInfo()
+  const allowOriginalDefault = isOriginalModelNameAllowedForAliases()
+  const targetAllowMap = new Map<string, boolean>()
 
-  for (const target of Object.values(aliases)) {
-    targets.add(target.toLowerCase())
+  for (const { target, allowOriginal } of Object.values(aliases)) {
+    const normalizedTarget = target.toLowerCase()
+    const effectiveAllow = allowOriginal ?? allowOriginalDefault
+    const currentAllow = targetAllowMap.get(normalizedTarget)
+    if (currentAllow === true) {
+      continue
+    }
+    if (effectiveAllow) {
+      targetAllowMap.set(normalizedTarget, true)
+    } else if (currentAllow === undefined) {
+      targetAllowMap.set(normalizedTarget, false)
+    }
   }
 
-  return targets
+  const blockedTargets = new Set<string>()
+  for (const [target, allowed] of targetAllowMap.entries()) {
+    if (!allowed) {
+      blockedTargets.add(target)
+    }
+  }
+
+  return blockedTargets
+}
+
+export function isOriginalModelNameAllowedForTarget(modelId: string): boolean {
+  const normalized = normalizeAliasKey(modelId)
+  if (!normalized) return true
+  const blockedTargets = getAliasTargetSet()
+  return !blockedTargets.has(normalized)
 }
 
 export function getPreferredAliasForTarget(modelId: string): string | null {
@@ -293,12 +364,7 @@ export function getExtraPromptForModel(model: string): string {
 export function getSmallModel(): string {
   const config = getConfig()
   const model = config.smallModel ?? "gpt-5-mini"
-  if (isOriginalModelNameAllowedForAliases()) {
-    return model
-  }
-
-  const targets = getAliasTargetSet()
-  if (!targets.has(model.toLowerCase())) {
+  if (isOriginalModelNameAllowedForTarget(model)) {
     return model
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,8 @@ export interface AppConfig {
     string,
     "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
   >
+  modelAliases?: Record<string, string>
+  allowOriginalModelNamesForAliases?: boolean
   useFunctionApplyPatch?: boolean
   forceAgent?: boolean
 }
@@ -33,6 +35,7 @@ const defaultConfig: AppConfig = {
   modelReasoningEfforts: {
     "gpt-5-mini": "low",
   },
+  allowOriginalModelNamesForAliases: false,
   useFunctionApplyPatch: true,
 }
 
@@ -178,14 +181,128 @@ export function getConfig(): AppConfig {
   return cachedConfig
 }
 
+type ModelAliasMap = Record<string, string>
+
+function normalizeAliasKey(value: string): string | null {
+  const trimmed = value.trim().toLowerCase()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeAliasTarget(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function getModelAliases(): ModelAliasMap {
+  const config = getConfig()
+  const raw = config.modelAliases ?? {}
+  const normalized: ModelAliasMap = {}
+
+  for (const [alias, target] of Object.entries(raw)) {
+    const normalizedAlias = normalizeAliasKey(alias)
+    const normalizedTarget = normalizeAliasTarget(target)
+    if (!normalizedAlias || !normalizedTarget) {
+      continue
+    }
+    if (!Object.hasOwn(normalized, normalizedAlias)) {
+      normalized[normalizedAlias] = normalizedTarget
+    }
+  }
+
+  return normalized
+}
+
+export function resolveModelAlias(modelId: string): string {
+  const normalized = normalizeAliasKey(modelId)
+  if (!normalized) return modelId
+  const aliases = getModelAliases()
+  return aliases[normalized] ?? modelId
+}
+
+export function isOriginalModelNameAllowedForAliases(): boolean {
+  const config = getConfig()
+  return config.allowOriginalModelNamesForAliases ?? false
+}
+
+export function getAliasTargetSet(): Set<string> {
+  const aliases = getModelAliases()
+  const targets = new Set<string>()
+
+  for (const target of Object.values(aliases)) {
+    targets.add(target.toLowerCase())
+  }
+
+  return targets
+}
+
+export function getPreferredAliasForTarget(modelId: string): string | null {
+  const aliases = getModelAliases()
+  const aliasKeys = getAliasKeysForTarget(modelId, aliases)
+  return aliasKeys[0] ?? null
+}
+
+function getAliasKeysForTarget(
+  target: string,
+  aliases: ModelAliasMap,
+): Array<string> {
+  const normalizedTarget = target.toLowerCase()
+  return Object.entries(aliases)
+    .filter(([, model]) => model.toLowerCase() === normalizedTarget)
+    .map(([alias]) => alias)
+    .sort()
+}
+
+function getAliasFallbackValue<T extends string>(
+  record: Record<string, T> | undefined,
+  modelId: string,
+  aliases: ModelAliasMap,
+): T | undefined {
+  if (!record) return undefined
+
+  const aliasKeys = getAliasKeysForTarget(modelId, aliases)
+  if (aliasKeys.length === 0) return undefined
+
+  const recordByAlias = new Map<string, T>()
+  for (const [key, value] of Object.entries(record)) {
+    const normalized = normalizeAliasKey(key)
+    if (normalized) {
+      recordByAlias.set(normalized, value)
+    }
+  }
+
+  for (const alias of aliasKeys) {
+    const value = recordByAlias.get(alias)
+    if (value !== undefined) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
 export function getExtraPromptForModel(model: string): string {
   const config = getConfig()
-  return config.extraPrompts?.[model] ?? ""
+  const direct = config.extraPrompts?.[model]
+  if (direct !== undefined) return direct
+
+  const aliases = getModelAliases()
+  const fallback = getAliasFallbackValue(config.extraPrompts, model, aliases)
+  return fallback ?? ""
 }
 
 export function getSmallModel(): string {
   const config = getConfig()
-  return config.smallModel ?? "gpt-5-mini"
+  const model = config.smallModel ?? "gpt-5-mini"
+  if (isOriginalModelNameAllowedForAliases()) {
+    return model
+  }
+
+  const targets = getAliasTargetSet()
+  if (!targets.has(model.toLowerCase())) {
+    return model
+  }
+
+  return getPreferredAliasForTarget(model) ?? model
 }
 
 export function isFreeModelLoadBalancingEnabled(): boolean {
@@ -197,7 +314,16 @@ export function getReasoningEffortForModel(
   model: string,
 ): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" {
   const config = getConfig()
-  return config.modelReasoningEfforts?.[model] ?? "high"
+  const direct = config.modelReasoningEfforts?.[model]
+  if (direct !== undefined) return direct
+
+  const aliases = getModelAliases()
+  const fallback = getAliasFallbackValue(
+    config.modelReasoningEfforts,
+    model,
+    aliases,
+  )
+  return fallback ?? "high"
 }
 
 export function isForceAgentEnabled(): boolean {

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -257,46 +257,94 @@ function parseReasoningRecord(
   return { value: record }
 }
 
-function parseModelAliases(
-  value: unknown,
-): ParseFieldResult<Record<string, string>> {
-  if (value === null || value === undefined) return { clear: true }
-  if (!isPlainObject(value)) {
-    return { error: "modelAliases must be an object with string values" }
+type ParsedModelAlias = {
+  alias: string
+  target: string
+  allowOriginal?: boolean
+}
+
+function parseModelAliasEntry(
+  rawAlias: string,
+  rawTarget: unknown,
+): ParseFieldResult<ParsedModelAlias> {
+  if (BLOCKED_KEYS.has(rawAlias)) {
+    return { error: `modelAliases.${rawAlias} is not allowed` }
   }
 
-  const record = Object.create(null) as Record<string, string>
+  const alias = rawAlias.trim().toLowerCase()
+  if (!alias) {
+    return { error: "modelAliases keys must be non-empty strings" }
+  }
+  if (BLOCKED_KEYS.has(alias)) {
+    return { error: `modelAliases.${alias} is not allowed` }
+  }
+
+  let target: string | undefined
+  let allowOriginal: boolean | undefined
+
+  if (typeof rawTarget === "string") {
+    target = rawTarget.trim()
+  } else if (isPlainObject(rawTarget)) {
+    const rawTargetValue = rawTarget.target
+    if (typeof rawTargetValue !== "string") {
+      return { error: `modelAliases.${rawAlias}.target must be a string` }
+    }
+    target = rawTargetValue.trim()
+
+    if ("allowOriginal" in rawTarget) {
+      if (typeof rawTarget.allowOriginal !== "boolean") {
+        return {
+          error: `modelAliases.${rawAlias}.allowOriginal must be a boolean`,
+        }
+      }
+      allowOriginal = rawTarget.allowOriginal
+    }
+  } else {
+    return { error: `modelAliases.${rawAlias} must be a string or object` }
+  }
+
+  if (!target) {
+    return { error: `modelAliases.${rawAlias} must be a non-empty string` }
+  }
+  if (alias === target.toLowerCase()) {
+    return { error: `modelAliases.${rawAlias} cannot map to itself` }
+  }
+
+  return { value: { alias, target, allowOriginal } }
+}
+
+function parseModelAliases(
+  value: unknown,
+): ParseFieldResult<
+  Record<string, { target: string; allowOriginal?: boolean }>
+> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: "modelAliases must be an object" }
+  }
+
+  const record = Object.create(null) as Record<
+    string,
+    { target: string; allowOriginal?: boolean }
+  >
 
   for (const [rawAlias, rawTarget] of Object.entries(value)) {
-    if (BLOCKED_KEYS.has(rawAlias)) {
-      return { error: `modelAliases.${rawAlias} is not allowed` }
-    }
-    if (typeof rawTarget !== "string") {
-      return { error: `modelAliases.${rawAlias} must be a string` }
-    }
+    const parsed = parseModelAliasEntry(rawAlias, rawTarget)
+    if ("error" in parsed) return parsed
+    if ("clear" in parsed) continue
 
-    const alias = rawAlias.trim().toLowerCase()
-    const target = rawTarget.trim()
-
-    if (!alias) {
-      return { error: "modelAliases keys must be non-empty strings" }
-    }
-    if (!target) {
-      return { error: `modelAliases.${rawAlias} must be a non-empty string` }
-    }
-    if (BLOCKED_KEYS.has(alias)) {
-      return { error: `modelAliases.${alias} is not allowed` }
-    }
-    if (alias === target.toLowerCase()) {
-      return { error: `modelAliases.${rawAlias} cannot map to itself` }
-    }
-
-    const existing = record[alias]
-    if (existing && existing !== target) {
+    const { alias, target, allowOriginal } = parsed.value
+    const existing = Object.hasOwn(record, alias) ? record[alias] : undefined
+    if (
+      existing
+      && (existing.target !== target
+        || existing.allowOriginal !== allowOriginal)
+    ) {
       return { error: `modelAliases.${rawAlias} conflicts with ${alias}` }
     }
 
-    record[alias] = target
+    record[alias] =
+      allowOriginal === undefined ? { target } : { target, allowOriginal }
   }
 
   return { value: record }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -6,6 +6,7 @@ import { accountsManager } from "~/lib/accounts-manager"
 import { listAccountsFromRegistry } from "~/lib/accounts-registry"
 import {
   getConfig,
+  getModelAliases,
   isFreeModelLoadBalancingEnabled,
   mergeConfigWithDefaults,
   type AppConfig,
@@ -146,6 +147,8 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "freeModelLoadBalancing",
   "apiKey",
   "modelReasoningEfforts",
+  "modelAliases",
+  "allowOriginalModelNamesForAliases",
   "useFunctionApplyPatch",
   "forceAgent",
 ])
@@ -254,6 +257,51 @@ function parseReasoningRecord(
   return { value: record }
 }
 
+function parseModelAliases(
+  value: unknown,
+): ParseFieldResult<Record<string, string>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: "modelAliases must be an object with string values" }
+  }
+
+  const record = Object.create(null) as Record<string, string>
+
+  for (const [rawAlias, rawTarget] of Object.entries(value)) {
+    if (BLOCKED_KEYS.has(rawAlias)) {
+      return { error: `modelAliases.${rawAlias} is not allowed` }
+    }
+    if (typeof rawTarget !== "string") {
+      return { error: `modelAliases.${rawAlias} must be a string` }
+    }
+
+    const alias = rawAlias.trim().toLowerCase()
+    const target = rawTarget.trim()
+
+    if (!alias) {
+      return { error: "modelAliases keys must be non-empty strings" }
+    }
+    if (!target) {
+      return { error: `modelAliases.${rawAlias} must be a non-empty string` }
+    }
+    if (BLOCKED_KEYS.has(alias)) {
+      return { error: `modelAliases.${alias} is not allowed` }
+    }
+    if (alias === target.toLowerCase()) {
+      return { error: `modelAliases.${rawAlias} cannot map to itself` }
+    }
+
+    const existing = record[alias]
+    if (existing && existing !== target) {
+      return { error: `modelAliases.${rawAlias} conflicts with ${alias}` }
+    }
+
+    record[alias] = target
+  }
+
+  return { value: record }
+}
+
 function applyOptionalString(
   next: AppConfig,
   key: "smallModel" | "apiKey",
@@ -271,7 +319,11 @@ function applyOptionalString(
 
 function applyOptionalBoolean(
   next: AppConfig,
-  key: "freeModelLoadBalancing" | "useFunctionApplyPatch" | "forceAgent",
+  key:
+    | "freeModelLoadBalancing"
+    | "useFunctionApplyPatch"
+    | "forceAgent"
+    | "allowOriginalModelNamesForAliases",
   value: unknown,
 ): string | undefined {
   const parsed = parseOptionalBoolean(value, key)
@@ -312,6 +364,20 @@ function applyReasoningEfforts(
   return undefined
 }
 
+function applyModelAliases(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseModelAliases(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.modelAliases
+    return undefined
+  }
+  next.modelAliases = parsed.value
+  return undefined
+}
+
 function applyConfigPatch(
   base: AppConfig,
   input: Record<string, unknown>,
@@ -345,6 +411,18 @@ function applyConfigPatch(
       }
       case "modelReasoningEfforts": {
         error = applyReasoningEfforts(next, value)
+        break
+      }
+      case "modelAliases": {
+        error = applyModelAliases(next, value)
+        break
+      }
+      case "allowOriginalModelNamesForAliases": {
+        error = applyOptionalBoolean(
+          next,
+          "allowOriginalModelNamesForAliases",
+          value,
+        )
         break
       }
       case "useFunctionApplyPatch": {
@@ -472,7 +550,8 @@ adminApiRoutes.get("/models", (c) => {
         .filter(
           (id): id is string => typeof id === "string" && id.trim().length > 0,
         ) ?? []
-    const uniqueItems = Array.from(new Set(items)).sort()
+    const aliasItems = Object.keys(getModelAliases())
+    const uniqueItems = Array.from(new Set([...items, ...aliasItems])).sort()
     return c.json({ items: uniqueItems })
   } catch {
     return jsonError(c, 500, {

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -6,6 +6,10 @@ import { randomUUID } from "node:crypto"
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
 import {
+  getAliasTargetSet,
+  isOriginalModelNameAllowedForAliases,
+} from "~/lib/config"
+import {
   computeDiff,
   extractErrorDetails,
   toAccountContext,
@@ -39,13 +43,31 @@ export async function handleCompletion(c: Context) {
   const request = buildRequestContext(c)
 
   const payload = await c.req.json<ChatCompletionsPayload>()
+  const clientModel = payload.model
   const streamRequested = Boolean(payload.stream)
+
+  if (!isOriginalModelNameAllowedForAliases()) {
+    const aliasTargets = getAliasTargetSet()
+    if (aliasTargets.has(clientModel.toLowerCase())) {
+      recordSelectionFailure(store, {
+        request,
+        clientModel,
+        stream: streamRequested,
+        reason: "MODEL_NOT_SUPPORTED",
+      })
+
+      return selectionFailureResponse(c, {
+        clientModel,
+        reason: "MODEL_NOT_SUPPORTED",
+      })
+    }
+  }
 
   logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
 
   const selection = await accountsManager.selectAccountForRequest([
     {
-      modelId: payload.model,
+      modelId: clientModel,
       endpoint: CHAT_COMPLETIONS_ENDPOINT,
     },
   ])
@@ -53,27 +75,32 @@ export async function handleCompletion(c: Context) {
   if (!selection.ok) {
     recordSelectionFailure(store, {
       request,
-      clientModel: payload.model,
+      clientModel,
       stream: streamRequested,
       reason: selection.reason,
     })
 
     return selectionFailureResponse(c, {
-      clientModel: payload.model,
+      clientModel,
       reason: selection.reason,
     })
   }
 
   const { account, selectedModel } = selection
 
+  const upstreamPayload = { ...payload, model: selectedModel.id }
+
   const premiumRemainingBefore = account.premiumRemaining
   const premiumUnlimitedBefore = account.unlimited
 
-  await logTokenCountForRequest({ payload, selectedModel })
+  await logTokenCountForRequest({ payload: upstreamPayload, selectedModel })
 
   if (state.manualApprove) await awaitApproval()
 
-  const payloadWithMaxTokens = applyDefaultMaxTokens(payload, selectedModel)
+  const payloadWithMaxTokens = applyDefaultMaxTokens(
+    upstreamPayload,
+    selectedModel,
+  )
 
   const accountCtx = toAccountContext(account)
 
@@ -85,6 +112,7 @@ export async function handleCompletion(c: Context) {
       payload: payloadWithMaxTokens,
       selection,
       accountCtx,
+      clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
     })
@@ -97,6 +125,7 @@ export async function handleCompletion(c: Context) {
     payload: payloadWithMaxTokens,
     selection,
     accountCtx,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   })
@@ -276,6 +305,7 @@ async function handleStreamingRequest(params: {
   payload: ChatCompletionsPayload
   selection: AccountSelectionOk
   accountCtx: Parameters<typeof createChatCompletions>[1]
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
 }): Promise<Response> {
@@ -286,6 +316,7 @@ async function handleStreamingRequest(params: {
     payload,
     selection,
     accountCtx,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   } = params
@@ -298,8 +329,8 @@ async function handleStreamingRequest(params: {
     return handleUpstreamCreateError({
       store,
       request,
-      payload,
       selection,
+      clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       error,
@@ -312,8 +343,8 @@ async function handleStreamingRequest(params: {
       c,
       store,
       request,
-      payload,
       selection,
+      clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       response,
@@ -328,8 +359,8 @@ async function handleStreamingRequest(params: {
       response,
       store,
       request,
-      payload,
       selection,
+      clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
     }),
@@ -339,8 +370,8 @@ async function handleStreamingRequest(params: {
 async function handleUpstreamCreateError(params: {
   store: Store
   request: RequestContext
-  payload: ChatCompletionsPayload
   selection: AccountSelectionOk
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   error: unknown
@@ -348,8 +379,8 @@ async function handleUpstreamCreateError(params: {
   const {
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     error,
@@ -377,7 +408,7 @@ async function handleUpstreamCreateError(params: {
     accountId: account.id,
     accountType: account.accountType,
     costUnits,
-    clientModel: payload.model,
+    clientModel,
     upstreamModel: selectedModel.id,
     premiumRemainingBefore,
     premiumRemainingAfter,
@@ -400,8 +431,8 @@ async function handleNonStreamingUpstreamResponse(params: {
   c: Context
   store: Store
   request: RequestContext
-  payload: ChatCompletionsPayload
   selection: AccountSelectionOk
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   response: ChatCompletionResponse
@@ -410,8 +441,8 @@ async function handleNonStreamingUpstreamResponse(params: {
     c,
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     response,
@@ -452,7 +483,7 @@ async function handleNonStreamingUpstreamResponse(params: {
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       ...usage,
       premiumRemainingBefore,
@@ -476,8 +507,8 @@ async function streamChatCompletionsAndLog(params: {
   response: ChatCompletionsStream
   store: Store
   request: RequestContext
-  payload: ChatCompletionsPayload
   selection: AccountSelectionOk
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
 }): Promise<void> {
@@ -486,8 +517,8 @@ async function streamChatCompletionsAndLog(params: {
     response,
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   } = params
@@ -540,7 +571,7 @@ async function streamChatCompletionsAndLog(params: {
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       ...lastUsage,
       premiumRemainingBefore,
@@ -584,6 +615,7 @@ async function handleNonStreamingRequest(params: {
   payload: ChatCompletionsPayload
   selection: AccountSelectionOk
   accountCtx: Parameters<typeof createChatCompletions>[1]
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
 }): Promise<Response> {
@@ -594,6 +626,7 @@ async function handleNonStreamingRequest(params: {
     payload,
     selection,
     accountCtx,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   } = params
@@ -658,7 +691,7 @@ async function handleNonStreamingRequest(params: {
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       ...usage,
       premiumRemainingBefore,

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -5,10 +5,7 @@ import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import {
-  getAliasTargetSet,
-  isOriginalModelNameAllowedForAliases,
-} from "~/lib/config"
+import { getAliasTargetSet } from "~/lib/config"
 import {
   computeDiff,
   extractErrorDetails,
@@ -46,21 +43,19 @@ export async function handleCompletion(c: Context) {
   const clientModel = payload.model
   const streamRequested = Boolean(payload.stream)
 
-  if (!isOriginalModelNameAllowedForAliases()) {
-    const aliasTargets = getAliasTargetSet()
-    if (aliasTargets.has(clientModel.toLowerCase())) {
-      recordSelectionFailure(store, {
-        request,
-        clientModel,
-        stream: streamRequested,
-        reason: "MODEL_NOT_SUPPORTED",
-      })
+  const blockedTargets = getAliasTargetSet()
+  if (blockedTargets.has(clientModel.toLowerCase())) {
+    recordSelectionFailure(store, {
+      request,
+      clientModel,
+      stream: streamRequested,
+      reason: "MODEL_NOT_SUPPORTED",
+    })
 
-      return selectionFailureResponse(c, {
-        clientModel,
-        reason: "MODEL_NOT_SUPPORTED",
-      })
-    }
+    return selectionFailureResponse(c, {
+      clientModel,
+      reason: "MODEL_NOT_SUPPORTED",
+    })
   }
 
   logger.debug("Request payload:", JSON.stringify(payload).slice(-400))

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -2,10 +2,7 @@ import { Hono, type Context } from "hono"
 import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
-import {
-  getAliasTargetSet,
-  isOriginalModelNameAllowedForAliases,
-} from "~/lib/config"
+import { getAliasTargetSet } from "~/lib/config"
 import { forwardError } from "~/lib/error"
 import {
   computeDiff,
@@ -73,16 +70,14 @@ embeddingRoutes.post("/", async (c) => {
     const payload = await c.req.json<EmbeddingRequest>()
     const clientModel = payload.model
 
-    if (!isOriginalModelNameAllowedForAliases()) {
-      const aliasTargets = getAliasTargetSet()
-      if (aliasTargets.has(clientModel.toLowerCase())) {
-        recordSelectionFailure(store, {
-          ctx,
-          clientModel,
-          reason: "MODEL_NOT_SUPPORTED",
-        })
-        return selectionFailureResponse(c, clientModel, "MODEL_NOT_SUPPORTED")
-      }
+    const blockedTargets = getAliasTargetSet()
+    if (blockedTargets.has(clientModel.toLowerCase())) {
+      recordSelectionFailure(store, {
+        ctx,
+        clientModel,
+        reason: "MODEL_NOT_SUPPORTED",
+      })
+      return selectionFailureResponse(c, clientModel, "MODEL_NOT_SUPPORTED")
     }
 
     const selection = await accountsManager.selectAccountForRequest([

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -2,6 +2,10 @@ import { Hono, type Context } from "hono"
 import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
+import {
+  getAliasTargetSet,
+  isOriginalModelNameAllowedForAliases,
+} from "~/lib/config"
 import { forwardError } from "~/lib/error"
 import {
   computeDiff,
@@ -67,10 +71,23 @@ embeddingRoutes.post("/", async (c) => {
     }
 
     const payload = await c.req.json<EmbeddingRequest>()
+    const clientModel = payload.model
+
+    if (!isOriginalModelNameAllowedForAliases()) {
+      const aliasTargets = getAliasTargetSet()
+      if (aliasTargets.has(clientModel.toLowerCase())) {
+        recordSelectionFailure(store, {
+          ctx,
+          clientModel,
+          reason: "MODEL_NOT_SUPPORTED",
+        })
+        return selectionFailureResponse(c, clientModel, "MODEL_NOT_SUPPORTED")
+      }
+    }
 
     const selection = await accountsManager.selectAccountForRequest([
       {
-        modelId: payload.model,
+        modelId: clientModel,
         endpoint: EMBEDDINGS_ENDPOINT,
       },
     ])
@@ -78,17 +95,20 @@ embeddingRoutes.post("/", async (c) => {
     if (!selection.ok) {
       recordSelectionFailure(store, {
         ctx,
-        clientModel: payload.model,
+        clientModel,
         reason: selection.reason,
       })
-      return selectionFailureResponse(c, payload.model, selection.reason)
+      return selectionFailureResponse(c, clientModel, selection.reason)
     }
+
+    const upstreamPayload = { ...payload, model: selection.selectedModel.id }
 
     return await runEmbeddingsWithAccount({
       c,
       store,
       ctx,
-      payload,
+      payload: upstreamPayload,
+      clientModel,
       selection,
     })
   } catch (error) {
@@ -160,12 +180,14 @@ async function runEmbeddingsWithAccount({
   store,
   ctx,
   payload,
+  clientModel,
   selection,
 }: {
   c: Context
   store: ReturnType<typeof getRequestHistoryStore>
   ctx: RequestContext
   payload: EmbeddingRequest
+  clientModel: string
   selection: AccountSelectionOk
 }) {
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
@@ -225,7 +247,7 @@ async function runEmbeddingsWithAccount({
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       clientIp: ctx.clientIp,
       clientIpSource: ctx.clientIpSource,

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -57,7 +57,12 @@ import {
   translateToOpenAI,
 } from "./non-stream-translation"
 import { translateChunkToAnthropicEvents } from "./stream-translation"
-import { mergeToolResultForClaude } from "./utils"
+import {
+  handleSelectionFailure,
+  isWarmupProbeRequest,
+  maybeBlockOriginalModelName,
+  mergeToolResultForClaude,
+} from "./utils"
 
 const logger = createHandlerLogger("messages-handler")
 
@@ -67,26 +72,7 @@ const RESPONSES_ENDPOINT = "/responses"
 type AccountSelection = Awaited<
   ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
 >
-
 type AccountSelectionOk = Extract<AccountSelection, { ok: true }>
-
-type AccountSelectionFailure = Extract<AccountSelection, { ok: false }>
-
-type SelectionFailureContext = {
-  c: Context
-  store: ReturnType<typeof getRequestHistoryStore>
-  requestId: string
-  startedAtMs: number
-  method: string
-  path: string
-  streamRequested: boolean
-  clientModel: string
-  clientIp?: string
-  clientIpSource?: string
-  userAgent?: string
-  selection: AccountSelectionFailure
-}
-
 type InstrumentationContext = {
   store: ReturnType<typeof getRequestHistoryStore>
   requestId: string
@@ -111,57 +97,44 @@ type InstrumentationContext = {
   premiumUnlimitedBefore?: boolean
 }
 
-const isWarmupProbeRequest = (payload: AnthropicMessagesPayload): boolean => {
-  const lastMsg = payload.messages.at(-1)
-  if (!lastMsg || lastMsg.role !== "user" || !Array.isArray(lastMsg.content)) {
-    return false
-  }
-
-  const lastBlock = lastMsg.content.at(-1)
-  if (!lastBlock || lastBlock.type !== "text") {
-    return false
-  }
-
-  const text = lastBlock.text.trim().toLowerCase()
-  return text === "warmup" && lastBlock.cache_control?.type === "ephemeral"
-}
-
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
-
   const store = getRequestHistoryStore()
-
   const requestId = randomUUID()
   const startedAtMs = Date.now()
-
   const method = c.req.raw.method
   const path = new URL(c.req.url, "http://local").pathname
-
   const { ip: clientIp, source: clientIpSource } = getClientIpInfo(c)
   const userAgent = c.req.header("user-agent") ?? undefined
-
   const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
   logger.debug("Anthropic request payload:", JSON.stringify(anthropicPayload))
-
-  // fix claude code 2.0.28+ warmup request consume premium request, forcing small model for warmup probe requests
-  // set "CLAUDE_CODE_SUBAGENT_MODEL": "you small model" also can avoid this
+  // Fix warmup probe: force small model for Claude Code warmup requests (CLAUDE_CODE_SUBAGENT_MODEL also works).
   const anthropicBeta = c.req.header("anthropic-beta")
   if (anthropicBeta && isWarmupProbeRequest(anthropicPayload)) {
     anthropicPayload.model = getSmallModel()
   }
-
+  const clientModel = anthropicPayload.model
   const streamRequested = Boolean(anthropicPayload.stream)
-
-  // Merge tool_result and text blocks into tool_result to avoid consuming premium requests
-  // (caused by skill invocations, edit hooks, plan or to do reminders)
-  // e.g. {"role":"user","content":[{"type":"tool_result","tool_use_id":"call_xxx","content":"Launching skill: xxx"},{"type":"text","text":"xxx"}]}
+  const blockedResponse = maybeBlockOriginalModelName({
+    c,
+    store,
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    streamRequested,
+    clientModel,
+    clientIp,
+    clientIpSource,
+    userAgent,
+  })
+  if (blockedResponse) return blockedResponse
+  // Merge tool_result blocks to avoid premium usage from skill hooks.
   mergeToolResultForClaude(anthropicBeta, anthropicPayload)
-
   const openAIPayload = translateToOpenAI(anthropicPayload)
-
   const selection = await accountsManager.selectAccountForRequest([
     {
-      modelId: anthropicPayload.model,
+      modelId: clientModel,
       endpoint: RESPONSES_ENDPOINT,
     },
     {
@@ -169,7 +142,6 @@ export async function handleCompletion(c: Context) {
       endpoint: CHAT_COMPLETIONS_ENDPOINT,
     },
   ])
-
   if (!selection.ok) {
     return handleSelectionFailure({
       c,
@@ -179,47 +151,38 @@ export async function handleCompletion(c: Context) {
       method,
       path,
       streamRequested,
-      clientModel: anthropicPayload.model,
+      clientModel,
       clientIp,
       clientIpSource,
       userAgent,
       selection,
     })
   }
-
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
-
+  openAIPayload.model = selectedModel.id
   const premiumRemainingBefore = account.premiumRemaining
   const premiumUnlimitedBefore = account.unlimited
-
   if (state.manualApprove) {
     await awaitApproval()
   }
-
   const instr: InstrumentationContext = {
     store,
     requestId,
     startedAtMs,
-
     method,
     path,
-
     clientIp,
     clientIpSource,
     userAgent,
-
-    clientModel: anthropicPayload.model,
-
+    clientModel,
     account,
     reservation,
     upstreamEndpoint: endpoint,
     upstreamModel: selectedModel.id,
     costUnits,
-
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   }
-
   if (endpoint === RESPONSES_ENDPOINT) {
     return await handleWithResponsesApi({
       c,
@@ -237,64 +200,6 @@ export async function handleCompletion(c: Context) {
     instr,
   })
 }
-
-const handleSelectionFailure = (context: SelectionFailureContext): Response => {
-  const {
-    c,
-    store,
-    requestId,
-    startedAtMs,
-    method,
-    path,
-    streamRequested,
-    clientModel,
-    clientIp,
-    clientIpSource,
-    userAgent,
-    selection,
-  } = context
-  const finishedAtMs = Date.now()
-
-  store.insert({
-    requestId,
-    startedAtMs,
-    finishedAtMs,
-    durationMs: finishedAtMs - startedAtMs,
-    method,
-    path,
-    stream: streamRequested,
-    clientModel,
-    clientIp,
-    clientIpSource,
-    userAgent,
-    httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
-    selectionFailureReason: selection.reason,
-  })
-
-  if (selection.reason === "MODEL_NOT_SUPPORTED") {
-    return c.json(
-      {
-        error: {
-          message: `Model "${clientModel}" is not available for any configured account.`,
-          type: "invalid_request_error",
-        },
-      },
-      400,
-    )
-  }
-
-  return c.json(
-    {
-      error: {
-        message:
-          "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
-        type: "rate_limit_error",
-      },
-    },
-    429,
-  )
-}
-
 const estimateInputTokens = async (
   payload: ChatCompletionsPayload,
   selectedModel: Model,
@@ -367,8 +272,10 @@ const handleWithResponsesApi = async (params: {
   instr: InstrumentationContext
 }): Promise<Response> => {
   const { c, anthropicPayload, openAIPayload, selectedModel, instr } = params
-  const responsesPayload =
-    translateAnthropicMessagesToResponsesPayload(anthropicPayload)
+  const responsesPayload = translateAnthropicMessagesToResponsesPayload(
+    anthropicPayload,
+    selectedModel.id,
+  )
   logger.debug(
     "Translated Responses payload:",
     JSON.stringify(responsesPayload),

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -47,7 +47,9 @@ const MESSAGE_TYPE = "message"
 
 export const translateAnthropicMessagesToResponsesPayload = (
   payload: AnthropicMessagesPayload,
+  modelOverride?: string,
 ): ResponsesPayload => {
+  const model = modelOverride ?? payload.model
   const input: Array<ResponseInputItem> = []
 
   for (const message of payload.messages) {
@@ -62,9 +64,9 @@ export const translateAnthropicMessagesToResponsesPayload = (
   )
 
   const responsesPayload: ResponsesPayload = {
-    model: payload.model,
+    model,
     input,
-    instructions: translateSystemPrompt(payload.system, payload.model),
+    instructions: translateSystemPrompt(payload.system, model),
     temperature: 1, // reasoning high temperature fixed to 1
     top_p: payload.top_p ?? null,
     max_output_tokens: Math.max(payload.max_tokens, 12800),
@@ -77,7 +79,7 @@ export const translateAnthropicMessagesToResponsesPayload = (
     store: false,
     parallel_tool_calls: true,
     reasoning: {
-      effort: getReasoningEffortForModel(payload.model),
+      effort: getReasoningEffortForModel(model),
       summary: "auto",
     },
     include: ["reasoning.encrypted_content"],

--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -1,9 +1,6 @@
 import type { Context } from "hono"
 
-import {
-  getAliasTargetSet,
-  isOriginalModelNameAllowedForAliases,
-} from "~/lib/config"
+import { getAliasTargetSet } from "~/lib/config"
 import { getRequestHistoryStore } from "~/lib/request-history"
 
 import type {
@@ -207,12 +204,8 @@ export const handleSelectionFailure = (
 export const maybeBlockOriginalModelName = (
   context: Omit<SelectionFailureContext, "selection">,
 ): Response | null => {
-  if (isOriginalModelNameAllowedForAliases()) {
-    return null
-  }
-
-  const aliasTargets = getAliasTargetSet()
-  if (!aliasTargets.has(context.clientModel.toLowerCase())) {
+  const blockedTargets = getAliasTargetSet()
+  if (!blockedTargets.has(context.clientModel.toLowerCase())) {
     return null
   }
 

--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -1,3 +1,11 @@
+import type { Context } from "hono"
+
+import {
+  getAliasTargetSet,
+  isOriginalModelNameAllowedForAliases,
+} from "~/lib/config"
+import { getRequestHistoryStore } from "~/lib/request-history"
+
 import type {
   AnthropicMessagesPayload,
   AnthropicResponse,
@@ -96,4 +104,120 @@ export const mergeToolResultForClaude = (
 
     msg.content = mergeToolResult(toolResults, textBlocks)
   }
+}
+
+type SelectionFailureReason = "MODEL_NOT_SUPPORTED" | "NO_QUOTA" | "NO_ACCOUNTS"
+
+type SelectionFailure = {
+  ok: false
+  reason: SelectionFailureReason
+}
+
+type SelectionFailureContext = {
+  c: Context
+  store: ReturnType<typeof getRequestHistoryStore>
+  requestId: string
+  startedAtMs: number
+  method: string
+  path: string
+  streamRequested: boolean
+  clientModel: string
+  clientIp?: string
+  clientIpSource?: string
+  userAgent?: string
+  selection: SelectionFailure
+}
+
+export const isWarmupProbeRequest = (
+  payload: AnthropicMessagesPayload,
+): boolean => {
+  const lastMsg = payload.messages.at(-1)
+  if (!lastMsg || lastMsg.role !== "user" || !Array.isArray(lastMsg.content)) {
+    return false
+  }
+
+  const lastBlock = lastMsg.content.at(-1)
+  if (!lastBlock || lastBlock.type !== "text") {
+    return false
+  }
+
+  const text = lastBlock.text.trim().toLowerCase()
+  return text === "warmup" && lastBlock.cache_control?.type === "ephemeral"
+}
+
+export const handleSelectionFailure = (
+  context: SelectionFailureContext,
+): Response => {
+  const {
+    c,
+    store,
+    requestId,
+    startedAtMs,
+    method,
+    path,
+    streamRequested,
+    clientModel,
+    clientIp,
+    clientIpSource,
+    userAgent,
+    selection,
+  } = context
+  const finishedAtMs = Date.now()
+
+  store.insert({
+    requestId,
+    startedAtMs,
+    finishedAtMs,
+    durationMs: finishedAtMs - startedAtMs,
+    method,
+    path,
+    stream: streamRequested,
+    clientModel,
+    clientIp,
+    clientIpSource,
+    userAgent,
+    httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
+    selectionFailureReason: selection.reason,
+  })
+
+  if (selection.reason === "MODEL_NOT_SUPPORTED") {
+    return c.json(
+      {
+        error: {
+          message: `Model "${clientModel}" is not available for any configured account.`,
+          type: "invalid_request_error",
+        },
+      },
+      400,
+    )
+  }
+
+  return c.json(
+    {
+      error: {
+        message:
+          "All accounts have exhausted their quota. Please wait for quota refresh or add additional accounts.",
+        type: "rate_limit_error",
+      },
+    },
+    429,
+  )
+}
+
+export const maybeBlockOriginalModelName = (
+  context: Omit<SelectionFailureContext, "selection">,
+): Response | null => {
+  if (isOriginalModelNameAllowedForAliases()) {
+    return null
+  }
+
+  const aliasTargets = getAliasTargetSet()
+  if (!aliasTargets.has(context.clientModel.toLowerCase())) {
+    return null
+  }
+
+  return handleSelectionFailure({
+    ...context,
+    selection: { ok: false, reason: "MODEL_NOT_SUPPORTED" },
+  })
 }

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -1,6 +1,11 @@
 import { Hono } from "hono"
 
 import { accountsManager } from "~/lib/accounts-manager"
+import {
+  getAliasTargetSet,
+  getModelAliases,
+  isOriginalModelNameAllowedForAliases,
+} from "~/lib/config"
 import { forwardError } from "~/lib/error"
 
 export const modelRoutes = new Hono()
@@ -9,19 +14,49 @@ modelRoutes.get("/", async (c) => {
   try {
     const accountModels = accountsManager.getFirstAccountModels()
 
-    const models = accountModels?.data.map((model) => ({
-      id: model.id,
+    const aliasTargets = getAliasTargetSet()
+    const models =
+      accountModels?.data
+        .filter((model) => {
+          if (isOriginalModelNameAllowedForAliases()) {
+            return true
+          }
+          return !aliasTargets.has(model.id.toLowerCase())
+        })
+        .map((model) => ({
+          id: model.id,
+          object: "model",
+          type: "model",
+          created: 0, // No date available from source
+          created_at: new Date(0).toISOString(), // No date available from source
+          owned_by: model.vendor,
+          display_name: model.name,
+        })) ?? []
+
+    const aliasItems = Object.keys(getModelAliases())
+    const aliasModels = aliasItems.map((alias) => ({
+      id: alias,
       object: "model",
       type: "model",
-      created: 0, // No date available from source
-      created_at: new Date(0).toISOString(), // No date available from source
-      owned_by: model.vendor,
-      display_name: model.name,
+      created: 0,
+      created_at: new Date(0).toISOString(),
+      owned_by: "alias",
+      display_name: alias,
     }))
+
+    const merged = new Map<string, (typeof models)[number]>()
+    for (const model of models) {
+      merged.set(model.id, model)
+    }
+    for (const model of aliasModels) {
+      if (!merged.has(model.id)) {
+        merged.set(model.id, model)
+      }
+    }
 
     return c.json({
       object: "list",
-      data: models ?? [],
+      data: Array.from(merged.values()),
       has_more: false,
     })
   } catch (error) {

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -1,11 +1,7 @@
 import { Hono } from "hono"
 
 import { accountsManager } from "~/lib/accounts-manager"
-import {
-  getAliasTargetSet,
-  getModelAliases,
-  isOriginalModelNameAllowedForAliases,
-} from "~/lib/config"
+import { getAliasTargetSet, getModelAliases } from "~/lib/config"
 import { forwardError } from "~/lib/error"
 
 export const modelRoutes = new Hono()
@@ -14,15 +10,10 @@ modelRoutes.get("/", async (c) => {
   try {
     const accountModels = accountsManager.getFirstAccountModels()
 
-    const aliasTargets = getAliasTargetSet()
+    const blockedTargets = getAliasTargetSet()
     const models =
       accountModels?.data
-        .filter((model) => {
-          if (isOriginalModelNameAllowedForAliases()) {
-            return true
-          }
-          return !aliasTargets.has(model.id.toLowerCase())
-        })
+        .filter((model) => !blockedTargets.has(model.id.toLowerCase()))
         .map((model) => ({
           id: model.id,
           object: "model",

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -638,12 +638,13 @@ async function handleNonStreamingResponses(params: {
     if (streamResponse) {
       return streamResponse
     }
-    usage = extractResponsesUsageFromResult(response)
+    const result = response as ResponsesResult
+    usage = extractResponsesUsageFromResult(result)
     logger.debug(
       "Forwarding native Responses result:",
-      JSON.stringify(response).slice(-400),
+      JSON.stringify(result).slice(-400),
     )
-    return c.json(response)
+    return c.json(result)
   } catch (error) {
     finishedAtMs = Date.now()
     const details = extractErrorDetails(error)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -57,6 +57,8 @@ export const handleResponses = async (c: Context) => {
 
     return selectionFailureResponse(c, {
       reason: "MODEL_NOT_SUPPORTED",
+      message:
+        "This model is only available via an alias. Please use the alias model name.",
     })
   }
 
@@ -226,16 +228,18 @@ function selectionFailureResponse(
   c: Context,
   params: {
     reason: AccountSelectionErr["reason"]
+    message?: string
   },
 ) {
-  const { reason } = params
+  const { reason, message } = params
 
   if (reason === "MODEL_NOT_SUPPORTED") {
     return c.json(
       {
         error: {
           message:
-            "This model does not support the responses endpoint. Please choose a different model.",
+            message
+            ?? "This model does not support the responses endpoint. Please choose a different model.",
           type: "invalid_request_error",
         },
       },

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -5,7 +5,11 @@ import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import { getConfig } from "~/lib/config"
+import {
+  getAliasTargetSet,
+  getConfig,
+  isOriginalModelNameAllowedForAliases,
+} from "~/lib/config"
 import {
   computeDiff,
   extractErrorDetails,
@@ -41,14 +45,30 @@ export const handleResponses = async (c: Context) => {
   const request = buildRequestContext(c)
 
   const payload = await c.req.json<ResponsesPayload>()
+  const clientModel = payload.model
   logger.debug("Responses request payload:", JSON.stringify(payload))
 
-  useFunctionApplyPatch(payload)
   const streamRequested = Boolean(payload.stream)
+
+  if (!isOriginalModelNameAllowedForAliases()) {
+    const aliasTargets = getAliasTargetSet()
+    if (aliasTargets.has(clientModel.toLowerCase())) {
+      recordSelectionFailure(store, {
+        request,
+        stream: streamRequested,
+        clientModel,
+        reason: "MODEL_NOT_SUPPORTED",
+      })
+
+      return selectionFailureResponse(c, {
+        reason: "MODEL_NOT_SUPPORTED",
+      })
+    }
+  }
 
   const selection = await accountsManager.selectAccountForRequest([
     {
-      modelId: payload.model,
+      modelId: clientModel,
       endpoint: RESPONSES_ENDPOINT,
     },
   ])
@@ -57,7 +77,7 @@ export const handleResponses = async (c: Context) => {
     recordSelectionFailure(store, {
       request,
       stream: streamRequested,
-      clientModel: payload.model,
+      clientModel,
       reason: selection.reason,
     })
 
@@ -66,12 +86,15 @@ export const handleResponses = async (c: Context) => {
     })
   }
 
-  const { account } = selection
+  const { account, selectedModel } = selection
+
+  const upstreamPayload = { ...payload, model: selectedModel.id }
+  useFunctionApplyPatch(upstreamPayload)
 
   const premiumRemainingBefore = account.premiumRemaining
   const premiumUnlimitedBefore = account.unlimited
 
-  const { vision, initiator } = getResponsesRequestOptions(payload)
+  const { vision, initiator } = getResponsesRequestOptions(upstreamPayload)
 
   if (state.manualApprove) await awaitApproval()
 
@@ -82,8 +105,9 @@ export const handleResponses = async (c: Context) => {
       c,
       store,
       request,
-      payload,
+      payload: upstreamPayload,
       selection,
+      clientModel,
       accountCtx,
       vision,
       initiator,
@@ -96,8 +120,9 @@ export const handleResponses = async (c: Context) => {
     c,
     store,
     request,
-    payload,
+    payload: upstreamPayload,
     selection,
+    clientModel,
     accountCtx,
     vision,
     initiator,
@@ -271,6 +296,7 @@ async function handleStreamingResponses(params: {
   request: RequestContext
   payload: ResponsesPayload
   selection: AccountSelectionOk
+  clientModel: string
   accountCtx: Parameters<typeof createResponses>[2]
   vision: boolean
   initiator: "agent" | "user"
@@ -283,6 +309,7 @@ async function handleStreamingResponses(params: {
     request,
     payload,
     selection,
+    clientModel,
     accountCtx,
     vision,
     initiator,
@@ -298,8 +325,8 @@ async function handleStreamingResponses(params: {
     return handleUpstreamCreateError({
       store,
       request,
-      payload,
       selection,
+      clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       error,
@@ -315,8 +342,8 @@ async function handleStreamingResponses(params: {
         response,
         store,
         request,
-        payload,
         selection,
+        clientModel,
         premiumRemainingBefore,
         premiumUnlimitedBefore,
       }),
@@ -327,8 +354,8 @@ async function handleStreamingResponses(params: {
     c,
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     result: response,
@@ -338,8 +365,8 @@ async function handleStreamingResponses(params: {
 async function handleUpstreamCreateError(params: {
   store: Store
   request: RequestContext
-  payload: ResponsesPayload
   selection: AccountSelectionOk
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   error: unknown
@@ -347,8 +374,8 @@ async function handleUpstreamCreateError(params: {
   const {
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     error,
@@ -376,7 +403,7 @@ async function handleUpstreamCreateError(params: {
     accountId: account.id,
     accountType: account.accountType,
     costUnits,
-    clientModel: payload.model,
+    clientModel,
     upstreamModel: selectedModel.id,
     premiumRemainingBefore,
     premiumRemainingAfter,
@@ -399,8 +426,8 @@ async function handleNonStreamingUpstreamResult(params: {
   c: Context
   store: Store
   request: RequestContext
-  payload: ResponsesPayload
   selection: AccountSelectionOk
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   result: ResponsesResult
@@ -409,8 +436,8 @@ async function handleNonStreamingUpstreamResult(params: {
     c,
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     result,
@@ -455,7 +482,7 @@ async function handleNonStreamingUpstreamResult(params: {
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       ...usage,
       premiumRemainingBefore,
@@ -479,8 +506,8 @@ async function streamResponsesAndLog(params: {
   response: AsyncIterable<unknown>
   store: Store
   request: RequestContext
-  payload: ResponsesPayload
   selection: AccountSelectionOk
+  clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
 }): Promise<void> {
@@ -489,8 +516,8 @@ async function streamResponsesAndLog(params: {
     response,
     store,
     request,
-    payload,
     selection,
+    clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   } = params
@@ -548,7 +575,7 @@ async function streamResponsesAndLog(params: {
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       ...lastUsage,
       premiumRemainingBefore,
@@ -573,6 +600,7 @@ async function handleNonStreamingResponses(params: {
   request: RequestContext
   payload: ResponsesPayload
   selection: AccountSelectionOk
+  clientModel: string
   accountCtx: Parameters<typeof createResponses>[2]
   vision: boolean
   initiator: "agent" | "user"
@@ -585,23 +613,20 @@ async function handleNonStreamingResponses(params: {
     request,
     payload,
     selection,
+    clientModel,
     accountCtx,
     vision,
     initiator,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
   } = params
-
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
-
   let httpStatus = 200
   let usage: NormalizedUsage = {}
   let errorName: string | undefined
   let errorStatus: number | undefined
   let errorMessage: string | undefined
-
   let finishedAtMs: number | undefined
-
   try {
     const response = await createResponses(
       payload,
@@ -609,25 +634,11 @@ async function handleNonStreamingResponses(params: {
       accountCtx,
     )
     finishedAtMs = Date.now()
-
-    if (isAsyncIterable(response)) {
-      // Defensive guard: upstream returned stream unexpectedly.
-      logger.debug("Forwarding native Responses stream (unexpected)")
-
-      return streamSSE(c, async (stream) => {
-        for await (const chunk of response) {
-          const { id, event, data } = getStreamChunkFields(chunk)
-          await stream.writeSSE({
-            id,
-            event,
-            data: data ?? "",
-          })
-        }
-      })
+    const streamResponse = handleUnexpectedResponsesStream(c, response)
+    if (streamResponse) {
+      return streamResponse
     }
-
     usage = extractResponsesUsageFromResult(response)
-
     logger.debug(
       "Forwarding native Responses result:",
       JSON.stringify(response).slice(-400),
@@ -635,18 +646,14 @@ async function handleNonStreamingResponses(params: {
     return c.json(response)
   } catch (error) {
     finishedAtMs = Date.now()
-
     const details = extractErrorDetails(error)
     httpStatus = details.httpStatus
-
     errorName = details.errorName
     errorStatus = details.errorStatus
     errorMessage = details.errorMessage
-
     if (details.unauthorized) {
       accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
     }
-
     throw error
   } finally {
     const finishedAtMsFinal = finishedAtMs ?? Date.now()
@@ -664,7 +671,7 @@ async function handleNonStreamingResponses(params: {
       accountId: account.id,
       accountType: account.accountType,
       costUnits,
-      clientModel: payload.model,
+      clientModel,
       upstreamModel: selectedModel.id,
       ...usage,
       premiumRemainingBefore,
@@ -681,6 +688,29 @@ async function handleNonStreamingResponses(params: {
       errorMessage,
     })
   }
+}
+
+function handleUnexpectedResponsesStream(
+  c: Context,
+  response: Awaited<ReturnType<typeof createResponses>>,
+): Response | null {
+  if (!isAsyncIterable(response)) {
+    return null
+  }
+
+  // Defensive guard: upstream returned stream unexpectedly.
+  logger.debug("Forwarding native Responses stream (unexpected)")
+
+  return streamSSE(c, async (stream) => {
+    for await (const chunk of response) {
+      const { id, event, data } = getStreamChunkFields(chunk)
+      await stream.writeSSE({
+        id,
+        event,
+        data: data ?? "",
+      })
+    }
+  })
 }
 
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -5,11 +5,7 @@ import { randomUUID } from "node:crypto"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import {
-  getAliasTargetSet,
-  getConfig,
-  isOriginalModelNameAllowedForAliases,
-} from "~/lib/config"
+import { getAliasTargetSet, getConfig } from "~/lib/config"
 import {
   computeDiff,
   extractErrorDetails,
@@ -50,20 +46,18 @@ export const handleResponses = async (c: Context) => {
 
   const streamRequested = Boolean(payload.stream)
 
-  if (!isOriginalModelNameAllowedForAliases()) {
-    const aliasTargets = getAliasTargetSet()
-    if (aliasTargets.has(clientModel.toLowerCase())) {
-      recordSelectionFailure(store, {
-        request,
-        stream: streamRequested,
-        clientModel,
-        reason: "MODEL_NOT_SUPPORTED",
-      })
+  const blockedTargets = getAliasTargetSet()
+  if (blockedTargets.has(clientModel.toLowerCase())) {
+    recordSelectionFailure(store, {
+      request,
+      stream: streamRequested,
+      clientModel,
+      reason: "MODEL_NOT_SUPPORTED",
+    })
 
-      return selectionFailureResponse(c, {
-        reason: "MODEL_NOT_SUPPORTED",
-      })
-    }
+    return selectionFailureResponse(c, {
+      reason: "MODEL_NOT_SUPPORTED",
+    })
   }
 
   const selection = await accountsManager.selectAccountForRequest([

--- a/tests/model-alias-switch.test.ts
+++ b/tests/model-alias-switch.test.ts
@@ -12,7 +12,7 @@ import { getRequestHistoryStore } from "~/lib/request-history"
 import { maybeBlockOriginalModelName } from "~/routes/messages/utils"
 import { modelRoutes } from "~/routes/models/route"
 
-type ModelsResponse = { data: Array<Model> }
+type ModelsResponse = { data: Array<Model>; object: string }
 
 type TestConfig = {
   modelAliases: Record<string, string>
@@ -78,6 +78,7 @@ test("alias-only blocks original model names and hides them from /models", async
       accountsManager.getFirstAccountModels = () =>
         ({
           data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+          object: "list",
         }) as ModelsResponse
 
       try {

--- a/tests/model-alias-switch.test.ts
+++ b/tests/model-alias-switch.test.ts
@@ -14,8 +14,13 @@ import { modelRoutes } from "~/routes/models/route"
 
 type ModelsResponse = { data: Array<Model>; object: string }
 
+type ModelAliasSpec = {
+  target: string
+  allowOriginal?: boolean
+}
+
 type TestConfig = {
-  modelAliases: Record<string, string>
+  modelAliases: Record<string, ModelAliasSpec | string>
   allowOriginalModelNamesForAliases: boolean
   smallModel: string
 }
@@ -63,55 +68,158 @@ const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
   }
 }
 
-test("alias-only blocks original model names and hides them from /models", async () => {
+const withMockedModels = async (run: () => Promise<void>) => {
+  const originalGetFirstAccountModels =
+    accountsManager.getFirstAccountModels.bind(accountsManager)
+  accountsManager.getFirstAccountModels = () =>
+    ({
+      data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+      object: "list",
+    }) as ModelsResponse
+
+  try {
+    await run()
+  } finally {
+    // eslint-disable-next-line require-atomic-updates
+    accountsManager.getFirstAccountModels = originalGetFirstAccountModels
+  }
+}
+
+const getModelIds = async () => {
+  const res = await modelRoutes.fetch(new Request("http://local/"))
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { data: Array<{ id: string }> }
+  return body.data.map((model) => model.id)
+}
+
+const getBlockStatus = async (clientModel: string) => {
+  const app = new Hono()
+  app.get("/", (c) => {
+    const blocked = maybeBlockOriginalModelName({
+      c,
+      store: getRequestHistoryStore(),
+      requestId: "req-1",
+      startedAtMs: Date.now(),
+      method: "GET",
+      path: "/",
+      streamRequested: false,
+      clientModel,
+    })
+    return blocked ?? c.text("ok")
+  })
+
+  const res = await app.fetch(new Request("http://local/"))
+  return res.status
+}
+
+test("per-alias block overrides global allow", async () => {
   await withConfig(
     {
       modelAliases: {
-        fast: "gpt-5-mini",
+        fast: { target: "gpt-5-mini", allowOriginal: false },
+      },
+      allowOriginalModelNamesForAliases: true,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      await withMockedModels(async () => {
+        const ids = await getModelIds()
+        expect(ids).toContain("fast")
+        expect(ids).not.toContain("gpt-5-mini")
+      })
+
+      expect(getSmallModel()).toBe("fast")
+      expect(await getBlockStatus("gpt-5-mini")).toBe(400)
+    },
+  )
+})
+
+test("per-alias allow overrides global block", async () => {
+  await withConfig(
+    {
+      modelAliases: {
+        fast: { target: "gpt-5-mini", allowOriginal: true },
       },
       allowOriginalModelNamesForAliases: false,
       smallModel: "gpt-5-mini",
     },
     async () => {
-      const originalGetFirstAccountModels =
-        accountsManager.getFirstAccountModels.bind(accountsManager)
-      accountsManager.getFirstAccountModels = () =>
-        ({
-          data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
-          object: "list",
-        }) as ModelsResponse
-
-      try {
-        const res = await modelRoutes.fetch(new Request("http://local/"))
-        expect(res.status).toBe(200)
-        const body = (await res.json()) as { data: Array<{ id: string }> }
-        const ids = body.data.map((model) => model.id)
+      await withMockedModels(async () => {
+        const ids = await getModelIds()
         expect(ids).toContain("fast")
-        expect(ids).not.toContain("gpt-5-mini")
-      } finally {
-        // eslint-disable-next-line require-atomic-updates
-        accountsManager.getFirstAccountModels = originalGetFirstAccountModels
-      }
-
-      expect(getSmallModel()).toBe("fast")
-
-      const app = new Hono()
-      app.get("/", (c) => {
-        const blocked = maybeBlockOriginalModelName({
-          c,
-          store: getRequestHistoryStore(),
-          requestId: "req-1",
-          startedAtMs: Date.now(),
-          method: "GET",
-          path: "/",
-          streamRequested: false,
-          clientModel: "gpt-5-mini",
-        })
-        return blocked ?? c.text("ok")
+        expect(ids).toContain("gpt-5-mini")
       })
 
-      const blockedRes = await app.fetch(new Request("http://local/"))
-      expect(blockedRes.status).toBe(400)
+      expect(getSmallModel()).toBe("gpt-5-mini")
+      expect(await getBlockStatus("gpt-5-mini")).toBe(200)
+    },
+  )
+})
+
+test("allow-wins when multiple aliases map to the same target", async () => {
+  await withConfig(
+    {
+      modelAliases: {
+        fast: { target: "gpt-5-mini", allowOriginal: false },
+        rapid: { target: "gpt-5-mini", allowOriginal: true },
+      },
+      allowOriginalModelNamesForAliases: false,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      await withMockedModels(async () => {
+        const ids = await getModelIds()
+        expect(ids).toContain("fast")
+        expect(ids).toContain("rapid")
+        expect(ids).toContain("gpt-5-mini")
+      })
+
+      expect(getSmallModel()).toBe("gpt-5-mini")
+      expect(await getBlockStatus("gpt-5-mini")).toBe(200)
+    },
+  )
+})
+
+test("alias default inherits global block", async () => {
+  await withConfig(
+    {
+      modelAliases: {
+        fast: { target: "gpt-5-mini" },
+      },
+      allowOriginalModelNamesForAliases: false,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      await withMockedModels(async () => {
+        const ids = await getModelIds()
+        expect(ids).toContain("fast")
+        expect(ids).not.toContain("gpt-5-mini")
+      })
+
+      expect(getSmallModel()).toBe("fast")
+      expect(await getBlockStatus("gpt-5-mini")).toBe(400)
+    },
+  )
+})
+
+test("alias default inherits global allow", async () => {
+  await withConfig(
+    {
+      modelAliases: {
+        fast: { target: "gpt-5-mini" },
+      },
+      allowOriginalModelNamesForAliases: true,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      await withMockedModels(async () => {
+        const ids = await getModelIds()
+        expect(ids).toContain("fast")
+        expect(ids).toContain("gpt-5-mini")
+      })
+
+      expect(getSmallModel()).toBe("gpt-5-mini")
+      expect(await getBlockStatus("gpt-5-mini")).toBe(200)
     },
   )
 })

--- a/tests/model-alias-switch.test.ts
+++ b/tests/model-alias-switch.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { Hono } from "hono"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { Model } from "~/services/copilot/get-models"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { getSmallModel, mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+import { getRequestHistoryStore } from "~/lib/request-history"
+import { maybeBlockOriginalModelName } from "~/routes/messages/utils"
+import { modelRoutes } from "~/routes/models/route"
+
+type ModelsResponse = { data: Array<Model> }
+
+type TestConfig = {
+  modelAliases: Record<string, string>
+  allowOriginalModelNamesForAliases: boolean
+  smallModel: string
+}
+
+const buildModel = (id: string): Model => ({
+  id,
+  name: id,
+  vendor: "upstream",
+  object: "model",
+  preview: false,
+  version: "test",
+  model_picker_enabled: true,
+  capabilities: {
+    family: "test",
+    limits: {},
+    object: "capabilities",
+    supports: {},
+    tokenizer: "test",
+    type: "chat",
+  },
+})
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+
+  try {
+    await run()
+  } finally {
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (original === null) {
+      await fs.rm(PATHS.CONFIG_PATH, { force: true })
+    } else {
+      await fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    }
+    mergeConfigWithDefaults()
+  }
+}
+
+test("alias-only blocks original model names and hides them from /models", async () => {
+  await withConfig(
+    {
+      modelAliases: {
+        fast: "gpt-5-mini",
+      },
+      allowOriginalModelNamesForAliases: false,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      const originalGetFirstAccountModels =
+        accountsManager.getFirstAccountModels.bind(accountsManager)
+      accountsManager.getFirstAccountModels = () =>
+        ({
+          data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+        }) as ModelsResponse
+
+      try {
+        const res = await modelRoutes.fetch(new Request("http://local/"))
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as { data: Array<{ id: string }> }
+        const ids = body.data.map((model) => model.id)
+        expect(ids).toContain("fast")
+        expect(ids).not.toContain("gpt-5-mini")
+      } finally {
+        // eslint-disable-next-line require-atomic-updates
+        accountsManager.getFirstAccountModels = originalGetFirstAccountModels
+      }
+
+      expect(getSmallModel()).toBe("fast")
+
+      const app = new Hono()
+      app.get("/", (c) => {
+        const blocked = maybeBlockOriginalModelName({
+          c,
+          store: getRequestHistoryStore(),
+          requestId: "req-1",
+          startedAtMs: Date.now(),
+          method: "GET",
+          path: "/",
+          streamRequested: false,
+          clientModel: "gpt-5-mini",
+        })
+        return blocked ?? c.text("ok")
+      })
+
+      const blockedRes = await app.fetch(new Request("http://local/"))
+      expect(blockedRes.status).toBe(400)
+    },
+  )
+})


### PR DESCRIPTION
## Summary
- Upgrade alias configuration with per-alias allow/block behavior and normalization
- Improve admin UI alias editor (security checks, clearer structure, consistent types)
- Clarify alias-only responses error messaging without changing reason semantics

## Tests
- bun run lint
- bun run typecheck
- bun test