### PR TITLE
chore(git): ignore .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 /.serena
 .DS_Store
 /.claude
+/.worktrees/


### PR DESCRIPTION
## Summary
- Add `/.worktrees/` to `.gitignore` so local git worktrees don't show up in `git status`.

## Test plan
- [ ] N/A (ignore rule only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂务**
  * 更新 Git 配置以优化版本控制管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->