### PR TITLE
fix(messages): detect Claude Code hello warmup probe

### DIFF
--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -159,7 +159,23 @@ export const isWarmupProbeRequest = (
   }
 
   const text = lastBlock.text.trim().toLowerCase()
-  return text === "warmup" && lastBlock.cache_control?.type === "ephemeral"
+  const isEphemeral = lastBlock.cache_control?.type === "ephemeral"
+  if (!isEphemeral) return false
+
+  if (text === "warmup") return true
+
+  if (text === "hello") {
+    const preludeBlocks = lastMsg.content.slice(0, -1)
+    if (preludeBlocks.length === 0) return false
+
+    return preludeBlocks.every(
+      (block) =>
+        block.type === "text"
+        && block.text.trimStart().toLowerCase().startsWith("<system-reminder"),
+    )
+  }
+
+  return false
 }
 
 export const handleSelectionFailure = (

--- a/tests/warmup-probe.test.ts
+++ b/tests/warmup-probe.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+
+import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+
+import { isWarmupProbeRequest } from "~/routes/messages/utils"
+
+describe("isWarmupProbeRequest", () => {
+  test("detects Claude Code hello warmup probe", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "copilot/gpt-5.2",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "<system-reminder>SessionStart:startup hook success: Success</system-reminder>",
+            },
+            {
+              type: "text",
+              text: "hello",
+              cache_control: {
+                type: "ephemeral",
+              },
+            },
+          ],
+        },
+      ],
+      max_tokens: 1,
+    }
+
+    expect(isWarmupProbeRequest(payload)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Detect new Claude Code warmup probe payload using ephemeral \"hello\" signature.
- Add regression test for warmup detection.

## Test plan
- [x] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了内部请求检测逻辑，增强了系统的可靠性和灵活性，同时保持向后兼容性。

* **测试**
  * 添加新的单元测试用例，全面覆盖更新后的内部检测功能，确保系统稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->