### PR TITLE
fix(admin-ui): improve admin token flow

### DIFF
--- a/admin-ui/src/components/token-dialog.tsx
+++ b/admin-ui/src/components/token-dialog.tsx
@@ -70,9 +70,7 @@ export function TokenDialog(): React.JSX.Element {
   function save(): void {
     setToken(draft)
     toast.success(
-      draft.trim()
-        ? t("tokenDialog.toast.tokenSavedForSession")
-        : t("tokenDialog.toast.tokenCleared")
+      draft.trim() ? t("tokenDialog.toast.tokenSaved") : t("tokenDialog.toast.tokenCleared")
     )
   }
 

--- a/admin-ui/src/components/token-dialog.tsx
+++ b/admin-ui/src/components/token-dialog.tsx
@@ -3,7 +3,12 @@ import { KeyRoundIcon } from "lucide-react"
 import { Trans, useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
-import { getAdminMeta, type AdminMeta, AdminApiError } from "@/lib/admin-api"
+import {
+  ADMIN_TOKEN_REQUIRED_EVENT,
+  AdminApiError,
+  getAdminMeta,
+  type AdminMeta,
+} from "@/lib/admin-api"
 import { useAdminToken } from "@/lib/admin-token"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -31,6 +36,19 @@ export function TokenDialog(): React.JSX.Element {
   const tokenStatus = token ? t("common.set") : t("common.unset")
 
   useEffect(() => {
+    if (typeof window === "undefined") return
+
+    function handleTokenRequired(): void {
+      setOpen(true)
+    }
+
+    window.addEventListener(ADMIN_TOKEN_REQUIRED_EVENT, handleTokenRequired)
+    return () => {
+      window.removeEventListener(ADMIN_TOKEN_REQUIRED_EVENT, handleTokenRequired)
+    }
+  }, [])
+
+  useEffect(() => {
     if (open) setDraft(token)
   }, [open, token])
 
@@ -38,7 +56,7 @@ export function TokenDialog(): React.JSX.Element {
     setTesting(true)
     setMeta(null)
     try {
-      const m = await getAdminMeta()
+      const m = await getAdminMeta(draft)
       setMeta(m)
       toast.success(t("tokenDialog.toast.adminApiOk"))
     } catch (err) {
@@ -84,7 +102,7 @@ export function TokenDialog(): React.JSX.Element {
           <DialogTitle>{t("tokenDialog.title")}</DialogTitle>
           <DialogDescription>
             <Trans i18nKey="tokenDialog.description">
-              Used as <code>x-admin-token</code> when calling <code>/api/admin/*</code>. Stored in <code>sessionStorage</code>.
+              Used as <code>x-admin-token</code> when calling <code>/api/admin/*</code>. Stored in <code>localStorage</code>.
             </Trans>
           </DialogDescription>
         </DialogHeader>

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -1,5 +1,7 @@
 import { readAdminToken } from "@/lib/admin-token"
 
+export const ADMIN_TOKEN_REQUIRED_EVENT = "admin-ui:admin-token-required"
+
 export type AdminMeta = {
   userVersion?: number
   dbPath?: string
@@ -125,8 +127,12 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-async function fetchAdminJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = readAdminToken()
+async function fetchAdminJson<T>(
+  path: string,
+  init?: RequestInit,
+  overrideToken?: string,
+): Promise<T> {
+  const token = overrideToken?.trim() ?? readAdminToken()
   const headers = new Headers(init?.headers ?? undefined)
 
   if (token) {
@@ -155,14 +161,20 @@ async function fetchAdminJson<T>(path: string, init?: RequestInit): Promise<T> {
       // ignore JSON parsing errors and keep raw text
     }
 
+    if (res.status === 401 || res.status === 403) {
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event(ADMIN_TOKEN_REQUIRED_EVENT))
+      }
+    }
+
     throw new AdminApiError(res.status, message)
   }
 
   return (await res.json()) as T
 }
 
-export async function getAdminMeta(): Promise<AdminMeta> {
-  return fetchAdminJson<AdminMeta>("/api/admin/meta")
+export async function getAdminMeta(overrideToken?: string): Promise<AdminMeta> {
+  return fetchAdminJson<AdminMeta>("/api/admin/meta", undefined, overrideToken)
 }
 
 export async function getAdminAccounts(params: {

--- a/admin-ui/src/lib/admin-token.tsx
+++ b/admin-ui/src/lib/admin-token.tsx
@@ -5,15 +5,19 @@ const ADMIN_TOKEN_STORAGE_KEY = "adminToken"
 export function readAdminToken(): string {
   if (typeof window === "undefined") return ""
 
-  const local = window.localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
-  if (local) return local
+  try {
+    const local = window.localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
+    if (local) return local
 
-  // One-time migration from legacy sessionStorage.
-  const legacy = window.sessionStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
-  if (legacy) {
-    window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, legacy)
-    window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
-    return legacy
+    // One-time migration from legacy sessionStorage.
+    const legacy = window.sessionStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
+    if (legacy) {
+      window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, legacy)
+      window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+      return legacy
+    }
+  } catch {
+    // Ignore Web Storage access errors (e.g. disabled storage).
   }
 
   return ""
@@ -22,15 +26,19 @@ export function readAdminToken(): string {
 export function writeAdminToken(token: string): void {
   if (typeof window === "undefined") return
 
-  const trimmed = token.trim()
-  if (trimmed) {
-    window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, trimmed)
-  } else {
-    window.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
-  }
+  try {
+    const trimmed = token.trim()
+    if (trimmed) {
+      window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, trimmed)
+    } else {
+      window.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+    }
 
-  // Cleanup legacy storage.
-  window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+    // Cleanup legacy storage.
+    window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+  } catch {
+    // Ignore Web Storage access errors (e.g. disabled storage).
+  }
 }
 
 type AdminTokenContextValue = {

--- a/admin-ui/src/lib/admin-token.tsx
+++ b/admin-ui/src/lib/admin-token.tsx
@@ -4,7 +4,19 @@ const ADMIN_TOKEN_STORAGE_KEY = "adminToken"
 
 export function readAdminToken(): string {
   if (typeof window === "undefined") return ""
-  return window.sessionStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
+
+  const local = window.localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
+  if (local) return local
+
+  // One-time migration from legacy sessionStorage.
+  const legacy = window.sessionStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) || ""
+  if (legacy) {
+    window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, legacy)
+    window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+    return legacy
+  }
+
+  return ""
 }
 
 export function writeAdminToken(token: string): void {
@@ -12,10 +24,13 @@ export function writeAdminToken(token: string): void {
 
   const trimmed = token.trim()
   if (trimmed) {
-    window.sessionStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, trimmed)
+    window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, trimmed)
   } else {
-    window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+    window.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
   }
+
+  // Cleanup legacy storage.
+  window.sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
 }
 
 type AdminTokenContextValue = {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -83,7 +83,7 @@
     "toast": {
       "adminApiOk": "Admin API access OK",
       "adminApiFailed": "Admin API access failed",
-      "tokenSavedForSession": "Token saved",
+      "tokenSaved": "Token saved",
       "tokenCleared": "Token cleared"
     }
   },

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -76,14 +76,14 @@
   "tokenDialog": {
     "trigger": "Token",
     "title": "Admin token",
-    "description": "Used as <1>x-admin-token</1> when calling <3>/api/admin/*</3>. Stored in <5>sessionStorage</5>.",
+    "description": "Used as <1>x-admin-token</1> when calling <3>/api/admin/*</3>. Stored in <5>localStorage</5>.",
     "inputPlaceholder": "Enter token",
     "remoteNote": "If the server is not running on localhost, you must set <1>ADMIN_TOKEN</1> on the server to enable remote access.",
     "connected": "Connected: DB v{{version}} · {{path}}",
     "toast": {
       "adminApiOk": "Admin API access OK",
       "adminApiFailed": "Admin API access failed",
-      "tokenSavedForSession": "Token saved for this session",
+      "tokenSavedForSession": "Token saved",
       "tokenCleared": "Token cleared"
     }
   },

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -76,14 +76,14 @@
   "tokenDialog": {
     "trigger": "Token",
     "title": "管理 Token",
-    "description": "调用 <3>/api/admin/*</3> 时会使用 <1>x-admin-token</1> 请求头。存储在 <5>sessionStorage</5> 中。",
+    "description": "调用 <3>/api/admin/*</3> 时会使用 <1>x-admin-token</1> 请求头。存储在 <5>localStorage</5> 中。",
     "inputPlaceholder": "输入 Token",
     "remoteNote": "如果服务端不在 localhost 运行，你必须在服务端设置 <1>ADMIN_TOKEN</1> 才能启用远程访问。",
     "connected": "已连接：DB v{{version}} · {{path}}",
     "toast": {
       "adminApiOk": "Admin API 访问正常",
       "adminApiFailed": "Admin API 访问失败",
-      "tokenSavedForSession": "Token 已在本会话保存",
+      "tokenSavedForSession": "Token 已保存",
       "tokenCleared": "Token 已清除"
     }
   },

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -83,7 +83,7 @@
     "toast": {
       "adminApiOk": "Admin API 访问正常",
       "adminApiFailed": "Admin API 访问失败",
-      "tokenSavedForSession": "Token 已保存",
+      "tokenSaved": "Token 已保存",
       "tokenCleared": "Token 已清除"
     }
   },


### PR DESCRIPTION
## Summary
- Auto-open Admin token dialog when Admin API returns 401/403
- Allow Test to validate the current draft token without requiring Save
- Persist `adminToken` in `localStorage` (with one-time migration from legacy `sessionStorage`)

## Test plan
- [ ] Clear token and load any admin page -> dialog opens automatically
- [ ] Enter token and click Test without Save -> shows validation result
- [ ] Save token and refresh -> token persists across sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **改进**
  * 管理令牌现在存储在本地存储，提供更持久的数据保存
  * 自动迁移旧会话存储中的令牌至本地存储，并清理旧数据

* **新特性**
  * 令牌对话框支持通过事件进行程序化打开，便于在不同场景触发输入

* **修正 / 文案**
  * 对话框描述与提示文本已更新为反映本地存储并显示“Token 已保存”/“Token saved”消息
<!-- end of auto-generated comment: release notes by coderabbit.ai -->