### PR TITLE
feat(admin-ui): add i18n (en-US/zh-CN)

### DIFF
--- a/admin-ui/bun.lock
+++ b/admin-ui/bun.lock
@@ -14,11 +14,13 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "i18next": "^25.8.3",
         "lucide-react": "^0.562.0",
         "motion": "^12.24.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^16.5.4",
         "react-router-dom": "^7.11.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
@@ -75,6 +77,8 @@
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
@@ -478,6 +482,10 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
+    "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
+
+    "i18next": ["i18next@25.8.3", "", { "dependencies": { "@babel/runtime": "^7.28.4" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-IC/pp2vkczdu1sBheq1eC92bLavN6fM5jH61c7Xa23PGio5ePEd+EP+re1IkO7KEM9eyeJHUxvIRxsaYTlsSyQ=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -588,6 +596,8 @@
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
+    "react-i18next": ["react-i18next@16.5.4", "", { "dependencies": { "@babel/runtime": "^7.28.4", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 25.6.2", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -652,7 +662,11 @@
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "vite": ["vite@7.3.0", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg=="],
+
+    "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -20,11 +20,13 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "i18next": "^25.8.3",
     "lucide-react": "^0.562.0",
     "motion": "^12.24.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-i18next": "^16.5.4",
     "react-router-dom": "^7.11.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"

--- a/admin-ui/src/components/app-shell.tsx
+++ b/admin-ui/src/components/app-shell.tsx
@@ -11,11 +11,11 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet"
-import { cn } from "@/lib/utils"
-import { TokenDialog } from "@/components/token-dialog"
+import { LocaleToggle } from "@/components/locale-toggle"
 import { MotionToggle } from "@/components/motion-toggle"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { LocaleToggle } from "@/components/locale-toggle"
+import { TokenDialog } from "@/components/token-dialog"
+import { cn } from "@/lib/utils"
 
 function NavItem({
   to,

--- a/admin-ui/src/components/app-shell.tsx
+++ b/admin-ui/src/components/app-shell.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet } from "react-router-dom"
 import { MenuIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { AnimatedGradientText } from "@/components/ui/animated-gradient-text"
 import { Button } from "@/components/ui/button"
@@ -14,6 +15,7 @@ import { cn } from "@/lib/utils"
 import { TokenDialog } from "@/components/token-dialog"
 import { MotionToggle } from "@/components/motion-toggle"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { LocaleToggle } from "@/components/locale-toggle"
 
 function NavItem({
   to,
@@ -38,22 +40,26 @@ function NavItem({
 }
 
 const NAV_ITEMS = [
-  { to: "/accounts", label: "Accounts" },
-  { to: "/requests", label: "Requests" },
-  { to: "/settings", label: "Settings" },
+  { to: "/accounts", labelKey: "nav.accounts" },
+  { to: "/requests", labelKey: "nav.requests" },
+  { to: "/settings", labelKey: "nav.settings" },
 ] as const
 
 function NavList(): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <>
       {NAV_ITEMS.map((item) => (
-        <NavItem key={item.to} to={item.to} label={item.label} />
+        <NavItem key={item.to} to={item.to} label={t(item.labelKey)} />
       ))}
     </>
   )
 }
 
 export function AppShell(): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <div className="min-h-svh bg-background text-foreground">
       <header className="bg-background/70 sticky top-0 z-50 border-b backdrop-blur">
@@ -61,7 +67,7 @@ export function AppShell(): React.JSX.Element {
           <div className="md:hidden">
             <Sheet>
               <SheetTrigger asChild>
-                <Button variant="outline" size="icon" aria-label="Open navigation">
+                <Button variant="outline" size="icon" aria-label={t("nav.openNavigation")}>
                   <MenuIcon className="size-4" />
                 </Button>
               </SheetTrigger>
@@ -69,7 +75,7 @@ export function AppShell(): React.JSX.Element {
                 <SheetHeader>
                   <SheetTitle>
                     <AnimatedGradientText className="text-base font-semibold">
-                      Copilot API Admin
+                      {t("app.title")}
                     </AnimatedGradientText>
                   </SheetTitle>
                 </SheetHeader>
@@ -82,7 +88,7 @@ export function AppShell(): React.JSX.Element {
 
           <div className="min-w-0">
             <AnimatedGradientText className="text-base font-semibold">
-              Copilot API Admin
+              {t("app.title")}
             </AnimatedGradientText>
           </div>
 
@@ -91,6 +97,7 @@ export function AppShell(): React.JSX.Element {
           </nav>
 
           <div className="ml-auto flex items-center gap-2">
+            <LocaleToggle />
             <MotionToggle />
             <ThemeToggle />
             <TokenDialog />

--- a/admin-ui/src/components/json/json-viewer.tsx
+++ b/admin-ui/src/components/json/json-viewer.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+import type { TFunction } from "i18next"
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
 import { fmtLocalDateTime } from "@/lib/format"
@@ -110,12 +112,14 @@ function NodeRow({
   valuePreview,
   expanded,
   toggle,
+  t,
 }: {
   depth: number
   name?: React.ReactNode
   valuePreview: React.ReactNode
   expanded: boolean
   toggle?: () => void
+  t: TFunction
 }): React.JSX.Element {
   return (
     <div
@@ -127,7 +131,7 @@ function NodeRow({
           type="button"
           onClick={toggle}
           className="text-muted-foreground hover:text-foreground mt-0.5"
-          aria-label={expanded ? "Collapse" : "Expand"}
+          aria-label={expanded ? t("jsonViewer.collapse") : t("jsonViewer.expand")}
         >
           {expanded ? (
             <ChevronDownIcon className="size-4" />
@@ -145,7 +149,7 @@ function NodeRow({
           <span className="text-muted-foreground">:</span>
         </>
       ) : (
-        <span className="text-muted-foreground">(root)</span>
+        <span className="text-muted-foreground">{t("jsonViewer.root")}</span>
       )}
 
       <span className="min-w-0 break-words">{valuePreview}</span>
@@ -163,6 +167,7 @@ function JsonNode({
   expandedPaths,
   collapsedPaths,
   onToggle,
+  t,
 }: {
   value: unknown
   name?: string
@@ -173,6 +178,7 @@ function JsonNode({
   expandedPaths: Set<string>
   collapsedPaths: Set<string>
   onToggle: (path: string, nextExpanded: boolean) => void
+  t: TFunction
 }): React.JSX.Element {
   const isObj = isRecord(value)
   const isArr = Array.isArray(value)
@@ -194,12 +200,15 @@ function JsonNode({
         name={name ? highlight(name, search) : undefined}
         valuePreview={formatPrimitive(value, search, name)}
         expanded={false}
+        t={t}
       />
     )
   }
 
   const count = isArr ? value.length : Object.keys(value).length
-  const label = isArr ? `Array(${count})` : `Object(${count})`
+  const label = isArr
+    ? t("jsonViewer.arrayLabel", { count })
+    : t("jsonViewer.objectLabel", { count })
 
   return (
     <div className="space-y-1">
@@ -209,6 +218,7 @@ function JsonNode({
         valuePreview={<span className="text-muted-foreground">{label}</span>}
         expanded={expanded}
         toggle={() => onToggle(path, !expanded)}
+        t={t}
       />
 
       {expanded ? (
@@ -228,6 +238,7 @@ function JsonNode({
                     expandedPaths={expandedPaths}
                     collapsedPaths={collapsedPaths}
                     onToggle={onToggle}
+                    t={t}
                   />
                 ))
             : Object.entries(value)
@@ -244,6 +255,7 @@ function JsonNode({
                     expandedPaths={expandedPaths}
                     collapsedPaths={collapsedPaths}
                     onToggle={onToggle}
+                    t={t}
                   />
                 ))}
 
@@ -252,10 +264,11 @@ function JsonNode({
               depth={depth + 1}
               valuePreview={
                 <span className="text-muted-foreground">
-                  … {count - MAX_ITEMS_PER_NODE} more
+                  {t("jsonViewer.more", { count: count - MAX_ITEMS_PER_NODE })}
                 </span>
               }
               expanded={false}
+              t={t}
             />
           ) : null}
         </div>
@@ -273,6 +286,7 @@ export function JsonViewer({
   const [baseExpandDepth, setBaseExpandDepth] = React.useState(defaultExpandedDepth)
   const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(() => new Set())
   const [collapsedPaths, setCollapsedPaths] = React.useState<Set<string>>(() => new Set())
+  const { t } = useTranslation()
 
   function toggle(path: string, nextExpanded: boolean): void {
     if (nextExpanded) {
@@ -317,17 +331,17 @@ export function JsonViewer({
     <div className={cn("space-y-3", className)}>
       <div className="flex flex-wrap items-center gap-2">
         <Button type="button" variant="outline" size="sm" onClick={expandAll}>
-          Expand all
+          {t("jsonViewer.expandAll")}
         </Button>
         <Button type="button" variant="outline" size="sm" onClick={collapseAll}>
-          Collapse all
+          {t("jsonViewer.collapseAll")}
         </Button>
         <span className="text-muted-foreground ml-auto text-xs">
           {baseExpandDepth === 0
-            ? "collapsed"
+            ? t("jsonViewer.statusCollapsed")
             : baseExpandDepth >= 99
-              ? "expanded"
-              : `depth<${baseExpandDepth}`}
+              ? t("jsonViewer.statusExpanded")
+              : t("jsonViewer.statusDepth", { depth: baseExpandDepth })}
         </span>
       </div>
 
@@ -341,6 +355,7 @@ export function JsonViewer({
           expandedPaths={expandedPaths}
           collapsedPaths={collapsedPaths}
           onToggle={toggle}
+          t={t}
         />
       </div>
     </div>

--- a/admin-ui/src/components/json/json-viewer.tsx
+++ b/admin-ui/src/components/json/json-viewer.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+
 import type { TFunction } from "i18next"
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { fmtLocalDateTime } from "@/lib/format"
@@ -327,6 +328,12 @@ export function JsonViewer({
     setCollapsedPaths(new Set())
   }
 
+  function getStatusText(): string {
+    if (baseExpandDepth === 0) return t("jsonViewer.statusCollapsed")
+    if (baseExpandDepth >= 99) return t("jsonViewer.statusExpanded")
+    return t("jsonViewer.statusDepth", { depth: baseExpandDepth })
+  }
+
   return (
     <div className={cn("space-y-3", className)}>
       <div className="flex flex-wrap items-center gap-2">
@@ -337,11 +344,7 @@ export function JsonViewer({
           {t("jsonViewer.collapseAll")}
         </Button>
         <span className="text-muted-foreground ml-auto text-xs">
-          {baseExpandDepth === 0
-            ? t("jsonViewer.statusCollapsed")
-            : baseExpandDepth >= 99
-              ? t("jsonViewer.statusExpanded")
-              : t("jsonViewer.statusDepth", { depth: baseExpandDepth })}
+          {getStatusText()}
         </span>
       </div>
 

--- a/admin-ui/src/components/locale-toggle.tsx
+++ b/admin-ui/src/components/locale-toggle.tsx
@@ -1,0 +1,30 @@
+import { GlobeIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { normalizeLocale } from "@/lib/i18n"
+import { useLocalePreference } from "@/lib/locale-preference"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+export function LocaleToggle(): React.JSX.Element {
+  const { t } = useTranslation()
+  const { locale, setLocale } = useLocalePreference()
+
+  return (
+    <Select value={locale} onValueChange={(value) => setLocale(normalizeLocale(value))}>
+      <SelectTrigger size="sm" className="w-[8.5rem]" aria-label={t("app.language")}>
+        <GlobeIcon className="size-4" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectItem value="en-US">{t("locale.enUS")}</SelectItem>
+        <SelectItem value="zh-CN">{t("locale.zhCN")}</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}

--- a/admin-ui/src/components/motion-toggle.tsx
+++ b/admin-ui/src/components/motion-toggle.tsx
@@ -1,4 +1,5 @@
 import { BanIcon, SparklesIcon, WavesIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import {
   type MotionPreference,
@@ -19,6 +20,7 @@ function MotionIcon({ value }: { value: MotionPreference }): React.JSX.Element {
 }
 
 export function MotionToggle(): React.JSX.Element {
+  const { t } = useTranslation()
   const { preference, reducedMotion, setPreference } = useMotionPreference()
   const value: MotionPreference = reducedMotion ? "off" : preference
 
@@ -31,16 +33,16 @@ export function MotionToggle(): React.JSX.Element {
       <SelectTrigger
         size="sm"
         className="w-[8.5rem]"
-        aria-label="Motion"
-        title={reducedMotion ? "Reduced motion is enabled in system settings" : undefined}
+        aria-label={t("motion.label")}
+        title={reducedMotion ? t("motion.reducedMotionEnabled") : undefined}
       >
         <MotionIcon value={value} />
         <SelectValue />
       </SelectTrigger>
       <SelectContent align="end">
-        <SelectItem value="magic">Magic</SelectItem>
-        <SelectItem value="subtle">Subtle</SelectItem>
-        <SelectItem value="off">Off</SelectItem>
+        <SelectItem value="magic">{t("motion.magic")}</SelectItem>
+        <SelectItem value="subtle">{t("motion.subtle")}</SelectItem>
+        <SelectItem value="off">{t("motion.off")}</SelectItem>
       </SelectContent>
     </Select>
   )

--- a/admin-ui/src/components/settings/floating-save-button.tsx
+++ b/admin-ui/src/components/settings/floating-save-button.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next"
+
 import { RainbowButton } from "@/components/ui/rainbow-button"
 import { cn } from "@/lib/utils"
 
@@ -18,6 +20,8 @@ export function FloatingSaveButton({
   onSave,
   className,
 }: FloatingSaveButtonProps) {
+  const { t } = useTranslation()
+
   return (
     <div
       className={cn(
@@ -33,7 +37,7 @@ export function FloatingSaveButton({
         disabled={!canSave}
         className="shadow-2xl"
       >
-        {saving ? "Saving..." : "Save Changes"}
+        {saving ? t("settingsPage.saveButton.saving") : t("settingsPage.saveButton.saveChanges")}
       </RainbowButton>
     </div>
   )

--- a/admin-ui/src/components/settings/floating-save-button.tsx
+++ b/admin-ui/src/components/settings/floating-save-button.tsx
@@ -37,7 +37,9 @@ export function FloatingSaveButton({
         disabled={!canSave}
         className="shadow-2xl"
       >
-        {saving ? t("settingsPage.saveButton.saving") : t("settingsPage.saveButton.saveChanges")}
+        {saving
+          ? t("settingsPage.saveButton.saving")
+          : t("settingsPage.saveButton.saveChanges")}
       </RainbowButton>
     </div>
   )

--- a/admin-ui/src/components/settings/settings-navigation.tsx
+++ b/admin-ui/src/components/settings/settings-navigation.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next"
+
 import type { SettingsSection } from "@/hooks/use-active-section"
 import { AnimatedGradientText } from "@/components/ui/animated-gradient-text"
 import { cn } from "@/lib/utils"
@@ -19,16 +21,18 @@ export function SettingsNavigation({
   onSectionClick,
   className,
 }: SettingsNavigationProps) {
+  const { t } = useTranslation()
+
   return (
     <nav
       className={cn(
         "sticky top-6 space-y-1 rounded-lg border bg-card p-2",
         className
       )}
-      aria-label="Settings sections"
+      aria-label={t("settingsPage.navigation.ariaLabel")}
     >
       <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-        Settings
+        {t("nav.settings")}
       </div>
       {sections.map((section) => {
         const isActive = activeSection === section.id

--- a/admin-ui/src/components/settings/settings-navigation.tsx
+++ b/admin-ui/src/components/settings/settings-navigation.tsx
@@ -20,14 +20,14 @@ export function SettingsNavigation({
   activeSection,
   onSectionClick,
   className,
-}: SettingsNavigationProps) {
+}: SettingsNavigationProps): React.JSX.Element {
   const { t } = useTranslation()
 
   return (
     <nav
       className={cn(
         "sticky top-6 space-y-1 rounded-lg border bg-card p-2",
-        className
+        className,
       )}
       aria-label={t("settingsPage.navigation.ariaLabel")}
     >
@@ -45,7 +45,7 @@ export function SettingsNavigation({
               "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
               "hover:bg-accent hover:text-accent-foreground",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              isActive && "bg-accent/50"
+              isActive && "bg-accent/50",
             )}
             aria-current={isActive ? "page" : undefined}
             aria-controls={section.id}

--- a/admin-ui/src/components/theme-toggle.tsx
+++ b/admin-ui/src/components/theme-toggle.tsx
@@ -22,7 +22,11 @@ export function ThemeToggle(): React.JSX.Element {
 
   return (
     <Select value={theme ?? "system"} onValueChange={setTheme}>
-      <SelectTrigger size="sm" className="w-[8.5rem]" aria-label={t("theme.label")}>
+      <SelectTrigger
+        size="sm"
+        className="w-[8.5rem]"
+        aria-label={t("theme.label")}
+      >
         <ThemeIcon theme={theme} />
         <SelectValue />
       </SelectTrigger>

--- a/admin-ui/src/components/theme-toggle.tsx
+++ b/admin-ui/src/components/theme-toggle.tsx
@@ -1,5 +1,6 @@
 import { LaptopIcon, MoonIcon, SunIcon } from "lucide-react"
 import { useTheme } from "next-themes"
+import { useTranslation } from "react-i18next"
 
 import {
   Select,
@@ -16,18 +17,19 @@ function ThemeIcon({ theme }: { theme: string | undefined }): React.JSX.Element 
 }
 
 export function ThemeToggle(): React.JSX.Element {
+  const { t } = useTranslation()
   const { theme, setTheme } = useTheme()
 
   return (
     <Select value={theme ?? "system"} onValueChange={setTheme}>
-      <SelectTrigger size="sm" className="w-[8.5rem]" aria-label="Theme">
+      <SelectTrigger size="sm" className="w-[8.5rem]" aria-label={t("theme.label")}>
         <ThemeIcon theme={theme} />
         <SelectValue />
       </SelectTrigger>
       <SelectContent align="end">
-        <SelectItem value="system">System</SelectItem>
-        <SelectItem value="light">Light</SelectItem>
-        <SelectItem value="dark">Dark</SelectItem>
+        <SelectItem value="system">{t("theme.system")}</SelectItem>
+        <SelectItem value="light">{t("theme.light")}</SelectItem>
+        <SelectItem value="dark">{t("theme.dark")}</SelectItem>
       </SelectContent>
     </Select>
   )

--- a/admin-ui/src/components/token-dialog.tsx
+++ b/admin-ui/src/components/token-dialog.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { KeyRoundIcon } from "lucide-react"
 import { toast } from "sonner"
+import { Trans, useTranslation } from "react-i18next"
 
 import { getAdminMeta, type AdminMeta, AdminApiError } from "@/lib/admin-api"
 import { useAdminToken } from "@/lib/admin-token"
@@ -20,15 +21,14 @@ import { Label } from "@/components/ui/label"
 import { RainbowButton } from "@/components/ui/rainbow-button"
 
 export function TokenDialog(): React.JSX.Element {
+  const { t } = useTranslation()
   const { token, setToken, clearToken } = useAdminToken()
   const [open, setOpen] = useState(false)
   const [draft, setDraft] = useState(token)
   const [testing, setTesting] = useState(false)
   const [meta, setMeta] = useState<AdminMeta | null>(null)
 
-  const tokenStatus = useMemo(() => {
-    return token ? "set" : "unset"
-  }, [token])
+  const tokenStatus = token ? t("common.set") : t("common.unset")
 
   useEffect(() => {
     if (open) setDraft(token)
@@ -40,10 +40,10 @@ export function TokenDialog(): React.JSX.Element {
     try {
       const m = await getAdminMeta()
       setMeta(m)
-      toast.success("Admin API access OK")
+      toast.success(t("tokenDialog.toast.adminApiOk"))
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
-      toast.error("Admin API access failed", { description: msg })
+      toast.error(t("tokenDialog.toast.adminApiFailed"), { description: msg })
     } finally {
       setTesting(false)
     }
@@ -51,13 +51,17 @@ export function TokenDialog(): React.JSX.Element {
 
   function save(): void {
     setToken(draft)
-    toast.success(draft.trim() ? "Token saved for this session" : "Token cleared")
+    toast.success(
+      draft.trim()
+        ? t("tokenDialog.toast.tokenSavedForSession")
+        : t("tokenDialog.toast.tokenCleared")
+    )
   }
 
   function clear(): void {
     clearToken()
     setDraft("")
-    toast.success("Token cleared")
+    toast.success(t("tokenDialog.toast.tokenCleared"))
   }
 
   return (
@@ -65,7 +69,7 @@ export function TokenDialog(): React.JSX.Element {
       <DialogTrigger asChild>
         <Button variant="outline" className="gap-2">
           <KeyRoundIcon className="size-4" />
-          Token
+          {t("tokenDialog.trigger")}
           <Badge
             variant={token ? "secondary" : "outline"}
             className="ml-1 hidden sm:inline-flex"
@@ -77,10 +81,11 @@ export function TokenDialog(): React.JSX.Element {
 
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Admin token</DialogTitle>
+          <DialogTitle>{t("tokenDialog.title")}</DialogTitle>
           <DialogDescription>
-            Used as <code>x-admin-token</code> when calling <code>/api/admin/*</code>. Stored
-            in <code>sessionStorage</code>.
+            <Trans i18nKey="tokenDialog.description">
+              Used as <code>x-admin-token</code> when calling <code>/api/admin/*</code>. Stored in <code>sessionStorage</code>.
+            </Trans>
           </DialogDescription>
         </DialogHeader>
 
@@ -89,31 +94,35 @@ export function TokenDialog(): React.JSX.Element {
           <Input
             id="admin-token"
             type="password"
-            placeholder="Enter token"
+            placeholder={t("tokenDialog.inputPlaceholder")}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             autoComplete="off"
           />
           <p className="text-muted-foreground text-xs">
-            If the server is not running on localhost, you must set <code>ADMIN_TOKEN</code>
-            on the server to enable remote access.
+            <Trans i18nKey="tokenDialog.remoteNote">
+              If the server is not running on localhost, you must set <code>ADMIN_TOKEN</code> on the server to enable remote access.
+            </Trans>
           </p>
           {meta?.dbPath && (
             <p className="text-muted-foreground text-xs">
-              Connected: DB v{meta.userVersion ?? "?"} · {meta.dbPath}
+              {t("tokenDialog.connected", {
+                version: meta.userVersion ?? "?",
+                path: meta.dbPath,
+              })}
             </p>
           )}
         </div>
 
         <DialogFooter className="gap-2 sm:gap-2">
           <Button variant="secondary" onClick={testToken} disabled={testing}>
-            {testing ? "Testing..." : "Test"}
+            {testing ? t("common.testing") : t("common.test")}
           </Button>
           <Button variant="outline" onClick={clear} disabled={!token && !draft.trim()}>
-            Clear
+            {t("common.clear")}
           </Button>
           <RainbowButton onClick={save} className="h-9 px-4">
-            Save
+            {t("common.save")}
           </RainbowButton>
         </DialogFooter>
       </DialogContent>

--- a/admin-ui/src/components/token-dialog.tsx
+++ b/admin-ui/src/components/token-dialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { KeyRoundIcon } from "lucide-react"
-import { toast } from "sonner"
 import { Trans, useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 import { getAdminMeta, type AdminMeta, AdminApiError } from "@/lib/admin-api"
 import { useAdminToken } from "@/lib/admin-token"

--- a/admin-ui/src/lib/i18n.ts
+++ b/admin-ui/src/lib/i18n.ts
@@ -14,13 +14,10 @@ export const LOCALE_STORAGE_KEY = "locale"
 export function normalizeLocale(raw: string | null | undefined): SupportedLocale {
   if (!raw) return DEFAULT_LOCALE
 
-  const lower = raw.toLowerCase().trim()
+  const normalized = raw.toLowerCase().trim().replace(/_/g, "-")
 
-  if (lower === "zh-cn" || lower === "zh_cn") return "zh-CN"
-  if (lower === "en-us" || lower === "en_us") return "en-US"
-
-  if (lower.startsWith("zh")) return "zh-CN"
-  if (lower.startsWith("en")) return "en-US"
+  if (normalized.startsWith("zh")) return "zh-CN"
+  if (normalized.startsWith("en")) return "en-US"
 
   return DEFAULT_LOCALE
 }
@@ -28,7 +25,7 @@ export function normalizeLocale(raw: string | null | undefined): SupportedLocale
 export function readLocalePreference(): SupportedLocale {
   if (typeof window === "undefined") return DEFAULT_LOCALE
   try {
-    const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY)
+    const stored = globalThis.localStorage.getItem(LOCALE_STORAGE_KEY)
     if (stored) return normalizeLocale(stored)
 
     const fromNavigator =

--- a/admin-ui/src/lib/i18n.ts
+++ b/admin-ui/src/lib/i18n.ts
@@ -1,0 +1,60 @@
+import i18n from "i18next"
+import { initReactI18next } from "react-i18next"
+
+import enUS from "@/locales/en-US.json"
+import zhCN from "@/locales/zh-CN.json"
+
+export type SupportedLocale = "en-US" | "zh-CN"
+
+export const DEFAULT_LOCALE: SupportedLocale = "en-US"
+export const SUPPORTED_LOCALES: readonly SupportedLocale[] = ["en-US", "zh-CN"] as const
+
+export const LOCALE_STORAGE_KEY = "locale"
+
+export function normalizeLocale(raw: string | null | undefined): SupportedLocale {
+  if (!raw) return DEFAULT_LOCALE
+
+  const lower = raw.toLowerCase().trim()
+
+  if (lower === "zh-cn" || lower === "zh_cn") return "zh-CN"
+  if (lower === "en-us" || lower === "en_us") return "en-US"
+
+  if (lower.startsWith("zh")) return "zh-CN"
+  if (lower.startsWith("en")) return "en-US"
+
+  return DEFAULT_LOCALE
+}
+
+export function readLocalePreference(): SupportedLocale {
+  if (typeof window === "undefined") return DEFAULT_LOCALE
+  try {
+    const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY)
+    if (stored) return normalizeLocale(stored)
+
+    const fromNavigator =
+      (Array.isArray(navigator.languages) && navigator.languages[0]) || navigator.language
+
+    return normalizeLocale(fromNavigator)
+  } catch {
+    return DEFAULT_LOCALE
+  }
+}
+
+void i18n.use(initReactI18next).init({
+  resources: {
+    "en-US": { translation: enUS },
+    "zh-CN": { translation: zhCN },
+  },
+  lng: readLocalePreference(),
+  fallbackLng: DEFAULT_LOCALE,
+  supportedLngs: [...SUPPORTED_LOCALES],
+  interpolation: {
+    escapeValue: false,
+  },
+  react: {
+    useSuspense: false,
+  },
+  initImmediate: false,
+})
+
+export { i18n }

--- a/admin-ui/src/lib/locale-preference.tsx
+++ b/admin-ui/src/lib/locale-preference.tsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+
+import { i18n, LOCALE_STORAGE_KEY, type SupportedLocale, readLocalePreference } from "@/lib/i18n"
+
+function writeLocalePreference(value: SupportedLocale): void {
+  try {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, value)
+  } catch {
+    // ignore
+  }
+}
+
+export type LocalePreferenceContextValue = {
+  locale: SupportedLocale
+  setLocale: (value: SupportedLocale) => void
+}
+
+const LocalePreferenceContext = createContext<LocalePreferenceContextValue | null>(null)
+
+export function LocalePreferenceProvider({
+  children,
+}: {
+  children: React.ReactNode
+}): React.JSX.Element {
+  const [locale, setLocaleState] = useState<SupportedLocale>(() => readLocalePreference())
+
+  const setLocale = useCallback((value: SupportedLocale) => {
+    setLocaleState(value)
+  }, [])
+
+  useEffect(() => {
+    writeLocalePreference(locale)
+  }, [locale])
+
+  useEffect(() => {
+    document.documentElement.lang = locale
+    void i18n.changeLanguage(locale)
+  }, [locale])
+
+  const value = useMemo<LocalePreferenceContextValue>(() => {
+    return { locale, setLocale }
+  }, [locale, setLocale])
+
+  return <LocalePreferenceContext.Provider value={value}>{children}</LocalePreferenceContext.Provider>
+}
+
+export function useLocalePreference(): LocalePreferenceContextValue {
+  const ctx = useContext(LocalePreferenceContext)
+  if (!ctx) {
+    throw new Error("useLocalePreference must be used within LocalePreferenceProvider")
+  }
+  return ctx
+}

--- a/admin-ui/src/lib/locale-preference.tsx
+++ b/admin-ui/src/lib/locale-preference.tsx
@@ -4,7 +4,7 @@ import { i18n, LOCALE_STORAGE_KEY, type SupportedLocale, readLocalePreference } 
 
 function writeLocalePreference(value: SupportedLocale): void {
   try {
-    window.localStorage.setItem(LOCALE_STORAGE_KEY, value)
+    globalThis.localStorage.setItem(LOCALE_STORAGE_KEY, value)
   } catch {
     // ignore
   }

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -1,0 +1,308 @@
+{
+  "app": {
+    "title": "Copilot API Admin",
+    "language": "Language"
+  },
+  "locale": {
+    "enUS": "English",
+    "zhCN": "简体中文"
+  },
+  "nav": {
+    "accounts": "Accounts",
+    "requests": "Requests",
+    "settings": "Settings",
+    "openNavigation": "Open navigation"
+  },
+  "theme": {
+    "label": "Theme",
+    "system": "System",
+    "light": "Light",
+    "dark": "Dark"
+  },
+  "motion": {
+    "label": "Motion",
+    "magic": "Magic",
+    "subtle": "Subtle",
+    "off": "Off",
+    "reducedMotionEnabled": "Reduced motion is enabled in system settings"
+  },
+  "common": {
+    "set": "set",
+    "unset": "unset",
+    "test": "Test",
+    "testing": "Testing...",
+    "clear": "Clear",
+    "save": "Save",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing...",
+    "retry": "Retry",
+    "errors": "Errors",
+    "tokens": "Tokens",
+    "failed": "Failed",
+    "errorRate": "Error rate",
+    "tokensPerRequest": "Tokens / req",
+    "avgDurationMs": "Avg duration (ms)",
+    "lastRequest": "Last req",
+    "account": "Account",
+    "status": "Status",
+    "avgMs": "Avg ms",
+    "clearFilter": "Clear filter",
+    "statusFailed": "failed",
+    "statusOk": "ok",
+    "used": "Used",
+    "remaining": "Remaining",
+    "unlimited": "unlimited",
+    "apply": "Apply",
+    "any": "(any)",
+    "yes": "yes",
+    "no": "no",
+    "from": "From",
+    "to": "To",
+    "time": "Time",
+    "path": "Path",
+    "endpoint": "Endpoint",
+    "model": "Model",
+    "cost": "Cost",
+    "quota": "Quota",
+    "durationAbbrev": "Dur",
+    "loading": "Loading...",
+    "loadMore": "Load more",
+    "noMore": "No more",
+    "clearFilters": "Clear filters",
+    "back": "Back",
+    "download": "Download",
+    "copyJson": "Copy JSON"
+  },
+  "tokenDialog": {
+    "trigger": "Token",
+    "title": "Admin token",
+    "description": "Used as <1>x-admin-token</1> when calling <3>/api/admin/*</3>. Stored in <5>sessionStorage</5>.",
+    "inputPlaceholder": "Enter token",
+    "remoteNote": "If the server is not running on localhost, you must set <1>ADMIN_TOKEN</1> on the server to enable remote access.",
+    "connected": "Connected: DB v{{version}} · {{path}}",
+    "toast": {
+      "adminApiOk": "Admin API access OK",
+      "adminApiFailed": "Admin API access failed",
+      "tokenSavedForSession": "Token saved for this session",
+      "tokenCleared": "Token cleared"
+    }
+  },
+  "accountsPage": {
+    "loadFailedTitle": "Failed to load accounts",
+    "statsWindowLabel": "Stats window",
+    "window": {
+      "last24h": "Last 24h",
+      "last7d": "Last 7d"
+    },
+    "dbInfo": "DB v{{version}} · {{path}}",
+    "tableDescription": "Click an account to filter requests.",
+    "filterAccountPlaceholder": "Filter account",
+    "premiumReq": "Premium req",
+    "empty": {
+      "noAccountsTitle": "No accounts",
+      "noMatchesTitle": "No matches",
+      "noAccountsDescription": "No accounts found.",
+      "noMatchesDescription": "No accounts match the current filter."
+    },
+    "premiumQuotaUsedAria": "Premium interactions quota used"
+  },
+  "requestsPage": {
+    "loadFailedTitle": "Failed to load requests",
+    "description": "Filter and inspect recent requests.",
+    "tabs": {
+      "quick": "Quick",
+      "advanced": "Advanced"
+    },
+    "filters": {
+      "timeRange": "Time range",
+      "hasError": "Has error",
+      "upstreamModel": "Upstream model",
+      "clientModel": "Client model"
+    },
+    "timeRange": {
+      "last15m": "Last 15m",
+      "last1h": "Last 1h",
+      "last6h": "Last 6h",
+      "last24h": "Last 24h",
+      "last7d": "Last 7d",
+      "custom": "Custom..."
+    },
+    "validation": {
+      "title": "Invalid time range",
+      "fromMsMustBeNumber": "from_ms must be a number (milliseconds)",
+      "toMsMustBeNumber": "to_ms must be a number (milliseconds)",
+      "fromMsMustBeLteToMs": "from_ms must be <= to_ms"
+    },
+    "empty": {
+      "noRequestsTitle": "No requests",
+      "noResultsForFilters": "No results for the current filters.",
+      "noRequestsFound": "No requests found."
+    }
+  },
+  "requestDetailPage": {
+    "loadFailedTitle": "Failed to load request",
+    "title": "Request",
+    "notFoundTitle": "Request not found",
+    "notFoundDescription": "Request not found.",
+    "summaryTitle": "Summary",
+    "rawTitle": "Raw",
+    "rawDescription": "Full record as JSON.",
+    "searchPlaceholder": "Search key/value",
+    "toast": {
+      "copiedJson": "Copied JSON",
+      "copyFailed": "Copy failed",
+      "downloadedJson": "Downloaded JSON",
+      "downloadFailed": "Download failed"
+    },
+    "fields": {
+      "time": "time",
+      "path": "path",
+      "endpoint": "endpoint",
+      "account": "account",
+      "userId": "user_id",
+      "safetyIdentifier": "safety_identifier",
+      "promptCacheKey": "prompt_cache_key",
+      "initiator": "initiator",
+      "upstreamRequestId": "upstream_request_id",
+      "model": "model",
+      "client": "client",
+      "tokens": "tokens",
+      "quota": "quota"
+    },
+    "badges": {
+      "durMs": "dur_ms",
+      "ttfbMs": "ttfb_ms"
+    },
+    "tokens": {
+      "in": "in",
+      "out": "out",
+      "total": "total",
+      "cached": "cached"
+    },
+    "quota": {
+      "before": "before",
+      "after": "after",
+      "diff": "diff"
+    }
+  },
+  "jsonViewer": {
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "root": "(root)",
+    "more": "… {{count}} more",
+    "arrayLabel": "Array({{count}})",
+    "objectLabel": "Object({{count}})",
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all",
+    "statusCollapsed": "collapsed",
+    "statusExpanded": "expanded",
+    "statusDepth": "depth<{{depth}}"
+  },
+  "settingsPage": {
+    "subtitle": "Manage server configuration and feature flags.",
+    "configPath": "Config path: {{path}}",
+    "note": "Changes take effect after saving.",
+    "errorTitle": "Failed to load settings",
+    "envOverrideNote": "Overridden by env {{env}}.",
+    "sections": {
+      "general": "General",
+      "loadBalancing": "Load balancing",
+      "reasoning": "Reasoning",
+      "aliases": "Aliases",
+      "prompts": "Prompts",
+      "advanced": "Advanced"
+    },
+    "navigation": {
+      "ariaLabel": "Settings sections"
+    },
+    "saveButton": {
+      "saving": "Saving...",
+      "saveChanges": "Save changes"
+    },
+    "toast": {
+      "loadModelsFailed": "Failed to load models",
+      "loadConfigFailed": "Failed to load config",
+      "configSaved": "Config saved",
+      "saveConfigFailed": "Failed to save config"
+    },
+    "common": {
+      "defaultOption": "(default)",
+      "customModel": "Custom: {{value}}",
+      "remove": "Remove",
+      "allow": "allow",
+      "block": "block",
+      "jsonMode": "JSON mode",
+      "invalidJsonTitle": "Invalid JSON",
+      "selectModelPlaceholder": "Select model",
+      "noModelsAvailable": "No models available"
+    },
+    "general": {
+      "title": "General",
+      "description": "Basic configuration.",
+      "smallModel": "Small model",
+      "smallModelManual": "Small model (manual)",
+      "smallModelPlaceholder": "Select small model",
+      "smallModelInputPlaceholder": "gpt-5-mini",
+      "smallModelHint": "Controls which model receives lightweight/free requests when routing.",
+      "apiKeyLabel": "API key",
+      "apiKeyPlaceholder": "sk-...",
+      "leaveEmptyHint": "Leave empty to clear config value."
+    },
+    "loadBalancing": {
+      "title": "Load balancing",
+      "description": "Toggle free account load balancing.",
+      "freeModelLabel": "Free model load balancing",
+      "freeModelHint": "When enabled, distributes free traffic across available accounts."
+    },
+    "reasoning": {
+      "title": "Reasoning efforts",
+      "description": "Override model reasoning effort levels.",
+      "hint": "Define per-model reasoning effort (optional).",
+      "jsonPlaceholder": "{ \"gpt-5-mini\": \"low\" }",
+      "emptyState": "No reasoning overrides. Add a model below.",
+      "itemHint": "Overrides reasoning effort for this model.",
+      "addButton": "Add model override"
+    },
+    "prompts": {
+      "title": "Extra prompts",
+      "description": "Inject extra system prompts per model.",
+      "hint": "Add or edit prompt snippets injected for specific models.",
+      "jsonPlaceholder": "{ \"gpt-5-mini\": \"...\" }",
+      "emptyState": "No extra prompts configured.",
+      "promptPlaceholder": "System prompt snippet...",
+      "itemHint": "Adds prompt content before model execution.",
+      "addButton": "Add prompt"
+    },
+    "aliases": {
+      "title": "Model aliases",
+      "description": "Map friendly alias names to upstream model IDs.",
+      "defaultBehaviorHint": "Default behavior: {{behavior}} original model IDs. Each alias can override this setting.",
+      "jsonPlaceholder": "{ \"fast\": { \"target\": \"gpt-5-mini\", \"allowOriginal\": true } }",
+      "aliasPlaceholder": "Alias",
+      "selectTargetPlaceholder": "Select target model",
+      "selectOption": "(select)",
+      "originalModelPlaceholder": "Original model ID",
+      "useDefault": "Use default",
+      "allowOriginal": "Allow original model ID",
+      "blockOriginal": "Block original model ID",
+      "emptyState": "No model aliases configured.",
+      "addButton": "Add alias"
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Feature flags and experimental toggles.",
+      "allowOriginalModelNamesLabel": "Allow original model names",
+      "allowOriginalModelNamesHint": "Default behavior when aliases do not override original model IDs.",
+      "useFunctionApplyPatchLabel": "Use function apply_patch",
+      "useFunctionApplyPatchHint": "Enables function-level patches in responses routing.",
+      "forceAgentLabel": "Force agent header",
+      "forceAgentHint": "Forces agent routing logic even when clients omit hints.",
+      "compactUseSmallModelLabel": "Compact uses small model",
+      "compactUseSmallModelHint": "When enabled, compact requests use the configured smallModel; otherwise they use the requested model."
+    }
+  },
+  "notFound": {
+    "title": "Not found",
+    "description": "The page you are looking for does not exist."
+  }
+}

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -251,8 +251,8 @@
     "loadBalancing": {
       "title": "Load balancing",
       "description": "Toggle free account load balancing.",
-      "freeModelLabel": "Free model load balancing",
-      "freeModelHint": "When enabled, distributes free traffic across available accounts."
+      "freeModelLabel": "Free model request load balancing",
+      "freeModelHint": "When enabled, downstream requests for free models are distributed across multiple upstream accounts."
     },
     "reasoning": {
       "title": "Reasoning efforts",
@@ -296,7 +296,7 @@
       "useFunctionApplyPatchLabel": "Use function apply_patch",
       "useFunctionApplyPatchHint": "Enables function-level patches in responses routing.",
       "forceAgentLabel": "Force agent header",
-      "forceAgentHint": "Forces agent routing logic even when clients omit hints.",
+      "forceAgentHint": "Affects Copilot Premium request consumption counting: when off, every agent conversation request counts as 1 (same as the VS Code extension); when on, multiple requests in the same session count only once per model.",
       "compactUseSmallModelLabel": "Compact uses small model",
       "compactUseSmallModelHint": "When enabled, compact requests use the configured smallModel; otherwise they use the requested model.",
       "messageStartInputTokensFallbackLabel": "Estimate input tokens at stream start",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -1,0 +1,308 @@
+{
+  "app": {
+    "title": "Copilot API 管理后台",
+    "language": "语言"
+  },
+  "locale": {
+    "enUS": "English",
+    "zhCN": "简体中文"
+  },
+  "nav": {
+    "accounts": "账号",
+    "requests": "请求",
+    "settings": "设置",
+    "openNavigation": "打开导航"
+  },
+  "theme": {
+    "label": "主题",
+    "system": "跟随系统",
+    "light": "浅色",
+    "dark": "深色"
+  },
+  "motion": {
+    "label": "动效",
+    "magic": "炫酷",
+    "subtle": "柔和",
+    "off": "关闭",
+    "reducedMotionEnabled": "系统设置已启用减少动态效果"
+  },
+  "common": {
+    "set": "已设置",
+    "unset": "未设置",
+    "test": "测试",
+    "testing": "测试中…",
+    "clear": "清除",
+    "save": "保存",
+    "refresh": "刷新",
+    "refreshing": "刷新中…",
+    "retry": "重试",
+    "errors": "错误",
+    "tokens": "Tokens",
+    "failed": "失败",
+    "errorRate": "错误率",
+    "tokensPerRequest": "Tokens/请求",
+    "avgDurationMs": "平均耗时（ms）",
+    "lastRequest": "最近请求",
+    "account": "账号",
+    "status": "状态",
+    "avgMs": "平均 ms",
+    "clearFilter": "清除筛选",
+    "statusFailed": "失败",
+    "statusOk": "正常",
+    "used": "已用",
+    "remaining": "剩余",
+    "unlimited": "无限",
+    "apply": "应用",
+    "any": "(任意)",
+    "yes": "是",
+    "no": "否",
+    "from": "从",
+    "to": "到",
+    "time": "时间",
+    "path": "路径",
+    "endpoint": "端点",
+    "model": "模型",
+    "cost": "成本",
+    "quota": "额度",
+    "durationAbbrev": "耗时",
+    "loading": "加载中…",
+    "loadMore": "加载更多",
+    "noMore": "没有更多",
+    "clearFilters": "清除筛选",
+    "back": "返回",
+    "download": "下载",
+    "copyJson": "复制 JSON"
+  },
+  "tokenDialog": {
+    "trigger": "Token",
+    "title": "管理 Token",
+    "description": "调用 <3>/api/admin/*</3> 时会使用 <1>x-admin-token</1> 请求头。存储在 <5>sessionStorage</5> 中。",
+    "inputPlaceholder": "输入 Token",
+    "remoteNote": "如果服务端不在 localhost 运行，你必须在服务端设置 <1>ADMIN_TOKEN</1> 才能启用远程访问。",
+    "connected": "已连接：DB v{{version}} · {{path}}",
+    "toast": {
+      "adminApiOk": "Admin API 访问正常",
+      "adminApiFailed": "Admin API 访问失败",
+      "tokenSavedForSession": "Token 已在本会话保存",
+      "tokenCleared": "Token 已清除"
+    }
+  },
+  "accountsPage": {
+    "loadFailedTitle": "加载账号失败",
+    "statsWindowLabel": "统计窗口",
+    "window": {
+      "last24h": "最近 24 小时",
+      "last7d": "最近 7 天"
+    },
+    "dbInfo": "DB v{{version}} · {{path}}",
+    "tableDescription": "点击账号可筛选请求。",
+    "filterAccountPlaceholder": "筛选账号",
+    "premiumReq": "Premium 请求",
+    "empty": {
+      "noAccountsTitle": "无账号",
+      "noMatchesTitle": "无匹配结果",
+      "noAccountsDescription": "未找到账号。",
+      "noMatchesDescription": "没有账号匹配当前筛选条件。"
+    },
+    "premiumQuotaUsedAria": "Premium 交互额度使用量"
+  },
+  "requestsPage": {
+    "loadFailedTitle": "加载请求失败",
+    "description": "筛选并查看最近的请求。",
+    "tabs": {
+      "quick": "快速",
+      "advanced": "高级"
+    },
+    "filters": {
+      "timeRange": "时间范围",
+      "hasError": "有错误",
+      "upstreamModel": "上游模型",
+      "clientModel": "客户端模型"
+    },
+    "timeRange": {
+      "last15m": "最近 15 分钟",
+      "last1h": "最近 1 小时",
+      "last6h": "最近 6 小时",
+      "last24h": "最近 24 小时",
+      "last7d": "最近 7 天",
+      "custom": "自定义…"
+    },
+    "validation": {
+      "title": "时间范围无效",
+      "fromMsMustBeNumber": "from_ms 必须是数字（毫秒）",
+      "toMsMustBeNumber": "to_ms 必须是数字（毫秒）",
+      "fromMsMustBeLteToMs": "from_ms 必须 <= to_ms"
+    },
+    "empty": {
+      "noRequestsTitle": "无请求",
+      "noResultsForFilters": "当前筛选条件下没有结果。",
+      "noRequestsFound": "未找到请求。"
+    }
+  },
+  "requestDetailPage": {
+    "loadFailedTitle": "加载请求详情失败",
+    "title": "请求",
+    "notFoundTitle": "请求不存在",
+    "notFoundDescription": "请求不存在。",
+    "summaryTitle": "摘要",
+    "rawTitle": "原始数据",
+    "rawDescription": "完整记录（JSON）。",
+    "searchPlaceholder": "搜索键/值",
+    "toast": {
+      "copiedJson": "已复制 JSON",
+      "copyFailed": "复制失败",
+      "downloadedJson": "已下载 JSON",
+      "downloadFailed": "下载失败"
+    },
+    "fields": {
+      "time": "时间",
+      "path": "路径",
+      "endpoint": "端点",
+      "account": "账号",
+      "userId": "user_id",
+      "safetyIdentifier": "safety_identifier",
+      "promptCacheKey": "prompt_cache_key",
+      "initiator": "initiator",
+      "upstreamRequestId": "upstream_request_id",
+      "model": "模型",
+      "client": "客户端",
+      "tokens": "tokens",
+      "quota": "额度"
+    },
+    "badges": {
+      "durMs": "dur_ms",
+      "ttfbMs": "ttfb_ms"
+    },
+    "tokens": {
+      "in": "输入",
+      "out": "输出",
+      "total": "总计",
+      "cached": "缓存"
+    },
+    "quota": {
+      "before": "之前",
+      "after": "之后",
+      "diff": "变化"
+    }
+  },
+  "jsonViewer": {
+    "expand": "展开",
+    "collapse": "折叠",
+    "root": "(根)",
+    "more": "… 还有 {{count}} 项",
+    "arrayLabel": "数组({{count}})",
+    "objectLabel": "对象({{count}})",
+    "expandAll": "全部展开",
+    "collapseAll": "全部折叠",
+    "statusCollapsed": "已折叠",
+    "statusExpanded": "已展开",
+    "statusDepth": "层级<{{depth}}"
+  },
+  "settingsPage": {
+    "subtitle": "管理服务端配置和功能开关。",
+    "configPath": "配置路径：{{path}}",
+    "note": "更改在保存后生效。",
+    "errorTitle": "加载设置失败",
+    "envOverrideNote": "已被环境变量 {{env}} 覆盖。",
+    "sections": {
+      "general": "通用",
+      "loadBalancing": "负载均衡",
+      "reasoning": "推理",
+      "aliases": "别名",
+      "prompts": "提示词",
+      "advanced": "高级"
+    },
+    "navigation": {
+      "ariaLabel": "设置分区"
+    },
+    "saveButton": {
+      "saving": "保存中…",
+      "saveChanges": "保存更改"
+    },
+    "toast": {
+      "loadModelsFailed": "加载模型失败",
+      "loadConfigFailed": "加载配置失败",
+      "configSaved": "配置已保存",
+      "saveConfigFailed": "保存配置失败"
+    },
+    "common": {
+      "defaultOption": "(默认)",
+      "customModel": "自定义：{{value}}",
+      "remove": "移除",
+      "allow": "允许",
+      "block": "阻止",
+      "jsonMode": "JSON 模式",
+      "invalidJsonTitle": "无效的 JSON",
+      "selectModelPlaceholder": "选择模型",
+      "noModelsAvailable": "没有可用模型"
+    },
+    "general": {
+      "title": "通用",
+      "description": "基础配置。",
+      "smallModel": "小模型",
+      "smallModelManual": "小模型（手动）",
+      "smallModelPlaceholder": "选择小模型",
+      "smallModelInputPlaceholder": "gpt-5-mini",
+      "smallModelHint": "控制路由时接收轻量/免费请求的模型。",
+      "apiKeyLabel": "API 密钥",
+      "apiKeyPlaceholder": "sk-...",
+      "leaveEmptyHint": "留空以清除配置值。"
+    },
+    "loadBalancing": {
+      "title": "负载均衡",
+      "description": "切换免费账号负载均衡。",
+      "freeModelLabel": "免费流量负载均衡",
+      "freeModelHint": "启用后，会将免费流量分配到可用账号。"
+    },
+    "reasoning": {
+      "title": "推理强度",
+      "description": "覆盖模型的推理强度等级。",
+      "hint": "定义每个模型的推理强度（可选）。",
+      "jsonPlaceholder": "{ \\\"gpt-5-mini\\\": \\\"low\\\" }",
+      "emptyState": "没有推理覆盖。请在下方添加模型。",
+      "itemHint": "覆盖该模型的推理强度。",
+      "addButton": "添加模型覆盖"
+    },
+    "prompts": {
+      "title": "额外提示词",
+      "description": "为每个模型注入额外的 system prompt。",
+      "hint": "为指定模型添加或编辑注入的 prompt 片段。",
+      "jsonPlaceholder": "{ \\\"gpt-5-mini\\\": \\\"...\\\" }",
+      "emptyState": "未配置额外提示词。",
+      "promptPlaceholder": "System prompt 片段…",
+      "itemHint": "在模型执行前追加 prompt 内容。",
+      "addButton": "添加提示词"
+    },
+    "aliases": {
+      "title": "模型别名",
+      "description": "将友好别名映射到上游模型 ID。",
+      "defaultBehaviorHint": "默认行为：{{behavior}} 原始模型 ID。每个别名可覆盖此设置。",
+      "jsonPlaceholder": "{ \\\"fast\\\": { \\\"target\\\": \\\"gpt-5-mini\\\", \\\"allowOriginal\\\": true } }",
+      "aliasPlaceholder": "别名",
+      "selectTargetPlaceholder": "选择目标模型",
+      "selectOption": "(选择)",
+      "originalModelPlaceholder": "原始模型 ID",
+      "useDefault": "使用默认值",
+      "allowOriginal": "允许原始模型 ID",
+      "blockOriginal": "阻止原始模型 ID",
+      "emptyState": "未配置模型别名。",
+      "addButton": "添加别名"
+    },
+    "advanced": {
+      "title": "高级",
+      "description": "功能开关与实验选项。",
+      "allowOriginalModelNamesLabel": "允许原始模型名",
+      "allowOriginalModelNamesHint": "当别名未覆盖时的默认行为。",
+      "useFunctionApplyPatchLabel": "启用 function apply_patch",
+      "useFunctionApplyPatchHint": "在响应路由中启用函数级补丁。",
+      "forceAgentLabel": "强制 agent 请求头",
+      "forceAgentHint": "即使客户端未提供提示，也强制启用 agent 路由逻辑。",
+      "compactUseSmallModelLabel": "compact 使用小模型",
+      "compactUseSmallModelHint": "启用后，compact 请求使用配置的小模型；否则使用请求的模型。"
+    }
+  },
+  "notFound": {
+    "title": "未找到页面",
+    "description": "你访问的页面不存在。"
+  }
+}

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -251,8 +251,8 @@
     "loadBalancing": {
       "title": "负载均衡",
       "description": "切换免费账号负载均衡。",
-      "freeModelLabel": "免费流量负载均衡",
-      "freeModelHint": "启用后，会将免费流量分配到可用账号。"
+      "freeModelLabel": "免费模型请求负载均衡",
+      "freeModelHint": "启用后，当下游请求免费模型时，请求会在多个可用上游账号之间分配。"
     },
     "reasoning": {
       "title": "推理强度",
@@ -295,8 +295,8 @@
       "allowOriginalModelNamesHint": "当别名未覆盖时的默认行为。",
       "useFunctionApplyPatchLabel": "启用 function apply_patch",
       "useFunctionApplyPatchHint": "在响应路由中启用函数级补丁。",
-      "forceAgentLabel": "强制 agent 请求头",
-      "forceAgentHint": "即使客户端未提供提示，也强制启用 agent 路由逻辑。",
+      "forceAgentLabel": "强制 Agent 请求头",
+      "forceAgentHint": "影响 Copilot高级请求消耗的计次：关闭时，每次与 Agent 的对话请求都会计 1 次（与 VS Code 插件一致）；开启时，同一会话内对同一模型的多次请求只计 1 次。",
       "compactUseSmallModelLabel": "compact 使用小模型",
       "compactUseSmallModelHint": "启用后，compact 请求使用配置的小模型；否则使用请求的模型。",
       "messageStartInputTokensFallbackLabel": "在流开始时估算输入 tokens",

--- a/admin-ui/src/main.tsx
+++ b/admin-ui/src/main.tsx
@@ -11,7 +11,10 @@ import { AdminTokenProvider } from "@/lib/admin-token"
 import { LocalePreferenceProvider } from "@/lib/locale-preference"
 import { MotionPreferenceProvider } from "@/lib/motion-preference"
 
-createRoot(document.getElementById("root")!).render(
+const rootElement = document.querySelector("#root")
+if (!rootElement) throw new Error("Root element not found")
+
+createRoot(rootElement).render(
   <StrictMode>
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <LocalePreferenceProvider>

--- a/admin-ui/src/main.tsx
+++ b/admin-ui/src/main.tsx
@@ -4,22 +4,26 @@ import { HashRouter } from "react-router-dom"
 import { ThemeProvider } from "next-themes"
 
 import "@/index.css"
+import "@/lib/i18n"
 import App from "@/App"
 import { Toaster } from "@/components/ui/sonner"
 import { AdminTokenProvider } from "@/lib/admin-token"
+import { LocalePreferenceProvider } from "@/lib/locale-preference"
 import { MotionPreferenceProvider } from "@/lib/motion-preference"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <AdminTokenProvider>
-        <MotionPreferenceProvider>
-          <HashRouter>
-            <App />
-          </HashRouter>
-          <Toaster />
-        </MotionPreferenceProvider>
-      </AdminTokenProvider>
+      <LocalePreferenceProvider>
+        <AdminTokenProvider>
+          <MotionPreferenceProvider>
+            <HashRouter>
+              <App />
+            </HashRouter>
+            <Toaster />
+          </MotionPreferenceProvider>
+        </AdminTokenProvider>
+      </LocalePreferenceProvider>
     </ThemeProvider>
   </StrictMode>
 )

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { toast } from "sonner"
-import { useTranslation } from "react-i18next"
 
 import {
   AdminApiError,

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 
 import {
   AdminApiError,
@@ -9,6 +10,7 @@ import {
   getAdminMeta,
 } from "@/lib/admin-api"
 import { fmtLocalDateTime, fmtNum } from "@/lib/format"
+import { i18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion"
 import { Badge } from "@/components/ui/badge"
@@ -129,6 +131,8 @@ function AccountsTableSkeleton({ rows }: { rows: number }): React.JSX.Element {
 }
 
 export function AccountsPage(): React.JSX.Element {
+  const { t } = useTranslation()
+
   const [windowPreset, setWindowPreset] = useState<WindowPreset>("86400000")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -158,7 +162,7 @@ export function AccountsPage(): React.JSX.Element {
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
       setError(msg)
-      toast.error("Failed to load accounts", { description: msg })
+      toast.error(i18n.t("accountsPage.loadFailedTitle"), { description: msg })
     } finally {
       setLoading(false)
     }
@@ -232,33 +236,38 @@ export function AccountsPage(): React.JSX.Element {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-sm">Stats window</span>
+          <span className="text-muted-foreground text-sm">{t("accountsPage.statsWindowLabel")}</span>
           <Select value={windowPreset} onValueChange={(v) => setWindowPreset(v as WindowPreset)}>
             <SelectTrigger size="sm" className="w-40">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="86400000">Last 24h</SelectItem>
-              <SelectItem value="604800000">Last 7d</SelectItem>
+              <SelectItem value="86400000">{t("accountsPage.window.last24h")}</SelectItem>
+              <SelectItem value="604800000">{t("accountsPage.window.last7d")}</SelectItem>
             </SelectContent>
           </Select>
         </div>
 
         <RainbowButton onClick={refresh} disabled={loading} size="sm">
-          {loading ? "Refreshing..." : "Refresh"}
+          {loading ? t("common.refreshing") : t("common.refresh")}
         </RainbowButton>
 
         <div className="text-muted-foreground ml-auto text-sm">
-          {meta?.dbPath ? `DB v${meta.userVersion ?? "?"} · ${meta.dbPath}` : null}
+          {meta?.dbPath
+            ? t("accountsPage.dbInfo", {
+                version: meta.userVersion ?? "?",
+                path: meta.dbPath,
+              })
+            : null}
         </div>
       </div>
 
       {error ? (
         <InlineAlert
           variant="error"
-          title="Failed to load accounts"
+          title={t("accountsPage.loadFailedTitle")}
           description={error}
-          actionLabel="Retry"
+          actionLabel={t("common.retry")}
           onAction={() => void refresh()}
         />
       ) : null}
@@ -266,7 +275,7 @@ export function AccountsPage(): React.JSX.Element {
       <BentoGrid className="auto-rows-min grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 2xl:grid-cols-8">
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Accounts</div>
+            <div className="text-muted-foreground text-xs">{t("nav.accounts")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.totalAccounts} />
             </div>
@@ -275,7 +284,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Failed</div>
+            <div className="text-muted-foreground text-xs">{t("common.failed")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.failedAccounts} />
             </div>
@@ -284,7 +293,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Requests</div>
+            <div className="text-muted-foreground text-xs">{t("nav.requests")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.totalRequests} />
             </div>
@@ -293,7 +302,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Errors</div>
+            <div className="text-muted-foreground text-xs">{t("common.errors")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.totalErrors} />
             </div>
@@ -302,7 +311,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Error rate</div>
+            <div className="text-muted-foreground text-xs">{t("common.errorRate")}</div>
             <div className="mt-1 flex items-baseline gap-1 text-2xl font-semibold">
               <KpiValue value={kpis.errorRatePct} decimalPlaces={1} />
               <span className="text-muted-foreground text-sm">%</span>
@@ -312,7 +321,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Tokens / req</div>
+            <div className="text-muted-foreground text-xs">{t("common.tokensPerRequest")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.tokensPerRequest} decimalPlaces={1} />
             </div>
@@ -321,7 +330,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Tokens</div>
+            <div className="text-muted-foreground text-xs">{t("common.tokens")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.totalTokens} />
             </div>
@@ -330,7 +339,7 @@ export function AccountsPage(): React.JSX.Element {
 
         <MagicCard className="rounded-xl">
           <div className="p-4">
-            <div className="text-muted-foreground text-xs">Avg duration (ms)</div>
+            <div className="text-muted-foreground text-xs">{t("common.avgDurationMs")}</div>
             <div className="mt-1 text-2xl font-semibold">
               <KpiValue value={kpis.avgDurationMs} />
             </div>
@@ -340,15 +349,13 @@ export function AccountsPage(): React.JSX.Element {
 
       <Card className="gap-4 py-4">
         <CardHeader className="px-4">
-          <CardTitle>Accounts</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Click an account to filter requests.
-          </CardDescription>
+          <CardTitle>{t("nav.accounts")}</CardTitle>
+          <CardDescription className="hidden sm:block">{t("accountsPage.tableDescription")}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3 px-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <Input
-              placeholder="Filter account"
+              placeholder={t("accountsPage.filterAccountPlaceholder")}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               className="h-8 sm:max-w-xs"
@@ -360,11 +367,11 @@ export function AccountsPage(): React.JSX.Element {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent align="end">
-                  <SelectItem value="requests">Requests</SelectItem>
-                  <SelectItem value="errors">Errors</SelectItem>
-                  <SelectItem value="tokens">Tokens</SelectItem>
-                  <SelectItem value="last_req">Last req</SelectItem>
-                  <SelectItem value="account">Account</SelectItem>
+                  <SelectItem value="requests">{t("nav.requests")}</SelectItem>
+                  <SelectItem value="errors">{t("common.errors")}</SelectItem>
+                  <SelectItem value="tokens">{t("common.tokens")}</SelectItem>
+                  <SelectItem value="last_req">{t("common.lastRequest")}</SelectItem>
+                  <SelectItem value="account">{t("common.account")}</SelectItem>
                 </SelectContent>
               </Select>
 
@@ -377,14 +384,22 @@ export function AccountsPage(): React.JSX.Element {
           <Table className="[&_th]:h-9 [&_td]:py-1.5">
             <TableHeader>
               <TableRow>
-                <TableHead>Account</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className={cn(accountsTableColVisibility[2])}>Premium req</TableHead>
-                <TableHead>Requests</TableHead>
-                <TableHead>Errors</TableHead>
-                <TableHead className={cn(accountsTableColVisibility[5])}>Tokens</TableHead>
-                <TableHead className={cn(accountsTableColVisibility[6])}>Avg ms</TableHead>
-                <TableHead className={cn(accountsTableColVisibility[7])}>Last req</TableHead>
+                <TableHead>{t("common.account")}</TableHead>
+                <TableHead>{t("common.status")}</TableHead>
+                <TableHead className={cn(accountsTableColVisibility[2])}>
+                  {t("accountsPage.premiumReq")}
+                </TableHead>
+                <TableHead>{t("nav.requests")}</TableHead>
+                <TableHead>{t("common.errors")}</TableHead>
+                <TableHead className={cn(accountsTableColVisibility[5])}>
+                  {t("common.tokens")}
+                </TableHead>
+                <TableHead className={cn(accountsTableColVisibility[6])}>
+                  {t("common.avgMs")}
+                </TableHead>
+                <TableHead className={cn(accountsTableColVisibility[7])}>
+                  {t("common.lastRequest")}
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -395,13 +410,17 @@ export function AccountsPage(): React.JSX.Element {
                   <TableCell colSpan={accountsTableColVisibility.length}>
                     <InlineAlert
                       variant="info"
-                      title={accounts.length === 0 ? "No accounts" : "No matches"}
+                      title={
+                        accounts.length === 0
+                          ? t("accountsPage.empty.noAccountsTitle")
+                          : t("accountsPage.empty.noMatchesTitle")
+                      }
                       description={
                         accounts.length === 0
-                          ? "No accounts found."
-                          : "No accounts match the current filter."
+                          ? t("accountsPage.empty.noAccountsDescription")
+                          : t("accountsPage.empty.noMatchesDescription")
                       }
-                      actionLabel={query.trim() ? "Clear filter" : undefined}
+                      actionLabel={query.trim() ? t("common.clearFilter") : undefined}
                       onAction={query.trim() ? () => setQuery("") : undefined}
                     />
                   </TableCell>
@@ -410,9 +429,9 @@ export function AccountsPage(): React.JSX.Element {
                 visibleAccounts.map((a) => {
                   const failed = a.runtime?.failed
                   const statusBadge = failed ? (
-                    <Badge variant="destructive">failed</Badge>
+                    <Badge variant="destructive">{t("common.statusFailed")}</Badge>
                   ) : (
-                    <Badge variant="secondary">ok</Badge>
+                    <Badge variant="secondary">{t("common.statusOk")}</Badge>
                   )
 
                   const total = a.runtime?.entitlement
@@ -433,18 +452,18 @@ export function AccountsPage(): React.JSX.Element {
                       : undefined
 
                   const remainingCell = a.runtime?.unlimited ? (
-                    <Badge variant="secondary">unlimited</Badge>
+                    <Badge variant="secondary">{t("common.unlimited")}</Badge>
                   ) : (
                     <div className="flex flex-col gap-1">
                       <div className="flex items-baseline justify-between gap-2 text-xs whitespace-nowrap">
                         <div className="flex items-baseline gap-1">
-                          <span className="text-muted-foreground">Used</span>
+                          <span className="text-muted-foreground">{t("common.used")}</span>
                           <span className="tabular-nums font-medium">
                             {fmtNumOrDash(usedQuota)}
                           </span>
                         </div>
                         <div className="flex items-baseline gap-1">
-                          <span className="text-muted-foreground">Remaining</span>
+                          <span className="text-muted-foreground">{t("common.remaining")}</span>
                           <span className="tabular-nums font-medium">
                             {fmtNumOrDash(remainingQuota)}
                           </span>
@@ -454,7 +473,7 @@ export function AccountsPage(): React.JSX.Element {
                         <Progress
                           value={percentUsed}
                           className="h-1.5"
-                          aria-label="Premium interactions quota used"
+                          aria-label={t("accountsPage.premiumQuotaUsedAria")}
                         />
                       ) : null}
                     </div>

--- a/admin-ui/src/pages/not-found-page.tsx
+++ b/admin-ui/src/pages/not-found-page.tsx
@@ -1,11 +1,15 @@
+import { useTranslation } from "react-i18next"
+
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 
 export function NotFoundPage(): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Not found</CardTitle>
-        <CardDescription>The page you are looking for does not exist.</CardDescription>
+        <CardTitle>{t("notFound.title")}</CardTitle>
+        <CardDescription>{t("notFound.description")}</CardDescription>
       </CardHeader>
     </Card>
   )

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -1,8 +1,8 @@
 import { ArrowLeftIcon, DownloadIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { Link, useLocation, useParams } from "react-router-dom"
-import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 import {
   AdminApiError,

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftIcon, DownloadIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { Link, useLocation, useParams } from "react-router-dom"
 import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 
 import {
   AdminApiError,
@@ -9,6 +10,7 @@ import {
   getAdminRequestDetail,
 } from "@/lib/admin-api"
 import { fmtLocalDateTime, fmtNum } from "@/lib/format"
+import { i18n } from "@/lib/i18n"
 import { JsonViewer } from "@/components/json/json-viewer"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -40,6 +42,7 @@ function StatusBadge({ status }: { status: number }): React.JSX.Element {
 }
 
 export function RequestDetailPage(): React.JSX.Element {
+  const { t } = useTranslation()
   const { requestId = "" } = useParams()
   const location = useLocation()
 
@@ -61,7 +64,7 @@ export function RequestDetailPage(): React.JSX.Element {
         setItem(data.item)
       } catch (err) {
         const msg = err instanceof AdminApiError ? err.message : String(err)
-        toast.error("Failed to load request", { description: msg })
+        toast.error(i18n.t("requestDetailPage.loadFailedTitle"), { description: msg })
         if (cancelled) return
         setItem(null)
       } finally {
@@ -82,9 +85,9 @@ export function RequestDetailPage(): React.JSX.Element {
     try {
       const raw = JSON.stringify(item, null, 2)
       await navigator.clipboard.writeText(raw)
-      toast.success("Copied JSON")
+      toast.success(t("requestDetailPage.toast.copiedJson"))
     } catch (err) {
-      toast.error("Copy failed", { description: String(err) })
+      toast.error(t("requestDetailPage.toast.copyFailed"), { description: String(err) })
     }
   }
 
@@ -102,9 +105,9 @@ export function RequestDetailPage(): React.JSX.Element {
       a.click()
 
       URL.revokeObjectURL(url)
-      toast.success("Downloaded JSON")
+      toast.success(t("requestDetailPage.toast.downloadedJson"))
     } catch (err) {
-      toast.error("Download failed", { description: String(err) })
+      toast.error(t("requestDetailPage.toast.downloadFailed"), { description: String(err) })
     }
   }
 
@@ -112,7 +115,7 @@ export function RequestDetailPage(): React.JSX.Element {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Request</CardTitle>
+          <CardTitle>{t("requestDetailPage.title")}</CardTitle>
           <CardDescription>
             <Skeleton className="h-4 w-40" />
           </CardDescription>
@@ -132,13 +135,13 @@ export function RequestDetailPage(): React.JSX.Element {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Request</CardTitle>
-          <CardDescription>Request not found.</CardDescription>
+          <CardTitle>{t("requestDetailPage.title")}</CardTitle>
+          <CardDescription>{t("requestDetailPage.notFoundDescription")}</CardDescription>
         </CardHeader>
         <CardContent>
           <InlineAlert
             variant="warning"
-            title="Request not found"
+            title={t("requestDetailPage.notFoundTitle")}
             description={`request_id: ${requestId}`}
           />
         </CardContent>
@@ -158,7 +161,7 @@ export function RequestDetailPage(): React.JSX.Element {
         <Button variant="ghost" size="sm" asChild>
           <Link to={backTo}>
             <ArrowLeftIcon className="size-4" />
-            Back
+            {t("common.back")}
           </Link>
         </Button>
       </div>
@@ -171,10 +174,10 @@ export function RequestDetailPage(): React.JSX.Element {
               <span className="font-mono text-sm">{item.request_id}</span>
               <StatusBadge status={item.http_status} />
               {item.duration_ms != null ? (
-                <Badge variant="outline">dur_ms: {fmtNum(item.duration_ms)}</Badge>
+                <Badge variant="outline">{t("requestDetailPage.badges.durMs")}: {fmtNum(item.duration_ms)}</Badge>
               ) : null}
               {item.ttfb_ms != null ? (
-                <Badge variant="outline">ttfb_ms: {fmtNum(item.ttfb_ms)}</Badge>
+                <Badge variant="outline">{t("requestDetailPage.badges.ttfbMs")}: {fmtNum(item.ttfb_ms)}</Badge>
               ) : null}
             </CardTitle>
             <CardDescription className="font-mono text-xs">
@@ -187,19 +190,23 @@ export function RequestDetailPage(): React.JSX.Element {
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-[1fr_2fr]">
         <Card>
           <CardHeader>
-            <CardTitle>Summary</CardTitle>
+            <CardTitle>{t("requestDetailPage.summaryTitle")}</CardTitle>
           </CardHeader>
           <CardContent>
             <Table>
               <TableBody>
                 <TableRow>
-                  <TableCell className="w-36 text-muted-foreground">time</TableCell>
+                  <TableCell className="w-36 text-muted-foreground">
+                    {t("requestDetailPage.fields.time")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs">
                     {fmtLocalDateTime(item.started_at_ms)}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">path</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.path")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     <Link
                       to={`/requests?path=${encodeURIComponent(item.path)}`}
@@ -210,13 +217,17 @@ export function RequestDetailPage(): React.JSX.Element {
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">endpoint</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.endpoint")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.upstream_endpoint || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">account</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.account")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.account_id ? (
                       <Link
@@ -231,66 +242,81 @@ export function RequestDetailPage(): React.JSX.Element {
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">user_id</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.userId")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.user_id || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="text-muted-foreground">
-                    safety_identifier
+                    {t("requestDetailPage.fields.safetyIdentifier")}
                   </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.safety_identifier || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">prompt_cache_key</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.promptCacheKey")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.prompt_cache_key || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">initiator</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.initiator")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.initiator || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="text-muted-foreground">
-                    upstream_request_id
+                    {t("requestDetailPage.fields.upstreamRequestId")}
                   </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.upstream_request_id || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">model</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.model")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs">
                     {item.upstream_model || ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">client</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.client")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
                     {item.client_ip || ""}
                     {item.user_agent ? ` (${item.user_agent})` : ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">tokens</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.tokens")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
-                    in={item.tokens_input ?? ""} out={item.tokens_output ?? ""} total={
-                      item.tokens_total ?? ""
-                    } cached={item.tokens_cached_input ?? ""}
+                    {t("requestDetailPage.tokens.in")}={item.tokens_input ?? ""}{" "}
+                    {t("requestDetailPage.tokens.out")}={item.tokens_output ?? ""}{" "}
+                    {t("requestDetailPage.tokens.total")}={item.tokens_total ?? ""}{" "}
+                    {t("requestDetailPage.tokens.cached")}={item.tokens_cached_input ?? ""}
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="text-muted-foreground">quota</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {t("requestDetailPage.fields.quota")}
+                  </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
-                    before={item.premium_remaining_before ?? ""} after={
-                      item.premium_remaining_after ?? ""
-                    } diff={item.premium_remaining_diff ?? ""} ({quota})
+                    {t("requestDetailPage.quota.before")}={item.premium_remaining_before ?? ""}{" "}
+                    {t("requestDetailPage.quota.after")}={item.premium_remaining_after ?? ""}{" "}
+                    {t("requestDetailPage.quota.diff")}={item.premium_remaining_diff ?? ""} ({quota})
                   </TableCell>
                 </TableRow>
               </TableBody>
@@ -300,13 +326,13 @@ export function RequestDetailPage(): React.JSX.Element {
 
         <Card>
           <CardHeader>
-            <CardTitle>Raw</CardTitle>
-            <CardDescription>Full record as JSON.</CardDescription>
+            <CardTitle>{t("requestDetailPage.rawTitle")}</CardTitle>
+            <CardDescription>{t("requestDetailPage.rawDescription")}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <Input
-                placeholder="Search key/value"
+                placeholder={t("requestDetailPage.searchPlaceholder")}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="h-8 sm:max-w-xs"
@@ -314,10 +340,10 @@ export function RequestDetailPage(): React.JSX.Element {
               <div className="flex items-center gap-2 sm:ml-auto">
                 <Button type="button" variant="outline" size="sm" onClick={downloadRaw}>
                   <DownloadIcon className="size-4" />
-                  Download
+                  {t("common.download")}
                 </Button>
                 <RainbowButton onClick={() => void copyRaw()} size="sm">
-                  Copy JSON
+                  {t("common.copyJson")}
                 </RainbowButton>
               </div>
             </div>

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeftIcon, DownloadIcon } from "lucide-react"
 import { useEffect, useState } from "react"
-import { Link, useLocation, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import { Link, useLocation, useParams } from "react-router-dom"
 import { toast } from "sonner"
 
 import {
@@ -136,7 +136,9 @@ export function RequestDetailPage(): React.JSX.Element {
       <Card>
         <CardHeader>
           <CardTitle>{t("requestDetailPage.title")}</CardTitle>
-          <CardDescription>{t("requestDetailPage.notFoundDescription")}</CardDescription>
+          <CardDescription>
+            {t("requestDetailPage.notFoundDescription")}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <InlineAlert
@@ -174,10 +176,16 @@ export function RequestDetailPage(): React.JSX.Element {
               <span className="font-mono text-sm">{item.request_id}</span>
               <StatusBadge status={item.http_status} />
               {typeof item.duration_ms === "number" ? (
-                <Badge variant="outline">{t("requestDetailPage.badges.durMs")}: {fmtNum(item.duration_ms)}</Badge>
+                <Badge variant="outline">
+                  {t("requestDetailPage.badges.durMs")}:{" "}
+                  {fmtNum(item.duration_ms)}
+                </Badge>
               ) : null}
               {typeof item.ttfb_ms === "number" ? (
-                <Badge variant="outline">{t("requestDetailPage.badges.ttfbMs")}: {fmtNum(item.ttfb_ms)}</Badge>
+                <Badge variant="outline">
+                  {t("requestDetailPage.badges.ttfbMs")}:{" "}
+                  {fmtNum(item.ttfb_ms)}
+                </Badge>
               ) : null}
             </CardTitle>
             <CardDescription className="font-mono text-xs">
@@ -303,10 +311,18 @@ export function RequestDetailPage(): React.JSX.Element {
                     {t("requestDetailPage.fields.tokens")}
                   </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
-                    {t("requestDetailPage.tokens.in")}={item.tokens_input ?? ""}{" "}
-                    {t("requestDetailPage.tokens.out")}={item.tokens_output ?? ""}{" "}
-                    {t("requestDetailPage.tokens.total")}={item.tokens_total ?? ""}{" "}
-                    {t("requestDetailPage.tokens.cached")}={item.tokens_cached_input ?? ""}
+                    <span>
+                      {t("requestDetailPage.tokens.in")}={item.tokens_input ?? ""}
+                    </span>{" "}
+                    <span>
+                      {t("requestDetailPage.tokens.out")}={item.tokens_output ?? ""}
+                    </span>{" "}
+                    <span>
+                      {t("requestDetailPage.tokens.total")}={item.tokens_total ?? ""}
+                    </span>{" "}
+                    <span>
+                      {t("requestDetailPage.tokens.cached")}={item.tokens_cached_input ?? ""}
+                    </span>
                   </TableCell>
                 </TableRow>
                 <TableRow>
@@ -314,9 +330,16 @@ export function RequestDetailPage(): React.JSX.Element {
                     {t("requestDetailPage.fields.quota")}
                   </TableCell>
                   <TableCell className="font-mono text-xs whitespace-normal break-words">
-                    {t("requestDetailPage.quota.before")}={item.premium_remaining_before ?? ""}{" "}
-                    {t("requestDetailPage.quota.after")}={item.premium_remaining_after ?? ""}{" "}
-                    {t("requestDetailPage.quota.diff")}={item.premium_remaining_diff ?? ""} ({quota})
+                    <span>
+                      {t("requestDetailPage.quota.before")}={item.premium_remaining_before ?? ""}
+                    </span>{" "}
+                    <span>
+                      {t("requestDetailPage.quota.after")}={item.premium_remaining_after ?? ""}
+                    </span>{" "}
+                    <span>
+                      {t("requestDetailPage.quota.diff")}={item.premium_remaining_diff ?? ""}{" "}
+                      ({quota})
+                    </span>
                   </TableCell>
                 </TableRow>
               </TableBody>
@@ -327,7 +350,9 @@ export function RequestDetailPage(): React.JSX.Element {
         <Card>
           <CardHeader>
             <CardTitle>{t("requestDetailPage.rawTitle")}</CardTitle>
-            <CardDescription>{t("requestDetailPage.rawDescription")}</CardDescription>
+            <CardDescription>
+              {t("requestDetailPage.rawDescription")}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -338,7 +363,12 @@ export function RequestDetailPage(): React.JSX.Element {
                 className="h-8 sm:max-w-xs"
               />
               <div className="flex items-center gap-2 sm:ml-auto">
-                <Button type="button" variant="outline" size="sm" onClick={downloadRaw}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={downloadRaw}
+                >
                   <DownloadIcon className="size-4" />
                   {t("common.download")}
                 </Button>

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -173,10 +173,10 @@ export function RequestDetailPage(): React.JSX.Element {
             <CardTitle className="flex flex-wrap items-center gap-2">
               <span className="font-mono text-sm">{item.request_id}</span>
               <StatusBadge status={item.http_status} />
-              {item.duration_ms != null ? (
+              {typeof item.duration_ms === "number" ? (
                 <Badge variant="outline">{t("requestDetailPage.badges.durMs")}: {fmtNum(item.duration_ms)}</Badge>
               ) : null}
-              {item.ttfb_ms != null ? (
+              {typeof item.ttfb_ms === "number" ? (
                 <Badge variant="outline">{t("requestDetailPage.badges.ttfbMs")}: {fmtNum(item.ttfb_ms)}</Badge>
               ) : null}
             </CardTitle>

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 
 import {
   AdminApiError,
@@ -8,6 +9,7 @@ import {
   queryAdminRequests,
 } from "@/lib/admin-api"
 import { fmtLocalDateTime, fmtNum } from "@/lib/format"
+import { i18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -104,14 +106,24 @@ function parseMs(value: string): number | null {
   return int
 }
 
-function validateTimeRange(fromMs: string, toMs: string): string | null {
+type TimeRangeValidationErrorKey =
+  | "requestsPage.validation.fromMsMustBeNumber"
+  | "requestsPage.validation.toMsMustBeNumber"
+  | "requestsPage.validation.fromMsMustBeLteToMs"
+
+function validateTimeRange(
+  fromMs: string,
+  toMs: string
+): TimeRangeValidationErrorKey | null {
   const from = parseMs(fromMs)
   const to = parseMs(toMs)
 
-  if (fromMs.trim() && from == null) return "from_ms must be a number (milliseconds)"
-  if (toMs.trim() && to == null) return "to_ms must be a number (milliseconds)"
+  if (fromMs.trim() && from == null) return "requestsPage.validation.fromMsMustBeNumber"
+  if (toMs.trim() && to == null) return "requestsPage.validation.toMsMustBeNumber"
 
-  if (from != null && to != null && from > to) return "from_ms must be <= to_ms"
+  if (from != null && to != null && from > to) {
+    return "requestsPage.validation.fromMsMustBeLteToMs"
+  }
 
   return null
 }
@@ -189,6 +201,7 @@ function TableSkeleton({ rows }: { rows: number }): React.JSX.Element {
 }
 
 export function RequestsPage(): React.JSX.Element {
+  const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
 
   const [filters, setFilters] = useState<Filters>(() =>
@@ -219,8 +232,9 @@ export function RequestsPage(): React.JSX.Element {
   }, [activeFilters])
 
   const validationError = useMemo(() => {
-    return validateTimeRange(filters.from_ms, filters.to_ms)
-  }, [filters.from_ms, filters.to_ms])
+    const key = validateTimeRange(filters.from_ms, filters.to_ms)
+    return key ? t(key) : null
+  }, [filters.from_ms, filters.to_ms, t])
 
   const load = useCallback(
     async ({
@@ -246,7 +260,7 @@ export function RequestsPage(): React.JSX.Element {
       } catch (err) {
         const msg = err instanceof AdminApiError ? err.message : String(err)
         setError(msg)
-        toast.error("Failed to load requests", { description: msg })
+        toast.error(i18n.t("requestsPage.loadFailedTitle"), { description: msg })
 
         if (reset) setItems([])
         setHasMore(false)
@@ -305,10 +319,8 @@ export function RequestsPage(): React.JSX.Element {
     <div className="space-y-4">
       <Card className="gap-4 py-4">
         <CardHeader className="px-4">
-          <CardTitle>Requests</CardTitle>
-          <CardDescription className="hidden sm:block">
-            Filter and inspect recent requests.
-          </CardDescription>
+          <CardTitle>{t("nav.requests")}</CardTitle>
+          <CardDescription className="hidden sm:block">{t("requestsPage.description")}</CardDescription>
           <CardAction className="flex items-center gap-2">
             <Button
               type="button"
@@ -317,25 +329,25 @@ export function RequestsPage(): React.JSX.Element {
               onClick={clearAll}
               disabled={!hasQuery || loading}
             >
-              Clear
+              {t("common.clear")}
             </Button>
             <RainbowButton onClick={apply} disabled={!canApply} size="sm">
-              Apply
+              {t("common.apply")}
             </RainbowButton>
           </CardAction>
         </CardHeader>
         <CardContent className="space-y-3 px-4">
           <Tabs defaultValue="quick" className="gap-1.5">
             <TabsList className="h-8 p-[2px]">
-              <TabsTrigger value="quick">Quick</TabsTrigger>
-              <TabsTrigger value="advanced">Advanced</TabsTrigger>
+              <TabsTrigger value="quick">{t("requestsPage.tabs.quick")}</TabsTrigger>
+              <TabsTrigger value="advanced">{t("requestsPage.tabs.advanced")}</TabsTrigger>
             </TabsList>
 
             <TabsContent value="quick">
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
                 <div className="grid gap-1.5">
                   <Label htmlFor="account_id" className="text-muted-foreground lg:text-xs">
-                    Account
+                    {t("common.account")}
                   </Label>
                   <Input
                     id="account_id"
@@ -349,26 +361,26 @@ export function RequestsPage(): React.JSX.Element {
                 </div>
 
                 <div className="grid gap-1.5">
-                  <Label className="text-muted-foreground lg:text-xs">Time range</Label>
+                  <Label className="text-muted-foreground lg:text-xs">{t("requestsPage.filters.timeRange")}</Label>
                   <Select value={timeRange} onValueChange={(v) => onTimeRangeChange(v as TimeRange)}>
                     <SelectTrigger size="sm" className="w-full">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__any__">(any)</SelectItem>
-                      <SelectItem value="15m">Last 15m</SelectItem>
-                      <SelectItem value="1h">Last 1h</SelectItem>
-                      <SelectItem value="6h">Last 6h</SelectItem>
-                      <SelectItem value="24h">Last 24h</SelectItem>
-                      <SelectItem value="7d">Last 7d</SelectItem>
-                      <SelectItem value="custom">Custom...</SelectItem>
+                      <SelectItem value="__any__">{t("common.any")}</SelectItem>
+                      <SelectItem value="15m">{t("requestsPage.timeRange.last15m")}</SelectItem>
+                      <SelectItem value="1h">{t("requestsPage.timeRange.last1h")}</SelectItem>
+                      <SelectItem value="6h">{t("requestsPage.timeRange.last6h")}</SelectItem>
+                      <SelectItem value="24h">{t("requestsPage.timeRange.last24h")}</SelectItem>
+                      <SelectItem value="7d">{t("requestsPage.timeRange.last7d")}</SelectItem>
+                      <SelectItem value="custom">{t("requestsPage.timeRange.custom")}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
 
                 <div className="grid gap-1.5">
                   <Label htmlFor="status" className="text-muted-foreground lg:text-xs">
-                    Status
+                    {t("common.status")}
                   </Label>
                   <Input
                     id="status"
@@ -382,7 +394,7 @@ export function RequestsPage(): React.JSX.Element {
                 </div>
 
                 <div className="grid gap-1.5">
-                  <Label className="text-muted-foreground lg:text-xs">Has error</Label>
+                  <Label className="text-muted-foreground lg:text-xs">{t("requestsPage.filters.hasError")}</Label>
                   <Select
                     value={filters.has_error || "__any__"}
                     onValueChange={(v) =>
@@ -396,9 +408,9 @@ export function RequestsPage(): React.JSX.Element {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__any__">(any)</SelectItem>
-                      <SelectItem value="1">yes</SelectItem>
-                      <SelectItem value="0">no</SelectItem>
+                      <SelectItem value="__any__">{t("common.any")}</SelectItem>
+                      <SelectItem value="1">{t("common.yes")}</SelectItem>
+                      <SelectItem value="0">{t("common.no")}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -407,7 +419,7 @@ export function RequestsPage(): React.JSX.Element {
                   <>
                     <div className="grid gap-1.5">
                       <Label htmlFor="from_dt" className="text-muted-foreground lg:text-xs">
-                        From
+                        {t("common.from")}
                       </Label>
                       <Input
                         id="from_dt"
@@ -425,7 +437,7 @@ export function RequestsPage(): React.JSX.Element {
                     </div>
                     <div className="grid gap-1.5">
                       <Label htmlFor="to_dt" className="text-muted-foreground lg:text-xs">
-                        To
+                        {t("common.to")}
                       </Label>
                       <Input
                         id="to_dt"
@@ -450,7 +462,7 @@ export function RequestsPage(): React.JSX.Element {
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
                 <div className="grid gap-1.5">
                   <Label htmlFor="upstream_model" className="text-muted-foreground lg:text-xs">
-                    Upstream model
+                    {t("requestsPage.filters.upstreamModel")}
                   </Label>
                   <Input
                     id="upstream_model"
@@ -465,7 +477,7 @@ export function RequestsPage(): React.JSX.Element {
 
                 <div className="grid gap-1.5">
                   <Label htmlFor="client_model" className="text-muted-foreground lg:text-xs">
-                    Client model
+                    {t("requestsPage.filters.clientModel")}
                   </Label>
                   <Input
                     id="client_model"
@@ -483,7 +495,7 @@ export function RequestsPage(): React.JSX.Element {
                     htmlFor="upstream_endpoint"
                     className="text-muted-foreground lg:text-xs"
                   >
-                    Endpoint
+                    {t("common.endpoint")}
                   </Label>
                   <Input
                     id="upstream_endpoint"
@@ -501,7 +513,7 @@ export function RequestsPage(): React.JSX.Element {
 
                 <div className="grid gap-1.5">
                   <Label htmlFor="path" className="text-muted-foreground lg:text-xs">
-                    Path
+                    {t("common.path")}
                   </Label>
                   <Input
                     id="path"
@@ -521,7 +533,7 @@ export function RequestsPage(): React.JSX.Element {
           {validationError ? (
             <InlineAlert
               variant="warning"
-              title="Invalid time range"
+              title={t("requestsPage.validation.title")}
               description={validationError}
             />
           ) : null}
@@ -537,9 +549,9 @@ export function RequestsPage(): React.JSX.Element {
             {error && items.length > 0 ? (
               <InlineAlert
                 variant="error"
-                title="Failed to load requests"
+                title={t("requestsPage.loadFailedTitle")}
                 description={error}
-                actionLabel="Retry"
+                actionLabel={t("common.retry")}
                 onAction={() => void load({ reset: true, cursor: null })}
               />
             ) : null}
@@ -547,16 +559,30 @@ export function RequestsPage(): React.JSX.Element {
             <Table className="[&_th]:h-9 [&_td]:py-1.5">
               <TableHeader>
                 <TableRow>
-                  <TableHead>Time</TableHead>
-                  <TableHead>Path</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[2])}>Endpoint</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[3])}>Account</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[4])}>Model</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[5])}>Tokens</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[6])}>Cost</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[7])}>Quota</TableHead>
-                  <TableHead className={cn(requestsTableColVisibility[8])}>Dur</TableHead>
-                  <TableHead>Status</TableHead>
+                  <TableHead>{t("common.time")}</TableHead>
+                  <TableHead>{t("common.path")}</TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[2])}>
+                    {t("common.endpoint")}
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[3])}>
+                    {t("common.account")}
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[4])}>
+                    {t("common.model")}
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[5])}>
+                    {t("common.tokens")}
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[6])}>
+                    {t("common.cost")}
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[7])}>
+                    {t("common.quota")}
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[8])}>
+                    {t("common.durationAbbrev")}
+                  </TableHead>
+                  <TableHead>{t("common.status")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -565,9 +591,9 @@ export function RequestsPage(): React.JSX.Element {
                     <TableCell colSpan={colSpan}>
                       <InlineAlert
                         variant="error"
-                        title="Failed to load requests"
+                        title={t("requestsPage.loadFailedTitle")}
                         description={error}
-                        actionLabel="Retry"
+                        actionLabel={t("common.retry")}
                         onAction={() => void load({ reset: true, cursor: null })}
                       />
                     </TableCell>
@@ -579,13 +605,13 @@ export function RequestsPage(): React.JSX.Element {
                     <TableCell colSpan={colSpan}>
                       <InlineAlert
                         variant="info"
-                        title="No requests"
+                        title={t("requestsPage.empty.noRequestsTitle")}
                         description={
                           hasQuery
-                            ? "No results for the current filters."
-                            : "No requests found."
+                            ? t("requestsPage.empty.noResultsForFilters")
+                            : t("requestsPage.empty.noRequestsFound")
                         }
-                        actionLabel={hasQuery ? "Clear filters" : undefined}
+                        actionLabel={hasQuery ? t("common.clearFilters") : undefined}
                         onAction={hasQuery ? clearAll : undefined}
                       />
                     </TableCell>
@@ -663,7 +689,11 @@ export function RequestsPage(): React.JSX.Element {
                 disabled={loading || !hasMore}
                 size="sm"
               >
-                {loading && hasMore ? "Loading..." : hasMore ? "Load more" : "No more"}
+                {loading && hasMore
+                  ? t("common.loading")
+                  : hasMore
+                    ? t("common.loadMore")
+                    : t("common.noMore")}
               </RainbowButton>
             </div>
           </CardContent>

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -118,10 +118,10 @@ function validateTimeRange(
   const from = parseMs(fromMs)
   const to = parseMs(toMs)
 
-  if (fromMs.trim() && from == null) return "requestsPage.validation.fromMsMustBeNumber"
-  if (toMs.trim() && to == null) return "requestsPage.validation.toMsMustBeNumber"
+  if (fromMs.trim() && from === null) return "requestsPage.validation.fromMsMustBeNumber"
+  if (toMs.trim() && to === null) return "requestsPage.validation.toMsMustBeNumber"
 
-  if (from != null && to != null && from > to) {
+  if (from !== null && to !== null && from > to) {
     return "requestsPage.validation.fromMsMustBeLteToMs"
   }
 
@@ -314,6 +314,11 @@ export function RequestsPage(): React.JSX.Element {
 
   const colSpan = requestsTableColVisibility.length
   const hasQuery = searchParams.toString().length > 0
+
+  let loadMoreLabel = t("common.noMore")
+  if (hasMore) {
+    loadMoreLabel = loading ? t("common.loading") : t("common.loadMore")
+  }
 
   return (
     <div className="space-y-4">
@@ -689,11 +694,7 @@ export function RequestsPage(): React.JSX.Element {
                 disabled={loading || !hasMore}
                 size="sm"
               >
-                {loading && hasMore
-                  ? t("common.loading")
-                  : hasMore
-                    ? t("common.loadMore")
-                    : t("common.noMore")}
+                {loadMoreLabel}
               </RainbowButton>
             </div>
           </CardContent>

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 
 import {
   AdminApiError,
@@ -11,6 +12,7 @@ import {
   getAdminModels,
   updateAdminConfig,
 } from "@/lib/admin-api"
+import { i18n } from "@/lib/i18n"
 import { Button } from "@/components/ui/button"
 import {
   FloatingSaveButton,
@@ -38,14 +40,14 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 
-const SETTINGS_SECTIONS: Array<SettingsSection> = [
-  { id: "general", label: "General" },
-  { id: "load-balancing", label: "Load Balancing" },
-  { id: "reasoning", label: "Reasoning" },
-  { id: "aliases", label: "Aliases" },
-  { id: "prompts", label: "Prompts" },
-  { id: "advanced", label: "Advanced" },
-]
+const SETTINGS_SECTION_IDS = [
+  "general",
+  "load-balancing",
+  "reasoning",
+  "aliases",
+  "prompts",
+  "advanced",
+] as const
 
 const REASONING_EFFORTS: Array<ReasoningEffort> = [
   "none",
@@ -687,6 +689,8 @@ function GeneralSettingsCard({
   onSmallModelInput,
   onApiKeyChange,
 }: GeneralSettingsCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
   const showCustomModel =
     hasModels
     && smallModelValue !== "__default__"
@@ -695,10 +699,8 @@ function GeneralSettingsCard({
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
-        <CardTitle>General</CardTitle>
-        <CardDescription className="hidden sm:block">
-          Default model routing and API key storage.
-        </CardDescription>
+        <CardTitle>{t("settingsPage.general.title")}</CardTitle>
+        <CardDescription className="hidden sm:block">{t("settingsPage.general.description")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 px-4">
         <div className="grid gap-2">
@@ -706,13 +708,13 @@ function GeneralSettingsCard({
           {hasModels ? (
             <Select value={smallModelValue} onValueChange={onSmallModelSelect}>
               <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select small model" />
+                <SelectValue placeholder={t("settingsPage.general.smallModelPlaceholder")} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__default__">(default)</SelectItem>
+                <SelectItem value="__default__">{t("settingsPage.common.defaultOption")}</SelectItem>
                 {showCustomModel ? (
                   <SelectItem value={smallModelValue}>
-                    Custom: {smallModelValue}
+                    {t("settingsPage.common.customModel", { value: smallModelValue })}
                   </SelectItem>
                 ) : null}
                 {models.map((model) => (
@@ -724,27 +726,27 @@ function GeneralSettingsCard({
             </Select>
           ) : (
             <Input
-              placeholder="gpt-5-mini"
+              placeholder={t("settingsPage.general.smallModelInputPlaceholder")}
               value={smallModelInputValue}
               onChange={(e) => onSmallModelInput(e.target.value)}
             />
           )}
           <div className="text-muted-foreground text-xs">
-            Controls which model receives lightweight/free requests when routing.
+            {t("settingsPage.general.smallModelHint")}
           </div>
         </div>
 
         <div className="grid gap-2">
-          <Label className="text-muted-foreground text-xs">API key</Label>
+          <Label className="text-muted-foreground text-xs">{t("settingsPage.general.apiKeyLabel")}</Label>
           <Input
             type="password"
             autoComplete="new-password"
-            placeholder="sk-..."
+            placeholder={t("settingsPage.general.apiKeyPlaceholder")}
             value={apiKeyValue}
             onChange={(e) => onApiKeyChange(e.target.value)}
           />
           <div className="text-muted-foreground text-xs">
-            {envOverrideNote} Leave empty to clear config value.
+            {envOverrideNote} {t("settingsPage.general.leaveEmptyHint")}
           </div>
         </div>
       </CardContent>
@@ -758,20 +760,22 @@ type LoadBalancingCardProps = {
 }
 
 function LoadBalancingCard({ enabled, onToggle }: LoadBalancingCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
-        <CardTitle>Load balancing</CardTitle>
+        <CardTitle>{t("settingsPage.loadBalancing.title")}</CardTitle>
         <CardDescription className="hidden sm:block">
-          Toggle free account load balancing.
+          {t("settingsPage.loadBalancing.description")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Free model load balancing</div>
+            <div className="text-sm font-medium">{t("settingsPage.loadBalancing.freeModelLabel")}</div>
             <div className="text-muted-foreground text-xs">
-              When enabled, distributes free traffic across available accounts.
+              {t("settingsPage.loadBalancing.freeModelHint")}
             </div>
           </div>
           <Switch checked={enabled} onCheckedChange={onToggle} />
@@ -808,23 +812,24 @@ function ReasoningEffortsCard({
 }: ReasoningEffortsCardProps): React.JSX.Element {
   const defaultModelValue = "__default__"
   const hasModels = models.length > 0
+  const { t } = useTranslation()
 
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
-        <CardTitle>Reasoning efforts</CardTitle>
+        <CardTitle>{t("settingsPage.reasoning.title")}</CardTitle>
         <CardDescription className="hidden sm:block">
-          Override model reasoning effort levels.
+          {t("settingsPage.reasoning.description")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
         <div className="flex items-center justify-between gap-3">
           <div className="text-muted-foreground text-xs">
-            Define per-model reasoning effort (optional).
+            {t("settingsPage.reasoning.hint")}
           </div>
           <div className="flex items-center gap-2">
             <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
-            <Label className="text-muted-foreground text-xs">JSON mode</Label>
+            <Label className="text-muted-foreground text-xs">{t("settingsPage.common.jsonMode")}</Label>
           </div>
         </div>
 
@@ -834,17 +839,17 @@ function ReasoningEffortsCard({
               value={json}
               onChange={(e) => onJsonChange(e.target.value)}
               className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
-              placeholder='{ "gpt-5-mini": "low" }'
+              placeholder={t("settingsPage.reasoning.jsonPlaceholder")}
             />
             {jsonIssue ? (
-              <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
+              <InlineAlert variant="warning" title={t("settingsPage.common.invalidJsonTitle")} description={jsonIssue} />
             ) : null}
           </div>
         ) : (
           <div className="space-y-2">
             {items.length === 0 ? (
               <div className="text-muted-foreground text-sm">
-                No reasoning overrides. Add a model below.
+                {t("settingsPage.reasoning.emptyState")}
               </div>
             ) : (
               items.map((item) => {
@@ -867,13 +872,21 @@ function ReasoningEffortsCard({
                       >
                         <SelectTrigger className="min-w-[220px]">
                           <SelectValue
-                            placeholder={hasModels ? "Select model" : "No models available"}
+                            placeholder={
+                              hasModels
+                                ? t("settingsPage.common.selectModelPlaceholder")
+                                : t("settingsPage.common.noModelsAvailable")
+                            }
                           />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value={defaultModelValue}>(default)</SelectItem>
+                          <SelectItem value={defaultModelValue}>
+                            {t("settingsPage.common.defaultOption")}
+                          </SelectItem>
                           {showCustomModel ? (
-                            <SelectItem value={modelValue}>Custom: {modelValue}</SelectItem>
+                            <SelectItem value={modelValue}>
+                              {t("settingsPage.common.customModel", { value: modelValue })}
+                            </SelectItem>
                           ) : null}
                           {models.map((model) => (
                             <SelectItem key={model} value={model}>
@@ -905,11 +918,11 @@ function ReasoningEffortsCard({
                         size="sm"
                         onClick={() => onRemoveItem(item.id)}
                       >
-                        Remove
+                        {t("settingsPage.common.remove")}
                       </Button>
                     </div>
                     <div className="text-muted-foreground text-xs">
-                      Overrides reasoning effort for this model.
+                      {t("settingsPage.reasoning.itemHint")}
                     </div>
                   </div>
                 )
@@ -917,7 +930,7 @@ function ReasoningEffortsCard({
             )}
 
             <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
-              Add model override
+              {t("settingsPage.reasoning.addButton")}
             </Button>
           </div>
         )}
@@ -953,23 +966,24 @@ function ExtraPromptsCard({
 }: ExtraPromptsCardProps): React.JSX.Element {
   const defaultModelValue = "__default__"
   const hasModels = models.length > 0
+  const { t } = useTranslation()
 
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
-        <CardTitle>Extra prompts</CardTitle>
+        <CardTitle>{t("settingsPage.prompts.title")}</CardTitle>
         <CardDescription className="hidden sm:block">
-          Inject extra system prompts per model.
+          {t("settingsPage.prompts.description")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
         <div className="flex items-center justify-between gap-3">
           <div className="text-muted-foreground text-xs">
-            Add or edit prompt snippets injected for specific models.
+            {t("settingsPage.prompts.hint")}
           </div>
           <div className="flex items-center gap-2">
             <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
-            <Label className="text-muted-foreground text-xs">JSON mode</Label>
+            <Label className="text-muted-foreground text-xs">{t("settingsPage.common.jsonMode")}</Label>
           </div>
         </div>
 
@@ -979,16 +993,16 @@ function ExtraPromptsCard({
               value={json}
               onChange={(e) => onJsonChange(e.target.value)}
               className="min-h-[200px] lg:min-h-[140px] max-h-[40vh] overflow-auto font-mono text-xs"
-              placeholder='{ "gpt-5-mini": "..." }'
+              placeholder={t("settingsPage.prompts.jsonPlaceholder")}
             />
             {jsonIssue ? (
-              <InlineAlert variant="warning" title="Invalid JSON" description={jsonIssue} />
+              <InlineAlert variant="warning" title={t("settingsPage.common.invalidJsonTitle")} description={jsonIssue} />
             ) : null}
           </div>
         ) : (
           <div className="space-y-2">
             {items.length === 0 ? (
-              <div className="text-muted-foreground text-sm">No extra prompts configured.</div>
+              <div className="text-muted-foreground text-sm">{t("settingsPage.prompts.emptyState")}</div>
             ) : (
               items.map((item) => {
                 const modelValue = item.model || defaultModelValue
@@ -1010,13 +1024,21 @@ function ExtraPromptsCard({
                       >
                         <SelectTrigger className="min-w-[220px]">
                           <SelectValue
-                            placeholder={hasModels ? "Select model" : "No models available"}
+                            placeholder={
+                              hasModels
+                                ? t("settingsPage.common.selectModelPlaceholder")
+                                : t("settingsPage.common.noModelsAvailable")
+                            }
                           />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value={defaultModelValue}>(default)</SelectItem>
+                          <SelectItem value={defaultModelValue}>
+                            {t("settingsPage.common.defaultOption")}
+                          </SelectItem>
                           {showCustomModel ? (
-                            <SelectItem value={modelValue}>Custom: {modelValue}</SelectItem>
+                            <SelectItem value={modelValue}>
+                              {t("settingsPage.common.customModel", { value: modelValue })}
+                            </SelectItem>
                           ) : null}
                           {models.map((model) => (
                             <SelectItem key={model} value={model}>
@@ -1031,17 +1053,17 @@ function ExtraPromptsCard({
                         size="sm"
                         onClick={() => onRemoveItem(item.id)}
                       >
-                        Remove
+                        {t("settingsPage.common.remove")}
                       </Button>
                     </div>
                     <Textarea
                       value={item.prompt}
                       onChange={(e) => onUpdateItem(item.id, { prompt: e.target.value })}
                       className="min-h-[120px] lg:min-h-[96px] max-h-[30vh] overflow-auto font-mono text-xs"
-                      placeholder="System prompt snippet..."
+                      placeholder={t("settingsPage.prompts.promptPlaceholder")}
                     />
                     <div className="text-muted-foreground text-xs">
-                      Adds prompt content before model execution.
+                      {t("settingsPage.prompts.itemHint")}
                     </div>
                   </div>
                 )
@@ -1049,7 +1071,7 @@ function ExtraPromptsCard({
             )}
 
             <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
-              Add prompt
+              {t("settingsPage.prompts.addButton")}
             </Button>
           </div>
         )}
@@ -1110,15 +1132,20 @@ function ModelAliasesHeader({
   mode,
   onToggleMode,
 }: ModelAliasesHeaderProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const defaultBehavior = allowOriginalModelNamesForAliases
+    ? t("settingsPage.common.allow")
+    : t("settingsPage.common.block")
+
   return (
     <div className="flex items-center justify-between gap-3">
       <div className="text-muted-foreground text-xs">
-        Default behavior: {allowOriginalModelNamesForAliases ? "allow" : "block"} original model
-        IDs. Each alias can override this setting.
+        {t("settingsPage.aliases.defaultBehaviorHint", { behavior: defaultBehavior })}
       </div>
       <div className="flex items-center gap-2">
         <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
-        <Label className="text-muted-foreground text-xs">JSON mode</Label>
+        <Label className="text-muted-foreground text-xs">{t("settingsPage.common.jsonMode")}</Label>
       </div>
     </div>
   )
@@ -1129,18 +1156,20 @@ function ModelAliasesJsonEditor({
   jsonIssue,
   onJsonChange,
 }: ModelAliasesJsonEditorProps): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <div className="space-y-2">
       <Textarea
         value={json}
         onChange={(e) => onJsonChange(e.target.value)}
         className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
-        placeholder='{ "fast": { "target": "gpt-5-mini", "allowOriginal": true } }'
+        placeholder={t("settingsPage.aliases.jsonPlaceholder")}
       />
       {jsonIssue ? (
         <InlineAlert
           variant="warning"
-          title="Invalid JSON"
+          title={t("settingsPage.common.invalidJsonTitle")}
           description={jsonIssue}
         />
       ) : null}
@@ -1157,6 +1186,8 @@ function ModelAliasItemCard({
   onUpdateItem,
   onRemoveItem,
 }: ModelAliasItemCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
   const targetValue = item.target || emptyTargetValue
   const showCustomTarget = targetValue !== emptyTargetValue && !models.includes(targetValue)
   const disableTargetSelect = !hasModels && !showCustomTarget
@@ -1172,7 +1203,7 @@ function ModelAliasItemCard({
       <div className="flex flex-wrap items-center gap-2">
         <Input
           className="min-w-[180px]"
-          placeholder="Alias"
+          placeholder={t("settingsPage.aliases.aliasPlaceholder")}
           value={item.alias}
           onChange={(e) => onUpdateItem(item.id, { alias: e.target.value })}
         />
@@ -1186,12 +1217,20 @@ function ModelAliasItemCard({
           disabled={disableTargetSelect}
         >
           <SelectTrigger className="min-w-[220px]">
-            <SelectValue placeholder={hasModels ? "Select target model" : "No models available"} />
+            <SelectValue
+              placeholder={
+                hasModels
+                  ? t("settingsPage.aliases.selectTargetPlaceholder")
+                  : t("settingsPage.common.noModelsAvailable")
+              }
+            />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={emptyTargetValue}>(select)</SelectItem>
+            <SelectItem value={emptyTargetValue}>{t("settingsPage.aliases.selectOption")}</SelectItem>
             {showCustomTarget ? (
-              <SelectItem value={targetValue}>Custom: {targetValue}</SelectItem>
+              <SelectItem value={targetValue}>
+                {t("settingsPage.common.customModel", { value: targetValue })}
+              </SelectItem>
             ) : null}
             {models.map((model) => (
               <SelectItem key={model} value={model}>
@@ -1212,12 +1251,12 @@ function ModelAliasItemCard({
           }
         >
           <SelectTrigger className="min-w-[200px]">
-            <SelectValue placeholder="Original model ID" />
+            <SelectValue placeholder={t("settingsPage.aliases.originalModelPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={allowOriginalDefaultValue}>Use default</SelectItem>
-            <SelectItem value="allow">Allow original model ID</SelectItem>
-            <SelectItem value="block">Block original model ID</SelectItem>
+            <SelectItem value={allowOriginalDefaultValue}>{t("settingsPage.aliases.useDefault")}</SelectItem>
+            <SelectItem value="allow">{t("settingsPage.aliases.allowOriginal")}</SelectItem>
+            <SelectItem value="block">{t("settingsPage.aliases.blockOriginal")}</SelectItem>
           </SelectContent>
         </Select>
         <Button
@@ -1226,7 +1265,7 @@ function ModelAliasItemCard({
           size="sm"
           onClick={() => onRemoveItem(item.id)}
         >
-          Remove
+          {t("settingsPage.common.remove")}
         </Button>
       </div>
     </div>
@@ -1243,10 +1282,12 @@ function ModelAliasesList({
   onRemoveItem,
   onUpdateItem,
 }: ModelAliasesListProps): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <div className="space-y-2">
       {items.length === 0 ? (
-        <div className="text-muted-foreground text-sm">No model aliases configured.</div>
+        <div className="text-muted-foreground text-sm">{t("settingsPage.aliases.emptyState")}</div>
       ) : (
         items.map((item) => (
           <ModelAliasItemCard
@@ -1263,7 +1304,7 @@ function ModelAliasesList({
       )}
 
       <Button type="button" variant="outline" size="sm" onClick={onAddItem}>
-        Add alias
+        {t("settingsPage.aliases.addButton")}
       </Button>
     </div>
   )
@@ -1285,13 +1326,14 @@ function ModelAliasesCard({
   const emptyTargetValue = "__target__"
   const allowOriginalDefaultValue = "__allow_original_default__"
   const hasModels = models.length > 0
+  const { t } = useTranslation()
 
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
-        <CardTitle>Model aliases</CardTitle>
+        <CardTitle>{t("settingsPage.aliases.title")}</CardTitle>
         <CardDescription className="hidden sm:block">
-          Map friendly alias names to upstream model IDs.
+          {t("settingsPage.aliases.description")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
@@ -1345,20 +1387,22 @@ function AdvancedSettingsCard({
   onToggleForceAgent,
   onToggleCompactUseSmallModel,
 }: AdvancedSettingsCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
-        <CardTitle>Advanced</CardTitle>
+        <CardTitle>{t("settingsPage.advanced.title")}</CardTitle>
         <CardDescription className="hidden sm:block">
-          Feature flags and experimental toggles.
+          {t("settingsPage.advanced.description")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4">
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Allow original model names</div>
+            <div className="text-sm font-medium">{t("settingsPage.advanced.allowOriginalModelNamesLabel")}</div>
             <div className="text-muted-foreground text-xs">
-              Default behavior when aliases do not override original model IDs.
+              {t("settingsPage.advanced.allowOriginalModelNamesHint")}
             </div>
           </div>
           <Switch
@@ -1369,9 +1413,9 @@ function AdvancedSettingsCard({
 
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Use function apply_patch</div>
+            <div className="text-sm font-medium">{t("settingsPage.advanced.useFunctionApplyPatchLabel")}</div>
             <div className="text-muted-foreground text-xs">
-              Enables function-level patches in responses routing.
+              {t("settingsPage.advanced.useFunctionApplyPatchHint")}
             </div>
           </div>
           <Switch checked={useFunctionApplyPatch} onCheckedChange={onToggleUseFunctionApplyPatch} />
@@ -1379,9 +1423,9 @@ function AdvancedSettingsCard({
 
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Force agent header</div>
+            <div className="text-sm font-medium">{t("settingsPage.advanced.forceAgentLabel")}</div>
             <div className="text-muted-foreground text-xs">
-              Forces agent routing logic even when clients omit hints.
+              {t("settingsPage.advanced.forceAgentHint")}
             </div>
           </div>
           <Switch checked={forceAgent} onCheckedChange={onToggleForceAgent} />
@@ -1389,9 +1433,9 @@ function AdvancedSettingsCard({
 
         <div className="flex items-center justify-between gap-4">
           <div className="space-y-1">
-            <div className="text-sm font-medium">Compact uses small model</div>
+            <div className="text-sm font-medium">{t("settingsPage.advanced.compactUseSmallModelLabel")}</div>
             <div className="text-muted-foreground text-xs">
-              When enabled, compact requests use the configured smallModel; otherwise they use the requested model.
+              {t("settingsPage.advanced.compactUseSmallModelHint")}
             </div>
           </div>
           <Switch
@@ -1462,6 +1506,8 @@ type SettingsPageViewProps = {
 }
 
 function useSettingsPageState(): SettingsPageViewProps {
+  const { t } = useTranslation()
+
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -1555,7 +1601,7 @@ function useSettingsPageState(): SettingsPageViewProps {
         setModels(modelsRes.value.items ?? [])
       } else {
         setModels([])
-        toast.error("Failed to load models", {
+        toast.error(i18n.t("settingsPage.toast.loadModelsFailed"), {
           description:
             modelsRes.reason instanceof Error ? modelsRes.reason.message : String(modelsRes.reason),
         })
@@ -1563,7 +1609,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
       setError(msg)
-      toast.error("Failed to load config", { description: msg })
+      toast.error(i18n.t("settingsPage.toast.loadConfigFailed"), { description: msg })
     } finally {
       setLoading(false)
     }
@@ -1580,11 +1626,11 @@ function useSettingsPageState(): SettingsPageViewProps {
     try {
       const updated = await updateAdminConfig(draft)
       applyConfigResponse(updated)
-      toast.success("Config saved")
+      toast.success(i18n.t("settingsPage.toast.configSaved"))
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
       setError(msg)
-      toast.error("Failed to save config", { description: msg })
+      toast.error(i18n.t("settingsPage.toast.saveConfigFailed"), { description: msg })
     } finally {
       setSaving(false)
     }
@@ -1666,10 +1712,13 @@ function useSettingsPageState(): SettingsPageViewProps {
     && !(reasoningMode === "json" && reasoningJsonIssue)
     && !(aliasMode === "json" && aliasJsonIssue)
 
-  const envOverrideNote =
-    "Environment variable COPILOT_API_KEY overrides this value when set."
+  const envOverrideNote = t("settingsPage.envOverrideNote", {
+    env: "COPILOT_API_KEY",
+  })
 
-  const smallModelLabel = hasModels ? "Small model" : "Small model (manual)"
+  const smallModelLabel = hasModels
+    ? t("settingsPage.general.smallModel")
+    : t("settingsPage.general.smallModelManual")
   const smallModelInputValue = draft.smallModel ?? ""
   const apiKeyValue = draft.apiKey ?? ""
 
@@ -1795,8 +1844,21 @@ function SettingsPageView({
   onForceAgentToggle,
   onCompactUseSmallModelToggle,
 }: SettingsPageViewProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const sections = useMemo<Array<SettingsSection>>(() => {
+    return [
+      { id: "general", label: t("settingsPage.sections.general") },
+      { id: "load-balancing", label: t("settingsPage.sections.loadBalancing") },
+      { id: "reasoning", label: t("settingsPage.sections.reasoning") },
+      { id: "aliases", label: t("settingsPage.sections.aliases") },
+      { id: "prompts", label: t("settingsPage.sections.prompts") },
+      { id: "advanced", label: t("settingsPage.sections.advanced") },
+    ]
+  }, [t])
+
   const { activeSection, registerSection, scrollToSection } = useActiveSection({
-    sectionIds: SETTINGS_SECTIONS.map((s) => s.id),
+    sectionIds: [...SETTINGS_SECTION_IDS],
   })
 
   return (
@@ -1804,10 +1866,8 @@ function SettingsPageView({
       {/* Page Header */}
       <div className="flex flex-wrap items-center gap-3">
         <div className="min-w-0">
-          <div className="text-lg font-semibold">Settings</div>
-          <div className="text-muted-foreground text-sm">
-            Manage config.json and apply updates instantly.
-          </div>
+          <div className="text-lg font-semibold">{t("nav.settings")}</div>
+          <div className="text-muted-foreground text-sm">{t("settingsPage.subtitle")}</div>
         </div>
 
         <div className="ml-auto flex flex-col items-end gap-1 text-right">
@@ -1819,16 +1879,16 @@ function SettingsPageView({
               onClick={onReload}
               disabled={loading || saving}
             >
-              {loading ? "Reloading..." : "Reload"}
+              {loading ? t("common.refreshing") : t("common.refresh")}
             </Button>
           </div>
           {configPath ? (
             <div className="text-muted-foreground text-xs leading-tight hidden sm:block">
-              Config path: {configPath}
+              {t("settingsPage.configPath", { path: configPath })}
             </div>
           ) : null}
           <div className="text-muted-foreground text-xs leading-tight hidden sm:block">
-            Changes apply to config.json immediately. Environment variables take precedence.
+            {t("settingsPage.note")}
           </div>
         </div>
       </div>
@@ -1836,9 +1896,9 @@ function SettingsPageView({
       {error ? (
         <InlineAlert
           variant="error"
-          title="Settings error"
+          title={t("settingsPage.errorTitle")}
           description={error}
-          actionLabel="Retry"
+          actionLabel={t("common.retry")}
           onAction={onReload}
         />
       ) : null}
@@ -1848,7 +1908,7 @@ function SettingsPageView({
         {/* Sidebar Navigation (desktop only) */}
         <aside className="hidden lg:block lg:col-span-2">
           <SettingsNavigation
-            sections={SETTINGS_SECTIONS}
+            sections={sections}
             activeSection={activeSection}
             onSectionClick={scrollToSection}
           />

--- a/admin-ui/tsconfig.app.json
+++ b/admin-ui/tsconfig.app.json
@@ -11,6 +11,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Add Admin UI i18n with `en-US` / `zh-CN`.
- Auto-detect browser locale with `en-US` fallback and persist preference in `localStorage`.
- Add header locale toggle and migrate UI copy to translation keys.

## Test plan
- [x] `bun run --cwd admin-ui typecheck`
- [x] `bun run --cwd admin-ui lint`
- [x] `bun run --cwd admin-ui build`
- [ ] Manual: switch locale in header; refresh; verify persistence + `<html lang>` updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 为管理界面添加完整国际化支持（en-US / zh-CN），引入运行时 i18n 并新增翻译资源。
  * 新增语言偏好提供者与页面级语言切换控件，选择会持久化并同步到页面语言属性。
  * 多个页面和组件（导航、JSON 查看器、设置页、令牌对话、主题/动效切换等）已本地化并更新无障碍标签。

* **其他**
  * 启用 JSON 模块导入以支持本地化资源文件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->