### PR TITLE
fix(responses): remove unsupported web_search tool

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -46,6 +46,9 @@ export const handleResponses = async (c: Context) => {
   const clientModel = payload.model
   logger.debug("Responses request payload:", JSON.stringify(payload))
 
+  // Remove web_search tool as it's not supported by GitHub Copilot
+  removeWebSearchTool(payload)
+
   const streamRequested = Boolean(payload.stream)
 
   const { initiator: initialInitiator } = getResponsesRequestOptions(payload)
@@ -786,4 +789,12 @@ const useFunctionApplyPatch = (payload: ResponsesPayload): void => {
       }
     }
   }
+}
+
+const removeWebSearchTool = (payload: ResponsesPayload): void => {
+  if (!Array.isArray(payload.tools) || payload.tools.length === 0) return
+
+  payload.tools = payload.tools.filter((t) => {
+    return t.type !== "web_search"
+  })
 }


### PR DESCRIPTION
## Summary
- Strip unsupported `web_search` tools from Responses payloads for GitHub Copilot.
- Keep the existing instrumentation-based request handling on `all`.

## Test plan
- [x] `bun run lint`
- [x] `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug 修复
* 优化了请求处理中的工具配置管理，调整了工具在请求中的处理方式。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->