### PR TITLE
fix(messages): normalize long reasoning ids

### DIFF
--- a/src/routes/messages/responses-stream-translation.ts
+++ b/src/routes/messages/responses-stream-translation.ts
@@ -204,8 +204,9 @@ const handleOutputItemDone = (
 
   const outputIndex = rawEvent.output_index
   const blockIndex = openThinkingBlockIfNeeded(state, outputIndex, events)
-  const signature =
-    (item.encrypted_content ?? "") + "@" + normalizeReasoningId(item.id)
+  const encryptedContent = item.encrypted_content ?? ""
+  const normalizedId = normalizeReasoningId(item.id) ?? ""
+  const signature = `${encryptedContent}@${normalizedId}`
   if (signature) {
     // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
     if (!item.summary || item.summary.length === 0) {

--- a/src/routes/messages/responses-stream-translation.ts
+++ b/src/routes/messages/responses-stream-translation.ts
@@ -18,6 +18,7 @@ import {
 
 import { type AnthropicStreamEventData } from "./anthropic-types"
 import {
+  normalizeReasoningId,
   THINKING_TEXT,
   translateResponsesResultToAnthropic,
 } from "./responses-translation"
@@ -203,7 +204,8 @@ const handleOutputItemDone = (
 
   const outputIndex = rawEvent.output_index
   const blockIndex = openThinkingBlockIfNeeded(state, outputIndex, events)
-  const signature = (item.encrypted_content ?? "") + "@" + item.id
+  const signature =
+    (item.encrypted_content ?? "") + "@" + normalizeReasoningId(item.id)
   if (signature) {
     // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
     if (!item.summary || item.summary.length === 0) {

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -53,7 +53,11 @@ export const MAX_REASONING_ID_LENGTH = 64
 const toBase64Url = (base64: string): string =>
   base64.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "")
 
-export const normalizeReasoningId = (id: string): string => {
+export const normalizeReasoningId = (id: unknown): string | undefined => {
+  if (typeof id !== "string" || id.length === 0) {
+    return undefined
+  }
+
   if (id.length <= MAX_REASONING_ID_LENGTH) {
     return id
   }
@@ -265,10 +269,11 @@ const createReasoningContent = (
   // align with vscode-copilot-chat extractThinkingData, should add id, otherwise it will cause miss cache occasionally —— the usage input cached tokens to be 0
   // https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/endpoint/node/responsesApi.ts#L162
   // when use in codex cli, reasoning id is empty, so it will cause miss cache occasionally
-  const array = block.signature.split("@")
-  const signature = array[0]
-  const rawId = array[1]
-  const id = typeof rawId === "string" ? normalizeReasoningId(rawId) : undefined
+  const lastAt = block.signature.lastIndexOf("@")
+  const signature =
+    lastAt === -1 ? block.signature : block.signature.slice(0, lastAt)
+  const rawId = lastAt === -1 ? undefined : block.signature.slice(lastAt + 1)
+  const id = normalizeReasoningId(rawId)
   const thinking = block.thinking === THINKING_TEXT ? "" : block.thinking
   return {
     id,
@@ -398,13 +403,12 @@ const mapOutputToAnthropicContent = (
       case "reasoning": {
         const thinkingText = extractReasoningText(item)
         if (thinkingText.length > 0) {
+          const encryptedContent = item.encrypted_content ?? ""
+          const normalizedId = normalizeReasoningId(item.id) ?? ""
           contentBlocks.push({
             type: "thinking",
             thinking: thinkingText,
-            signature:
-              (item.encrypted_content ?? "")
-              + "@"
-              + normalizeReasoningId(item.id),
+            signature: `${encryptedContent}@${normalizedId}`,
           })
         }
         break

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -1,4 +1,5 @@
 import consola from "consola"
+import { createHash } from "node:crypto"
 
 import {
   getExtraPromptForModel,
@@ -46,6 +47,19 @@ import {
 const MESSAGE_TYPE = "message"
 
 export const THINKING_TEXT = "Thinking..."
+
+export const MAX_REASONING_ID_LENGTH = 64
+
+const toBase64Url = (base64: string): string =>
+  base64.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "")
+
+export const normalizeReasoningId = (id: string): string => {
+  if (id.length <= MAX_REASONING_ID_LENGTH) {
+    return id
+  }
+
+  return toBase64Url(createHash("sha256").update(id).digest("base64"))
+}
 
 export const translateAnthropicMessagesToResponsesPayload = (
   payload: AnthropicMessagesPayload,
@@ -253,7 +267,8 @@ const createReasoningContent = (
   // when use in codex cli, reasoning id is empty, so it will cause miss cache occasionally
   const array = block.signature.split("@")
   const signature = array[0]
-  const id = array[1]
+  const rawId = array[1]
+  const id = typeof rawId === "string" ? normalizeReasoningId(rawId) : undefined
   const thinking = block.thinking === THINKING_TEXT ? "" : block.thinking
   return {
     id,
@@ -386,7 +401,10 @@ const mapOutputToAnthropicContent = (
           contentBlocks.push({
             type: "thinking",
             thinking: thinkingText,
-            signature: (item.encrypted_content ?? "") + "@" + item.id,
+            signature:
+              (item.encrypted_content ?? "")
+              + "@"
+              + normalizeReasoningId(item.id),
           })
         }
         break

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -1,5 +1,4 @@
 import consola from "consola"
-import { createHash } from "node:crypto"
 
 import {
   getExtraPromptForModel,
@@ -50,19 +49,19 @@ export const THINKING_TEXT = "Thinking..."
 
 export const MAX_REASONING_ID_LENGTH = 64
 
-const toBase64Url = (base64: string): string =>
-  base64.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "")
-
 export const normalizeReasoningId = (id: unknown): string | undefined => {
-  if (typeof id !== "string" || id.length === 0) {
+  if (typeof id !== "string") {
     return undefined
   }
 
-  if (id.length <= MAX_REASONING_ID_LENGTH) {
-    return id
+  // NOTE: Copilot Responses API validates input item IDs; if an ID is too long,
+  // it may not be a real server-issued ID. In that case we omit it rather than
+  // generating a synthetic ID that could fail upstream validation.
+  if (id.length === 0 || id.length > MAX_REASONING_ID_LENGTH) {
+    return undefined
   }
 
-  return toBase64Url(createHash("sha256").update(id).digest("base64"))
+  return id
 }
 
 export const translateAnthropicMessagesToResponsesPayload = (


### PR DESCRIPTION
## Summary
- Normalize overly long `reasoning.id` values using sha256 base64url when translating `thinking.signature` for the Responses API.
- Also normalize reasoning IDs when converting Responses output back into `thinking.signature` to prevent reintroducing invalid long IDs.

## Test plan
- [x] bun run lint
- [x] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增可公开使用的推理ID校验与规范化接口及最大长度常量。

* **优化**
  * 改进对签名中推理ID的解析与构建，支持包含分隔符的ID并使用规范化ID生成签名。
  * 统一与强化推理ID处理逻辑，提升一致性与稳定性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->