### PR TITLE
fix(messages): make message_start input_tokens fallback optional

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -98,6 +98,7 @@ export type AdminConfig = {
   useFunctionApplyPatch?: boolean
   forceAgent?: boolean
   compactUseSmallModel?: boolean
+  messageStartInputTokensFallback?: boolean
 }
 
 export type AdminConfigResponse = AdminConfig & {

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -40,7 +40,6 @@ import {
 
 const SETTINGS_SECTIONS: Array<SettingsSection> = [
   { id: "general", label: "General" },
-  { id: "load-balancing", label: "Load Balancing" },
   { id: "reasoning", label: "Reasoning" },
   { id: "aliases", label: "Aliases" },
   { id: "prompts", label: "Prompts" },
@@ -752,35 +751,6 @@ function GeneralSettingsCard({
   )
 }
 
-type LoadBalancingCardProps = {
-  enabled: boolean
-  onToggle: (value: boolean) => void
-}
-
-function LoadBalancingCard({ enabled, onToggle }: LoadBalancingCardProps): React.JSX.Element {
-  return (
-    <Card className="gap-4 py-4">
-      <CardHeader className="px-4">
-        <CardTitle>Load balancing</CardTitle>
-        <CardDescription className="hidden sm:block">
-          Toggle free account load balancing.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3 px-4">
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
-            <div className="text-sm font-medium">Free model load balancing</div>
-            <div className="text-muted-foreground text-xs">
-              When enabled, distributes free traffic across available accounts.
-            </div>
-          </div>
-          <Switch checked={enabled} onCheckedChange={onToggle} />
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
 type ReasoningEffortsCardProps = {
   mode: JsonMode
   json: string
@@ -1325,11 +1295,13 @@ function ModelAliasesCard({
 }
 
 type AdvancedSettingsCardProps = {
+  loadBalancingEnabled: boolean
   allowOriginalModelNamesForAliases: boolean
   useFunctionApplyPatch: boolean
   forceAgent: boolean
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
+  onToggleLoadBalancing: (value: boolean) => void
   onToggleAllowOriginalModelNamesForAliases: (value: boolean) => void
   onToggleUseFunctionApplyPatch: (value: boolean) => void
   onToggleForceAgent: (value: boolean) => void
@@ -1338,11 +1310,13 @@ type AdvancedSettingsCardProps = {
 }
 
 function AdvancedSettingsCard({
+  loadBalancingEnabled,
   allowOriginalModelNamesForAliases,
   useFunctionApplyPatch,
   forceAgent,
   compactUseSmallModel,
   messageStartInputTokensFallback,
+  onToggleLoadBalancing,
   onToggleAllowOriginalModelNamesForAliases,
   onToggleUseFunctionApplyPatch,
   onToggleForceAgent,
@@ -1360,6 +1334,19 @@ function AdvancedSettingsCard({
       <CardContent className="space-y-3 px-4">
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
+            <div className="text-sm font-medium">Free model load balancing</div>
+            <div className="text-muted-foreground text-xs">
+              When enabled, distributes free traffic across available accounts.
+            </div>
+          </div>
+          <Switch
+            checked={loadBalancingEnabled}
+            onCheckedChange={onToggleLoadBalancing}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
             <div className="text-sm font-medium">Allow original model names</div>
             <div className="text-muted-foreground text-xs">
               Default behavior when aliases do not override original model IDs.
@@ -1373,9 +1360,9 @@ function AdvancedSettingsCard({
 
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Use function apply_patch</div>
+            <div className="text-sm font-medium">Use apply_patch as function tool</div>
             <div className="text-muted-foreground text-xs">
-              Enables function-level patches in responses routing.
+              When enabled, exposes apply_patch as a function tool in Responses API requests.
             </div>
           </div>
           <Switch checked={useFunctionApplyPatch} onCheckedChange={onToggleUseFunctionApplyPatch} />
@@ -1383,9 +1370,9 @@ function AdvancedSettingsCard({
 
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Force agent header</div>
+            <div className="text-sm font-medium">Reduce repeated premium consumption in agent sessions</div>
             <div className="text-muted-foreground text-xs">
-              Forces agent routing logic even when clients omit hints.
+              When enabled, sends X-Initiator=agent more aggressively; depending on upstream counting, this may reduce repeated premium consumption within the same session. When disabled, each user turn may be counted separately (VS Code-like).
             </div>
           </div>
           <Switch checked={forceAgent} onCheckedChange={onToggleForceAgent} />
@@ -1406,9 +1393,9 @@ function AdvancedSettingsCard({
 
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">message_start input_tokens fallback</div>
+            <div className="text-sm font-medium">Estimate input tokens at stream start</div>
             <div className="text-muted-foreground text-xs">
-              When enabled, estimates input token usage for message_start; disable to always report 0.
+              When enabled, estimates message_start input tokens when upstream usage is unavailable.
             </div>
           </div>
           <Switch
@@ -1909,14 +1896,6 @@ function SettingsPageView({
             />
           </SettingsSectionCard>
 
-          {/* Load Balancing */}
-          <SettingsSectionCard
-            id="load-balancing"
-            isActive={activeSection === "load-balancing"}
-            ref={(el) => registerSection("load-balancing", el)}
-          >
-            <LoadBalancingCard enabled={loadBalancingEnabled} onToggle={onLoadBalancingToggle} />
-          </SettingsSectionCard>
 
           {/* Reasoning Efforts */}
           <SettingsSectionCard
@@ -1986,11 +1965,13 @@ function SettingsPageView({
             ref={(el) => registerSection("advanced", el)}
           >
             <AdvancedSettingsCard
+              loadBalancingEnabled={loadBalancingEnabled}
               allowOriginalModelNamesForAliases={allowOriginalModelNamesForAliases}
               useFunctionApplyPatch={useFunctionApplyPatch}
               forceAgent={forceAgent}
               compactUseSmallModel={compactUseSmallModel}
               messageStartInputTokensFallback={messageStartInputTokensFallback}
+              onToggleLoadBalancing={onLoadBalancingToggle}
               onToggleAllowOriginalModelNamesForAliases={
                 onAllowOriginalModelNamesForAliasesToggle
               }

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1329,10 +1329,12 @@ type AdvancedSettingsCardProps = {
   useFunctionApplyPatch: boolean
   forceAgent: boolean
   compactUseSmallModel: boolean
+  messageStartInputTokensFallback: boolean
   onToggleAllowOriginalModelNamesForAliases: (value: boolean) => void
   onToggleUseFunctionApplyPatch: (value: boolean) => void
   onToggleForceAgent: (value: boolean) => void
   onToggleCompactUseSmallModel: (value: boolean) => void
+  onToggleMessageStartInputTokensFallback: (value: boolean) => void
 }
 
 function AdvancedSettingsCard({
@@ -1340,10 +1342,12 @@ function AdvancedSettingsCard({
   useFunctionApplyPatch,
   forceAgent,
   compactUseSmallModel,
+  messageStartInputTokensFallback,
   onToggleAllowOriginalModelNamesForAliases,
   onToggleUseFunctionApplyPatch,
   onToggleForceAgent,
   onToggleCompactUseSmallModel,
+  onToggleMessageStartInputTokensFallback,
 }: AdvancedSettingsCardProps): React.JSX.Element {
   return (
     <Card className="gap-4 py-4">
@@ -1397,6 +1401,19 @@ function AdvancedSettingsCard({
           <Switch
             checked={compactUseSmallModel}
             onCheckedChange={onToggleCompactUseSmallModel}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">message_start input_tokens fallback</div>
+            <div className="text-muted-foreground text-xs">
+              When enabled, estimates input token usage for message_start; disable to always report 0.
+            </div>
+          </div>
+          <Switch
+            checked={messageStartInputTokensFallback}
+            onCheckedChange={onToggleMessageStartInputTokensFallback}
           />
         </div>
       </CardContent>
@@ -1455,10 +1472,12 @@ type SettingsPageViewProps = {
   useFunctionApplyPatch: boolean
   forceAgent: boolean
   compactUseSmallModel: boolean
+  messageStartInputTokensFallback: boolean
   onAllowOriginalModelNamesForAliasesToggle: (value: boolean) => void
   onUseFunctionApplyPatchToggle: (value: boolean) => void
   onForceAgentToggle: (value: boolean) => void
   onCompactUseSmallModelToggle: (value: boolean) => void
+  onMessageStartInputTokensFallbackToggle: (value: boolean) => void
 }
 
 function useSettingsPageState(): SettingsPageViewProps {
@@ -1657,6 +1676,13 @@ function useSettingsPageState(): SettingsPageViewProps {
     [setDraft],
   )
 
+  const handleMessageStartInputTokensFallbackToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, messageStartInputTokensFallback: value }))
+    },
+    [setDraft],
+  )
+
   const hasModels = models.length > 0
   const smallModelValue = draft.smallModel ? draft.smallModel : "__default__"
   const canSave =
@@ -1679,6 +1705,8 @@ function useSettingsPageState(): SettingsPageViewProps {
   const useFunctionApplyPatch = draft.useFunctionApplyPatch ?? true
   const forceAgent = draft.forceAgent ?? false
   const compactUseSmallModel = draft.compactUseSmallModel ?? true
+  const messageStartInputTokensFallback =
+    draft.messageStartInputTokensFallback ?? true
 
   return {
     loading,
@@ -1731,11 +1759,14 @@ function useSettingsPageState(): SettingsPageViewProps {
     useFunctionApplyPatch,
     forceAgent,
     compactUseSmallModel,
+    messageStartInputTokensFallback,
     onAllowOriginalModelNamesForAliasesToggle:
       handleAllowOriginalModelNamesForAliasesToggle,
     onUseFunctionApplyPatchToggle: handleUseFunctionApplyPatchToggle,
     onForceAgentToggle: handleForceAgentToggle,
     onCompactUseSmallModelToggle: handleCompactUseSmallModelToggle,
+    onMessageStartInputTokensFallbackToggle:
+      handleMessageStartInputTokensFallbackToggle,
   }
 }
 
@@ -1790,10 +1821,12 @@ function SettingsPageView({
   useFunctionApplyPatch,
   forceAgent,
   compactUseSmallModel,
+  messageStartInputTokensFallback,
   onAllowOriginalModelNamesForAliasesToggle,
   onUseFunctionApplyPatchToggle,
   onForceAgentToggle,
   onCompactUseSmallModelToggle,
+  onMessageStartInputTokensFallbackToggle,
 }: SettingsPageViewProps): React.JSX.Element {
   const { activeSection, registerSection, scrollToSection } = useActiveSection({
     sectionIds: SETTINGS_SECTIONS.map((s) => s.id),
@@ -1957,12 +1990,16 @@ function SettingsPageView({
               useFunctionApplyPatch={useFunctionApplyPatch}
               forceAgent={forceAgent}
               compactUseSmallModel={compactUseSmallModel}
+              messageStartInputTokensFallback={messageStartInputTokensFallback}
               onToggleAllowOriginalModelNamesForAliases={
                 onAllowOriginalModelNamesForAliasesToggle
               }
               onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
               onToggleForceAgent={onForceAgentToggle}
               onToggleCompactUseSmallModel={onCompactUseSmallModelToggle}
+              onToggleMessageStartInputTokensFallback={
+                onMessageStartInputTokensFallbackToggle
+              }
             />
           </SettingsSectionCard>
         </main>

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1706,7 +1706,7 @@ function useSettingsPageState(): SettingsPageViewProps {
   const forceAgent = draft.forceAgent ?? false
   const compactUseSmallModel = draft.compactUseSmallModel ?? true
   const messageStartInputTokensFallback =
-    draft.messageStartInputTokensFallback ?? true
+    draft.messageStartInputTokensFallback ?? false
 
   return {
     loading,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,7 @@ export interface AppConfig {
   useFunctionApplyPatch?: boolean
   forceAgent?: boolean
   compactUseSmallModel?: boolean
+  messageStartInputTokensFallback?: boolean
 }
 
 const gpt5ExplorationPrompt = `## Exploration and reading files
@@ -39,6 +40,7 @@ const defaultConfig: AppConfig = {
   allowOriginalModelNamesForAliases: false,
   useFunctionApplyPatch: true,
   compactUseSmallModel: true,
+  messageStartInputTokensFallback: true,
 }
 
 let cachedConfig: AppConfig | null = null
@@ -376,6 +378,11 @@ export function getSmallModel(): string {
 export function isFreeModelLoadBalancingEnabled(): boolean {
   const config = getConfig()
   return config.freeModelLoadBalancing ?? true
+}
+
+export function isMessageStartInputTokensFallbackEnabled(): boolean {
+  const config = getConfig()
+  return config.messageStartInputTokensFallback ?? true
 }
 
 export function getReasoningEffortForModel(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -40,7 +40,7 @@ const defaultConfig: AppConfig = {
   allowOriginalModelNamesForAliases: false,
   useFunctionApplyPatch: true,
   compactUseSmallModel: true,
-  messageStartInputTokensFallback: true,
+  messageStartInputTokensFallback: false,
 }
 
 let cachedConfig: AppConfig | null = null
@@ -382,7 +382,7 @@ export function isFreeModelLoadBalancingEnabled(): boolean {
 
 export function isMessageStartInputTokensFallbackEnabled(): boolean {
   const config = getConfig()
-  return config.messageStartInputTokensFallback ?? true
+  return config.messageStartInputTokensFallback ?? false
 }
 
 export function getReasoningEffortForModel(

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -152,6 +152,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "useFunctionApplyPatch",
   "forceAgent",
   "compactUseSmallModel",
+  "messageStartInputTokensFallback",
 ])
 
 const REASONING_EFFORTS = new Set<ReasoningEffort>([
@@ -373,6 +374,7 @@ function applyOptionalBoolean(
     | "useFunctionApplyPatch"
     | "forceAgent"
     | "compactUseSmallModel"
+    | "messageStartInputTokensFallback"
     | "allowOriginalModelNamesForAliases",
   value: unknown,
 ): string | undefined {
@@ -485,6 +487,14 @@ function applyConfigPatch(
       }
       case "compactUseSmallModel": {
         error = applyOptionalBoolean(next, "compactUseSmallModel", value)
+        break
+      }
+      case "messageStartInputTokensFallback": {
+        error = applyOptionalBoolean(
+          next,
+          "messageStartInputTokensFallback",
+          value,
+        )
         break
       }
       default: {

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -9,7 +9,11 @@ import type { Model } from "~/services/copilot/get-models"
 
 import { accountsManager } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import { getSmallModel, shouldCompactUseSmallModel } from "~/lib/config"
+import {
+  getSmallModel,
+  isMessageStartInputTokensFallbackEnabled,
+  shouldCompactUseSmallModel,
+} from "~/lib/config"
 import {
   computeDiff,
   extractErrorDetails,
@@ -310,14 +314,15 @@ const handleWithChatCompletions = async (params: {
 
   logger.debug("Streaming response from Copilot")
 
-  const estimatedInputTokens = await estimateInputTokens(
-    openAIPayload,
-    selectedModel,
-    logger,
-  )
+  const fallbackEnabled = isMessageStartInputTokensFallbackEnabled()
+
+  const estimatedInputTokens =
+    fallbackEnabled ?
+      await estimateInputTokens(openAIPayload, selectedModel, logger)
+    : undefined
 
   const historicalUsage =
-    instr.promptCacheKey && instr.safetyIdentifier ?
+    fallbackEnabled && instr.promptCacheKey && instr.safetyIdentifier ?
       instr.store.getLastCompletedUsageBySession({
         promptCacheKey: instr.promptCacheKey,
         safetyIdentifier: instr.safetyIdentifier,
@@ -383,14 +388,15 @@ const handleWithResponsesApi = async (params: {
   if (responsesPayload.stream && isAsyncIterable(response)) {
     logger.debug("Streaming response from Copilot (Responses API)")
 
-    const estimatedInputTokens = await estimateInputTokens(
-      openAIPayload,
-      selectedModel,
-      logger,
-    )
+    const fallbackEnabled = isMessageStartInputTokensFallbackEnabled()
+
+    const estimatedInputTokens =
+      fallbackEnabled ?
+        await estimateInputTokens(openAIPayload, selectedModel, logger)
+      : undefined
 
     const historicalUsage =
-      instr.promptCacheKey && instr.safetyIdentifier ?
+      fallbackEnabled && instr.promptCacheKey && instr.safetyIdentifier ?
         instr.store.getLastCompletedUsageBySession({
           promptCacheKey: instr.promptCacheKey,
           safetyIdentifier: instr.safetyIdentifier,

--- a/tests/message-start-input-tokens-fallback.test.ts
+++ b/tests/message-start-input-tokens-fallback.test.ts
@@ -1,0 +1,344 @@
+import { expect, mock, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { AccountRuntime } from "~/lib/types/account"
+import type { Model } from "~/services/copilot/get-models"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+import { messageRoutes } from "~/routes/messages/route"
+
+type TestConfig = Record<string, unknown>
+
+type SseEvent = {
+  event?: string
+  data: string
+}
+
+function parseSse(body: string): Array<SseEvent> {
+  const blocks = body
+    .split("\n\n")
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0)
+
+  return blocks.map((block) => {
+    const lines = block.split("\n")
+    let event: string | undefined
+    const dataLines: Array<string> = []
+
+    for (const line of lines) {
+      if (line.startsWith("event:")) {
+        event = line.slice("event:".length).trim() || undefined
+        continue
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice("data:".length).trim())
+      }
+    }
+
+    return {
+      event,
+      data: dataLines.join("\n"),
+    }
+  })
+}
+
+async function withConfig(config: TestConfig, run: () => Promise<void>) {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+
+  try {
+    await run()
+  } finally {
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (original === null) {
+      await fs.rm(PATHS.CONFIG_PATH, { force: true })
+    } else {
+      await fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    }
+    mergeConfigWithDefaults()
+  }
+}
+
+function buildTestAccount(): AccountRuntime {
+  return {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_test",
+    copilotToken: "copilot_test",
+    vsCodeVersion: "1.0.0",
+  }
+}
+
+function buildTestModel(id: string): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {},
+      object: "capabilities",
+      supports: { streaming: true },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+
+test("message_start input_tokens is 0 when fallback disabled (chat.completions stream)", async () => {
+  await withConfig(
+    {
+      messageStartInputTokensFallback: false,
+    },
+    async () => {
+      const originalSelect =
+        accountsManager.selectAccountForRequest.bind(accountsManager)
+      const originalFinalize =
+        accountsManager.finalizeQuota.bind(accountsManager)
+
+      const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+      const originalFetch = fetchHolder.fetch
+
+      accountsManager.selectAccountForRequest = () =>
+        Promise.resolve({
+          ok: true,
+          account: buildTestAccount(),
+          selectedModel: buildTestModel("gpt-test"),
+          endpoint: "/chat/completions",
+          costUnits: 0,
+        })
+
+      accountsManager.finalizeQuota = async () => {}
+
+      const upstreamSse =
+        "data: "
+        + JSON.stringify({
+          id: "chatcmpl_test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "gpt-test",
+          choices: [
+            {
+              index: 0,
+              delta: { content: "Hello" },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        })
+        + "\n\n"
+        + "data: "
+        + JSON.stringify({
+          id: "chatcmpl_test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "gpt-test",
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: "stop",
+              logprobs: null,
+            },
+          ],
+        })
+        + "\n\n"
+        + "data: [DONE]\n\n"
+
+      const fetchMock = mock((url: string) => {
+        if (url.includes("/chat/completions")) {
+          return new Response(upstreamSse, {
+            status: 200,
+            headers: {
+              "content-type": "text/event-stream",
+            },
+          })
+        }
+
+        return new Response("not found", { status: 404 })
+      })
+
+      // @ts-expect-error - mock doesn't implement full fetch signature
+      fetchHolder.fetch = fetchMock
+
+      try {
+        const payload = {
+          model: "gpt-test",
+          stream: true,
+          max_tokens: 16,
+          messages: [{ role: "user", content: "hi" }],
+        }
+
+        const res = await messageRoutes.fetch(
+          new Request("http://local/", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+        )
+
+        expect(res.status).toBe(200)
+
+        const body = await res.text()
+        const events = parseSse(body)
+
+        const messageStart = events.find((e) => e.event === "message_start")
+        expect(messageStart).toBeTruthy()
+
+        const parsed = JSON.parse(messageStart?.data ?? "null") as {
+          type: string
+          message?: { usage?: { input_tokens?: number } }
+        }
+
+        expect(parsed.type).toBe("message_start")
+        expect(parsed.message?.usage?.input_tokens).toBe(0)
+      } finally {
+        // eslint-disable-next-line require-atomic-updates
+        accountsManager.selectAccountForRequest = originalSelect
+        // eslint-disable-next-line require-atomic-updates
+        accountsManager.finalizeQuota = originalFinalize
+        fetchHolder.fetch = originalFetch
+      }
+    },
+  )
+})
+
+test("message_start input_tokens is 0 when fallback disabled (responses stream)", async () => {
+  await withConfig(
+    {
+      messageStartInputTokensFallback: false,
+    },
+    async () => {
+      const originalSelect =
+        accountsManager.selectAccountForRequest.bind(accountsManager)
+      const originalFinalize =
+        accountsManager.finalizeQuota.bind(accountsManager)
+
+      const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+      const originalFetch = fetchHolder.fetch
+
+      accountsManager.selectAccountForRequest = () =>
+        Promise.resolve({
+          ok: true,
+          account: buildTestAccount(),
+          selectedModel: buildTestModel("gpt-test"),
+          endpoint: "/responses",
+          costUnits: 0,
+        })
+
+      accountsManager.finalizeQuota = async () => {}
+
+      const responseBase = {
+        id: "resp_test",
+        object: "response",
+        created_at: 0,
+        model: "gpt-test",
+        output: [],
+        output_text: "",
+        status: "completed",
+        error: null,
+        incomplete_details: null,
+        instructions: null,
+        metadata: null,
+        parallel_tool_calls: false,
+        temperature: null,
+        tool_choice: null,
+        tools: [],
+        top_p: null,
+      }
+
+      const upstreamSse =
+        "event: response.created\n"
+        + "data: "
+        + JSON.stringify({
+          type: "response.created",
+          sequence_number: 0,
+          response: responseBase,
+        })
+        + "\n\n"
+        + "event: response.completed\n"
+        + "data: "
+        + JSON.stringify({
+          type: "response.completed",
+          sequence_number: 1,
+          response: responseBase,
+        })
+        + "\n\n"
+
+      const fetchMock = mock((url: string) => {
+        if (url.includes("/responses")) {
+          return new Response(upstreamSse, {
+            status: 200,
+            headers: {
+              "content-type": "text/event-stream",
+            },
+          })
+        }
+
+        return new Response("not found", { status: 404 })
+      })
+
+      // @ts-expect-error - mock doesn't implement full fetch signature
+      fetchHolder.fetch = fetchMock
+
+      try {
+        const payload = {
+          model: "gpt-test",
+          stream: true,
+          max_tokens: 16,
+          messages: [{ role: "user", content: "hi" }],
+        }
+
+        const res = await messageRoutes.fetch(
+          new Request("http://local/", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+        )
+
+        expect(res.status).toBe(200)
+
+        const body = await res.text()
+        const events = parseSse(body)
+
+        const messageStart = events.find((e) => e.event === "message_start")
+        expect(messageStart).toBeTruthy()
+
+        const parsed = JSON.parse(messageStart?.data ?? "null") as {
+          type: string
+          message?: { usage?: { input_tokens?: number } }
+        }
+
+        expect(parsed.type).toBe("message_start")
+        expect(parsed.message?.usage?.input_tokens).toBe(0)
+      } finally {
+        // eslint-disable-next-line require-atomic-updates
+        accountsManager.selectAccountForRequest = originalSelect
+        // eslint-disable-next-line require-atomic-updates
+        accountsManager.finalizeQuota = originalFinalize
+        fetchHolder.fetch = originalFetch
+      }
+    },
+  )
+})


### PR DESCRIPTION
## Summary
- Add `messageStartInputTokensFallback` config flag (default: true) to control whether `message_start` input token estimation/historical usage fallback runs.
- When disabled, `message_start` reports `input_tokens: 0`.
- Admin config patch endpoint now supports the flag; added regression tests for both chat.completions and responses streaming.

## Test plan
- [ ] bun test tests/message-start-input-tokens-fallback.test.ts
- [ ] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增可配置的“Estimate input tokens at stream start”开关（默认关闭），可在管理面板“高级设置”中切换并持久化。
  * 管理面板中将负载均衡选项并入高级设置，相关独立设置项已移除。

* **行为变更**
  * 后端在流处理中会根据该开关决定是否对起始消息进行输入令牌估算与历史使用统计。

* **测试**
  * 新增集成测试，验证流中起始消息的输入令牌行为在不同开关状态下的表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->