### PR TITLE
feat: support messages api with instrumentation

### DIFF
--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -118,6 +118,38 @@ export function normalizeResponsesUsage(
   }
 }
 
+type AnthropicUsage = {
+  input_tokens?: number
+  output_tokens?: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+  service_tier?: "standard" | "priority" | "batch"
+}
+
+export function normalizeMessagesUsage(
+  usage?: AnthropicUsage | null,
+): NormalizedUsage {
+  if (!usage) return {}
+
+  const cached = usage.cache_read_input_tokens ?? 0
+  const input = usage.input_tokens
+  const output = usage.output_tokens
+  const hasInput = typeof input === "number"
+  const hasOutput = typeof output === "number"
+  const tokensInput = hasInput ? Math.max(0, input - cached) : undefined
+  const tokensOutput = hasOutput ? output : undefined
+  const tokensTotal =
+    hasInput || hasOutput ? (input ?? 0) + (output ?? 0) : undefined
+
+  return {
+    tokensCachedInput: cached,
+    tokensInput,
+    tokensOutput,
+    tokensTotal,
+    usageJson: JSON.stringify(usage),
+  }
+}
+
 export function normalizeEmbeddingsUsage(
   usage?: EmbeddingResponse["usage"],
 ): NormalizedUsage {

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -45,7 +45,10 @@ import {
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
-import { createMessages } from "~/services/copilot/create-messages"
+import {
+  createMessages,
+  getMessagesInitiator,
+} from "~/services/copilot/create-messages"
 import {
   createResponses,
   type ResponsesResult,
@@ -936,24 +939,6 @@ async function streamResponsesAndLog(params: {
   }
 }
 
-function getMessagesInitiator(
-  payload: AnthropicMessagesPayload,
-): "agent" | "user" {
-  const lastMessage = payload.messages.at(-1)
-  if (!lastMessage || lastMessage.role !== "user") {
-    return "agent"
-  }
-
-  if (!Array.isArray(lastMessage.content)) {
-    return "user"
-  }
-
-  const hasNonToolResult = lastMessage.content.some(
-    (block) => block.type !== "tool_result",
-  )
-  return hasNonToolResult ? "user" : "agent"
-}
-
 async function handleMessagesCreateError(params: {
   error: unknown
   instr: InstrumentationContext
@@ -1081,7 +1066,11 @@ async function streamMessagesAndLog(params: {
         ttfbMs = Date.now() - instr.startedAtMs
       }
 
-      const eventName = (rawEvent as { event?: string }).event
+      const eventNameRaw = (rawEvent as { event?: string }).event
+      const eventName =
+        typeof eventNameRaw === "string" && eventNameRaw.length > 0 ?
+          eventNameRaw
+        : "message"
       const data = (rawEvent as { data?: string }).data ?? ""
       logger.debug("Messages raw stream event:", data)
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import type { Context } from "hono"
 
 import { streamSSE } from "hono/streaming"
@@ -22,6 +23,7 @@ import {
   getClientIpInfo,
   getRequestHistoryStore,
   normalizeChatCompletionsUsage,
+  normalizeMessagesUsage,
   type NormalizedUsage,
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
@@ -43,6 +45,7 @@ import {
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
+import { createMessages } from "~/services/copilot/create-messages"
 import {
   createResponses,
   type ResponsesResult,
@@ -51,6 +54,8 @@ import {
 
 import {
   type AnthropicMessagesPayload,
+  type AnthropicResponse,
+  type AnthropicStreamEventData,
   type AnthropicStreamState,
 } from "./anthropic-types"
 import {
@@ -70,6 +75,7 @@ const logger = createHandlerLogger("messages-handler")
 
 const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
 const RESPONSES_ENDPOINT = "/responses"
+const MESSAGES_ENDPOINT = "/v1/messages"
 
 type AccountSelection = Awaited<
   ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
@@ -158,6 +164,10 @@ export async function handleCompletion(c: Context) {
   const selection = await accountsManager.selectAccountForRequest([
     {
       modelId: clientModel,
+      endpoint: MESSAGES_ENDPOINT,
+    },
+    {
+      modelId: clientModel,
       endpoint: RESPONSES_ENDPOINT,
     },
     {
@@ -212,6 +222,14 @@ export async function handleCompletion(c: Context) {
     costUnits,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
+  }
+  if (endpoint === MESSAGES_ENDPOINT) {
+    return await handleWithMessagesApi({
+      c,
+      anthropicPayload,
+      anthropicBetaHeader: anthropicBeta ?? undefined,
+      instr,
+    })
   }
   if (endpoint === RESPONSES_ENDPOINT) {
     return await handleWithResponsesApi({
@@ -392,6 +410,8 @@ type ChatCompletionsStream = Exclude<
   ChatCompletionsResult,
   ChatCompletionResponse
 >
+
+type MessagesResult = Awaited<ReturnType<typeof createMessages>>
 
 function insertRequestLog(
   instr: InstrumentationContext,
@@ -914,6 +934,250 @@ async function streamResponsesAndLog(params: {
       errorMessage,
     })
   }
+}
+
+function getMessagesInitiator(
+  payload: AnthropicMessagesPayload,
+): "agent" | "user" {
+  const lastMessage = payload.messages.at(-1)
+  if (!lastMessage || lastMessage.role !== "user") {
+    return "agent"
+  }
+
+  if (!Array.isArray(lastMessage.content)) {
+    return "user"
+  }
+
+  const hasNonToolResult = lastMessage.content.some(
+    (block) => block.type !== "tool_result",
+  )
+  return hasNonToolResult ? "user" : "agent"
+}
+
+async function handleMessagesCreateError(params: {
+  error: unknown
+  instr: InstrumentationContext
+  stream: boolean
+}): Promise<never> {
+  const { error, instr, stream } = params
+
+  const finishedAtMs = Date.now()
+  const details = extractErrorDetails(error)
+
+  if (details.unauthorized) {
+    accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+  }
+
+  const { premiumRemainingAfter, premiumUnlimitedAfter, premiumRemainingDiff } =
+    await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+  insertRequestLog(instr, {
+    finishedAtMs,
+    durationMs: finishedAtMs - instr.startedAtMs,
+    stream,
+    premiumRemainingAfter,
+    premiumUnlimitedAfter,
+    premiumRemainingDiff,
+    httpStatus: details.httpStatus,
+    errorName: details.errorName,
+    errorStatus: details.errorStatus,
+    errorMessage: details.errorMessage,
+  })
+
+  throw error
+}
+
+async function handleMessagesNonStreaming(params: {
+  c: Context
+  response: AnthropicResponse
+  instr: InstrumentationContext
+}): Promise<Response> {
+  const { c, response, instr } = params
+
+  let httpStatus = 200
+  const usage = normalizeMessagesUsage(response.usage)
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  const finishedAtMs = Date.now()
+
+  try {
+    logger.debug(
+      "Non-streaming Messages result:",
+      JSON.stringify(response).slice(-400),
+    )
+    return c.json(response)
+  } catch (error) {
+    const details = extractErrorDetails(error)
+
+    httpStatus = details.httpStatus
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+
+    throw error
+  } finally {
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      stream: false,
+      ...usage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus,
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+const parseMessagesStreamUsage = (data: string): NormalizedUsage | null => {
+  if (!data) return null
+
+  try {
+    const parsed = JSON.parse(data) as AnthropicStreamEventData
+    if (parsed.type !== "message_delta" || !parsed.usage) {
+      return null
+    }
+
+    return normalizeMessagesUsage(parsed.usage)
+  } catch (error) {
+    logger.warn("Failed to parse messages stream event", error)
+    return null
+  }
+}
+
+async function streamMessagesAndLog(params: {
+  stream: StreamSseStream
+  response: AsyncIterable<unknown>
+  instr: InstrumentationContext
+}): Promise<void> {
+  const { stream, response, instr } = params
+
+  let ttfbMs: number | undefined
+  let lastUsage: NormalizedUsage = {}
+
+  let errorName: string | undefined
+  let errorStatus: number | undefined
+  let errorMessage: string | undefined
+
+  try {
+    for await (const rawEvent of response) {
+      if (ttfbMs === undefined) {
+        ttfbMs = Date.now() - instr.startedAtMs
+      }
+
+      const eventName = (rawEvent as { event?: string }).event
+      const data = (rawEvent as { data?: string }).data ?? ""
+      logger.debug("Messages raw stream event:", data)
+
+      const usage = parseMessagesStreamUsage(data)
+      if (usage) {
+        lastUsage = usage
+      }
+
+      await stream.writeSSE({
+        event: eventName,
+        data,
+      })
+    }
+  } catch (error) {
+    const details = extractErrorDetails(error)
+
+    errorName = details.errorName
+    errorStatus = details.errorStatus
+    errorMessage = details.errorMessage
+
+    logger.warn("Streaming error:", error)
+
+    if (details.unauthorized) {
+      accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
+    }
+  } finally {
+    const finishedAtMs = Date.now()
+
+    const {
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+    } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    insertRequestLog(instr, {
+      finishedAtMs,
+      durationMs: finishedAtMs - instr.startedAtMs,
+      ttfbMs,
+      stream: true,
+      ...lastUsage,
+      premiumRemainingAfter,
+      premiumUnlimitedAfter,
+      premiumRemainingDiff,
+      httpStatus: errorStatus ?? (errorName ? 500 : 200),
+      errorName,
+      errorStatus,
+      errorMessage,
+    })
+  }
+}
+
+const handleWithMessagesApi = async (params: {
+  c: Context
+  anthropicPayload: AnthropicMessagesPayload
+  anthropicBetaHeader?: string
+  instr: InstrumentationContext
+}): Promise<Response> => {
+  const { c, anthropicPayload, anthropicBetaHeader, instr } = params
+  const ctx = toAccountContext(instr.account)
+  const upstreamRequestId = randomUUID()
+  const initiator = getMessagesInitiator(anthropicPayload)
+
+  instr.initiator = initiator
+  instr.upstreamRequestId = upstreamRequestId
+
+  let response: MessagesResult
+
+  try {
+    response = await createMessages(anthropicPayload, ctx, {
+      anthropicBetaHeader,
+      upstreamRequestId,
+    })
+  } catch (error) {
+    return await handleMessagesCreateError({
+      error,
+      instr,
+      stream: Boolean(anthropicPayload.stream),
+    })
+  }
+
+  if (isAsyncIterable(response)) {
+    logger.debug("Streaming response from Copilot (Messages API)")
+    return streamSSE(c, (stream) =>
+      streamMessagesAndLog({
+        stream,
+        response,
+        instr,
+      }),
+    )
+  }
+
+  return handleMessagesNonStreaming({
+    c,
+    response,
+    instr,
+  })
 }
 
 const isNonStreaming = (

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -1,0 +1,70 @@
+import consola from "consola"
+import { events } from "fetch-event-stream"
+
+import type { AccountContext } from "~/lib/types/account"
+import type {
+  AnthropicMessagesPayload,
+  AnthropicResponse,
+} from "~/routes/messages/anthropic-types"
+
+import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
+import { HTTPError } from "~/lib/error"
+import { accountFromState } from "~/lib/state"
+
+export type MessagesStream = ReturnType<typeof events>
+export type CreateMessagesReturn = AnthropicResponse | MessagesStream
+
+export const createMessages = async (
+  payload: AnthropicMessagesPayload,
+  account?: AccountContext,
+  options?: {
+    anthropicBetaHeader?: string
+    upstreamRequestId?: string
+  },
+): Promise<CreateMessagesReturn> => {
+  const ctx = account ?? accountFromState()
+  if (!ctx.copilotToken) throw new Error("Copilot token not found")
+
+  const enableVision = payload.messages.some(
+    (message) =>
+      Array.isArray(message.content)
+      && message.content.some((block) => block.type === "image"),
+  )
+
+  let isInitiateRequest = false
+  const lastMessage = payload.messages.at(-1)
+  if (lastMessage?.role === "user") {
+    isInitiateRequest =
+      Array.isArray(lastMessage.content) ?
+        lastMessage.content.some((block) => block.type !== "tool_result")
+      : true
+  }
+
+  const headers: Record<string, string> = {
+    ...copilotHeaders(ctx, enableVision, options?.upstreamRequestId),
+    "X-Initiator": isInitiateRequest ? "user" : "agent",
+  }
+
+  if (options?.anthropicBetaHeader) {
+    headers["anthropic-beta"] = options.anthropicBetaHeader
+  } else if (payload.thinking?.budget_tokens) {
+    headers["anthropic-beta"] = "interleaved-thinking-2025-05-14"
+  }
+
+  const response = await fetch(`${copilotBaseUrl(ctx)}/v1/messages`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    consola.error("Failed to create messages", response)
+    throw new HTTPError("Failed to create messages", response)
+  }
+
+  if (payload.stream) {
+    return events(response)
+  }
+
+  return (await response.json()) as AnthropicResponse
+}

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -11,6 +11,24 @@ import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
 import { accountFromState } from "~/lib/state"
 
+export const getMessagesInitiator = (
+  payload: AnthropicMessagesPayload,
+): "agent" | "user" => {
+  const lastMessage = payload.messages.at(-1)
+  if (!lastMessage || lastMessage.role !== "user") {
+    return "agent"
+  }
+
+  if (!Array.isArray(lastMessage.content)) {
+    return "user"
+  }
+
+  const hasNonToolResult = lastMessage.content.some(
+    (block) => block.type !== "tool_result",
+  )
+  return hasNonToolResult ? "user" : "agent"
+}
+
 export type MessagesStream = ReturnType<typeof events>
 export type CreateMessagesReturn = AnthropicResponse | MessagesStream
 
@@ -31,18 +49,11 @@ export const createMessages = async (
       && message.content.some((block) => block.type === "image"),
   )
 
-  let isInitiateRequest = false
-  const lastMessage = payload.messages.at(-1)
-  if (lastMessage?.role === "user") {
-    isInitiateRequest =
-      Array.isArray(lastMessage.content) ?
-        lastMessage.content.some((block) => block.type !== "tool_result")
-      : true
-  }
+  const initiator = getMessagesInitiator(payload)
 
   const headers: Record<string, string> = {
     ...copilotHeaders(ctx, enableVision, options?.upstreamRequestId),
-    "X-Initiator": isInitiateRequest ? "user" : "agent",
+    "X-Initiator": initiator,
   }
 
   if (options?.anthropicBetaHeader) {


### PR DESCRIPTION
## Summary
- route /v1/messages through account selection with messages priority
- add instrumentation and usage logging for messages responses and streams
- update createMessages to use account context and request IDs

## Test plan
- [x] bun run lint
- [x] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加对新的 Messages API 支持并提供消息创建与流式响应能力
  * 新增消息流处理与使用量归一化展示

* **改进**
  * 优化消息路由、流式事件代理与实时使用量解析
  * 强化错误处理、配额记录与日志埋点，改善非流/流式返回体验

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->