### PR TITLE
feat(admin-ui): add models page

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from "react-router-dom"
 
 import { AppShell } from "@/components/app-shell"
 import { AccountsPage } from "@/pages/accounts-page"
+import { ModelsPage } from "@/pages/models-page"
 import { NotFoundPage } from "@/pages/not-found-page"
 import { RequestDetailPage } from "@/pages/request-detail-page"
 import { RequestsPage } from "@/pages/requests-page"
@@ -14,6 +15,7 @@ export default function App(): React.JSX.Element {
         <Route path="/" element={<Navigate to="/accounts" replace />} />
         <Route path="/accounts" element={<AccountsPage />} />
         <Route path="/requests" element={<RequestsPage />} />
+        <Route path="/models" element={<ModelsPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/request/:requestId" element={<RequestDetailPage />} />
         <Route path="*" element={<NotFoundPage />} />

--- a/admin-ui/src/components/app-shell.tsx
+++ b/admin-ui/src/components/app-shell.tsx
@@ -42,6 +42,7 @@ function NavItem({
 const NAV_ITEMS = [
   { to: "/accounts", labelKey: "nav.accounts" },
   { to: "/requests", labelKey: "nav.requests" },
+  { to: "/models", labelKey: "nav.models" },
   { to: "/settings", labelKey: "nav.settings" },
 ] as const
 

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -111,6 +111,35 @@ export type AdminModelsResponse = {
   items: string[]
 }
 
+export type AdminModelDetailsItem = {
+  id: string
+  name: string
+  preview: boolean
+  billing?: {
+    is_premium?: boolean
+    multiplier?: number
+  }
+  supported_endpoints?: Array<string>
+  capabilities: {
+    limits: {
+      max_context_window_tokens?: number
+      max_output_tokens?: number
+    }
+    supports: {
+      tool_calls?: boolean
+      parallel_tool_calls?: boolean
+      structured_outputs?: boolean
+      streaming?: boolean
+      vision?: boolean
+    }
+  }
+  aliases: Array<string>
+}
+
+export type AdminModelsDetailsResponse = {
+  items: Array<AdminModelDetailsItem>
+}
+
 export class AdminApiError extends Error {
   readonly status: number
   readonly responseText: string
@@ -240,4 +269,8 @@ export async function updateAdminConfig(
 
 export async function getAdminModels(): Promise<AdminModelsResponse> {
   return fetchAdminJson<AdminModelsResponse>("/api/admin/models")
+}
+
+export async function getAdminModelDetails(): Promise<AdminModelsDetailsResponse> {
+  return fetchAdminJson<AdminModelsDetailsResponse>("/api/admin/models/details")
 }

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -123,6 +123,7 @@ export type AdminModelDetailsItem = {
   capabilities: {
     limits: {
       max_context_window_tokens?: number
+      max_prompt_tokens?: number
       max_output_tokens?: number
     }
     supports: {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -149,14 +149,15 @@
       "loadFailed": "Failed to load models"
     },
     "columns": {
-      "name": "Name",
+      "name": "Model",
       "endpoints": "Endpoints",
-      "originalId": "Original ID",
+      "originalId": "Model ID",
       "aliases": "Aliases",
       "context": "Context",
       "features": "Features",
       "multiplier": "Multiplier"
     },
+    "contextTooltip": "↓ Max input tokens: {{input}} | ↑ Max output tokens: {{output}}",
     "badges": {
       "preview": "preview",
       "premium": "premium"

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -10,6 +10,7 @@
   "nav": {
     "accounts": "Accounts",
     "requests": "Requests",
+    "models": "Models",
     "settings": "Settings",
     "openNavigation": "Open navigation"
   },
@@ -137,6 +138,39 @@
       "noRequestsTitle": "No requests",
       "noResultsForFilters": "No results for the current filters.",
       "noRequestsFound": "No requests found."
+    }
+  },
+  "modelsPage": {
+    "title": "Models",
+    "description": "View available models and their metadata.",
+    "totalCount": "{{count}} models",
+    "loadFailedTitle": "Failed to load models",
+    "toast": {
+      "loadFailed": "Failed to load models"
+    },
+    "columns": {
+      "name": "Name",
+      "endpoints": "Endpoints",
+      "originalId": "Original ID",
+      "aliases": "Aliases",
+      "context": "Context",
+      "features": "Features",
+      "multiplier": "Multiplier"
+    },
+    "badges": {
+      "preview": "preview",
+      "premium": "premium"
+    },
+    "features": {
+      "tools": "tools",
+      "vision": "vision",
+      "structuredOutputs": "structured",
+      "streaming": "streaming",
+      "parallelTools": "parallel tools"
+    },
+    "empty": {
+      "title": "No models",
+      "description": "No models found."
     }
   },
   "requestDetailPage": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -10,6 +10,7 @@
   "nav": {
     "accounts": "账号",
     "requests": "请求",
+    "models": "模型",
     "settings": "设置",
     "openNavigation": "打开导航"
   },
@@ -137,6 +138,39 @@
       "noRequestsTitle": "无请求",
       "noResultsForFilters": "当前筛选条件下没有结果。",
       "noRequestsFound": "未找到请求。"
+    }
+  },
+  "modelsPage": {
+    "title": "模型",
+    "description": "查看当前可用模型及其元数据。",
+    "totalCount": "共 {{count}} 个模型",
+    "loadFailedTitle": "加载模型失败",
+    "toast": {
+      "loadFailed": "加载模型失败"
+    },
+    "columns": {
+      "name": "名称",
+      "endpoints": "端点",
+      "originalId": "原始 ID",
+      "aliases": "别名",
+      "context": "上下文大小",
+      "features": "功能",
+      "multiplier": "乘数"
+    },
+    "badges": {
+      "preview": "预览",
+      "premium": "高级"
+    },
+    "features": {
+      "tools": "工具",
+      "vision": "视觉",
+      "structuredOutputs": "结构化",
+      "streaming": "流式",
+      "parallelTools": "并行工具"
+    },
+    "empty": {
+      "title": "无模型",
+      "description": "未找到模型。"
     }
   },
   "requestDetailPage": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -149,14 +149,15 @@
       "loadFailed": "加载模型失败"
     },
     "columns": {
-      "name": "名称",
+      "name": "模型",
       "endpoints": "端点",
-      "originalId": "原始 ID",
+      "originalId": "模型ID",
       "aliases": "别名",
       "context": "上下文大小",
       "features": "功能",
       "multiplier": "乘数"
     },
+    "contextTooltip": "↓ 最大输入令牌数：{{input}} | ↑ 最大输出令牌数：{{output}}",
     "badges": {
       "preview": "预览",
       "premium": "高级"

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -40,6 +40,8 @@ type SortKey =
   | "features"
   | "multiplier"
 
+type SortState = { key: SortKey | null; dir: SortDir }
+
 function fmtTokensCompact(n?: number): string {
   if (n == null) return ""
   if (!Number.isFinite(n) || n <= 0) return ""
@@ -295,18 +297,19 @@ export function ModelsPage(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [models, setModels] = useState<AdminModelDetailsItem[]>([])
 
-  const [sortKey, setSortKey] = useState<SortKey | null>(null)
-  const [sortDir, setSortDir] = useState<SortDir>("asc")
+  const [sortState, setSortState] = useState<SortState>({
+    key: null,
+    dir: "asc",
+  })
+  const { key: sortKey, dir: sortDir } = sortState
 
   const onSort = useCallback((key: SortKey) => {
-    setSortKey((prevKey) => {
-      if (prevKey === key) {
-        setSortDir((prevDir) => (prevDir === "asc" ? "desc" : "asc"))
-        return prevKey
+    setSortState((prev) => {
+      if (prev.key === key) {
+        return { key: prev.key, dir: prev.dir === "asc" ? "desc" : "asc" }
       }
 
-      setSortDir("asc")
-      return key
+      return { key, dir: "asc" }
     })
   }, [])
 
@@ -359,7 +362,7 @@ export function ModelsPage(): React.JSX.Element {
       }
 
       if (cmp !== 0) return cmp
-      return compareMaybeString(a.id, b.id, sortDir)
+      return a.id.localeCompare(b.id)
     })
   }, [models, sortDir, sortKey])
 

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -129,7 +129,11 @@ function SortableTableHead({
   className?: string
 }): React.JSX.Element {
   const isActive = sortKey === columnKey
-  const ariaSort = isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none"
+
+  let ariaSort: "ascending" | "descending" | "none" = "none"
+  if (isActive) {
+    ariaSort = sortDir === "asc" ? "ascending" : "descending"
+  }
 
   return (
     <TableHead aria-sort={ariaSort} className={className}>
@@ -458,9 +462,8 @@ export function ModelsPage(): React.JSX.Element {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {loading && models.length === 0 ? (
-                <ModelsTableSkeleton rows={10} />
-              ) : models.length === 0 ? (
+              {loading && models.length === 0 && <ModelsTableSkeleton rows={10} />}
+              {!loading && models.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={modelsTableColVisibility.length}>
                     <InlineAlert
@@ -470,7 +473,8 @@ export function ModelsPage(): React.JSX.Element {
                     />
                   </TableCell>
                 </TableRow>
-              ) : (
+              )}
+              {models.length > 0 &&
                 sortedModels.map((model) => (
                   <TableRow key={model.id}>
                     <TableCell>
@@ -506,8 +510,7 @@ export function ModelsPage(): React.JSX.Element {
                       <MultiplierCell billing={model.billing} />
                     </TableCell>
                   </TableRow>
-                ))
-              )}
+                ))}
             </TableBody>
           </Table>
         </CardContent>

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
@@ -28,21 +28,122 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
-const modelsTableColVisibility = [
-  null,
-  null,
-  null,
-  null,
-  null,
-  null,
-  null,
-] as const
+const modelsTableColVisibility = [null, null, null, null, null, null] as const
+
+type SortDir = "asc" | "desc"
+
+type SortKey =
+  | "name"
+  | "endpoints"
+  | "originalId"
+  | "context"
+  | "features"
+  | "multiplier"
 
 function fmtTokensCompact(n?: number): string {
   if (n == null) return ""
   if (!Number.isFinite(n) || n <= 0) return ""
   if (n >= 1000) return `${Math.floor(n / 1000)}K`
   return String(Math.floor(n))
+}
+
+function fmtTokensRaw(n?: number): string {
+  if (n == null) return "—"
+  if (!Number.isFinite(n) || n <= 0) return "—"
+  return String(Math.floor(n))
+}
+
+function compareMaybeString(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  dir: SortDir,
+): number {
+  const aVal = a?.trim()
+  const bVal = b?.trim()
+
+  if (!aVal && !bVal) return 0
+  if (!aVal) return 1
+  if (!bVal) return -1
+
+  const cmp = aVal.toLowerCase().localeCompare(bVal.toLowerCase())
+  return dir === "asc" ? cmp : -cmp
+}
+
+function compareMaybeNumber(
+  a: number | null | undefined,
+  b: number | null | undefined,
+  dir: SortDir,
+): number {
+  const aVal = typeof a === "number" && Number.isFinite(a) ? a : null
+  const bVal = typeof b === "number" && Number.isFinite(b) ? b : null
+
+  if (aVal == null && bVal == null) return 0
+  if (aVal == null) return 1
+  if (bVal == null) return -1
+
+  const cmp = aVal - bVal
+  if (cmp === 0) return 0
+  return dir === "asc" ? cmp : -cmp
+}
+
+function makeListSortKey(values: Array<string> | null | undefined): string | null {
+  if (!values || values.length === 0) return null
+
+  const out = values
+    .map((v) => v.trim().toLowerCase())
+    .filter((v) => v.length > 0)
+    .sort()
+
+  return out.length > 0 ? out.join("|") : null
+}
+
+function makeFeaturesSortKey(
+  supports: AdminModelDetailsItem["capabilities"]["supports"],
+): string | null {
+  const out: Array<string> = []
+
+  if (supports.tool_calls) out.push("tool_calls")
+  if (supports.vision) out.push("vision")
+  if (supports.structured_outputs) out.push("structured_outputs")
+  if (supports.streaming) out.push("streaming")
+  if (supports.parallel_tool_calls) out.push("parallel_tool_calls")
+
+  return out.length > 0 ? out.join("|") : null
+}
+
+function SortableTableHead({
+  columnKey,
+  label,
+  sortKey,
+  sortDir,
+  onSort,
+  className,
+}: {
+  columnKey: SortKey
+  label: string
+  sortKey: SortKey | null
+  sortDir: SortDir
+  onSort: (key: SortKey) => void
+  className?: string
+}): React.JSX.Element {
+  const isActive = sortKey === columnKey
+  const ariaSort = isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none"
+
+  return (
+    <TableHead aria-sort={ariaSort} className={className}>
+      <button
+        type="button"
+        onClick={() => onSort(columnKey)}
+        className={cn(
+          "flex w-full cursor-pointer select-none items-center gap-1 text-left",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        )}
+      >
+        <span>{label}</span>
+        {isActive ? <span className="text-muted-foreground">{sortDir === "asc" ? "↑" : "↓"}</span> : null}
+      </button>
+    </TableHead>
+  )
 }
 
 function ModelsTableSkeleton({ rows }: { rows: number }): React.JSX.Element {
@@ -133,36 +234,32 @@ function EndpointBadges({
   )
 }
 
-function AliasBadges({ aliases }: { aliases: string[] }): React.JSX.Element {
-  if (aliases.length === 0) {
-    return <span className="text-muted-foreground">—</span>
-  }
-
-  return (
-    <div className="flex flex-wrap gap-1 whitespace-normal">
-      {aliases.map((alias) => (
-        <Badge key={alias} variant="outline" className="font-mono text-xs">
-          {alias}
-        </Badge>
-      ))}
-    </div>
-  )
-}
 
 function ContextCell({
   limits,
 }: {
   limits: AdminModelDetailsItem["capabilities"]["limits"]
 }): React.JSX.Element {
-  const ctx = fmtTokensCompact(limits.max_context_window_tokens)
-  const out = fmtTokensCompact(limits.max_output_tokens)
+  const { t } = useTranslation()
+
+  const inputCompact = fmtTokensCompact(limits.max_prompt_tokens)
+  const outputCompact = fmtTokensCompact(limits.max_output_tokens)
+
+  const tooltip = t("modelsPage.contextTooltip", {
+    input: fmtTokensRaw(limits.max_prompt_tokens),
+    output: fmtTokensRaw(limits.max_output_tokens),
+  })
 
   return (
-    <div className="flex items-center gap-3 tabular-nums">
+    <div
+      title={tooltip}
+      aria-label={tooltip}
+      className="flex items-center gap-3 tabular-nums cursor-help"
+    >
       <span className="text-muted-foreground">↓</span>
-      <span>{ctx || "—"}</span>
+      <span>{inputCompact || "—"}</span>
       <span className="text-muted-foreground">↑</span>
-      <span>{out || "—"}</span>
+      <span>{outputCompact || "—"}</span>
     </div>
   )
 }
@@ -197,6 +294,74 @@ export function ModelsPage(): React.JSX.Element {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [models, setModels] = useState<AdminModelDetailsItem[]>([])
+
+  const [sortKey, setSortKey] = useState<SortKey | null>(null)
+  const [sortDir, setSortDir] = useState<SortDir>("asc")
+
+  const onSort = useCallback((key: SortKey) => {
+    setSortKey((prevKey) => {
+      if (prevKey === key) {
+        setSortDir((prevDir) => (prevDir === "asc" ? "desc" : "asc"))
+        return prevKey
+      }
+
+      setSortDir("asc")
+      return key
+    })
+  }, [])
+
+  const sortedModels = useMemo(() => {
+    if (!sortKey) return models
+
+    return [...models].sort((a, b) => {
+      let cmp = 0
+
+      switch (sortKey) {
+        case "name":
+          cmp = compareMaybeString(a.name, b.name, sortDir)
+          break
+        case "endpoints":
+          cmp = compareMaybeString(
+            makeListSortKey(a.supported_endpoints),
+            makeListSortKey(b.supported_endpoints),
+            sortDir,
+          )
+          break
+        case "originalId":
+          cmp = compareMaybeString(a.id, b.id, sortDir)
+          break
+        case "context":
+          cmp = compareMaybeNumber(
+            a.capabilities.limits.max_prompt_tokens,
+            b.capabilities.limits.max_prompt_tokens,
+            sortDir,
+          )
+          if (cmp === 0) {
+            cmp = compareMaybeNumber(
+              a.capabilities.limits.max_output_tokens,
+              b.capabilities.limits.max_output_tokens,
+              sortDir,
+            )
+          }
+          break
+        case "features":
+          cmp = compareMaybeString(
+            makeFeaturesSortKey(a.capabilities.supports),
+            makeFeaturesSortKey(b.capabilities.supports),
+            sortDir,
+          )
+          break
+        case "multiplier":
+          cmp = compareMaybeNumber(a.billing?.multiplier, b.billing?.multiplier, sortDir)
+          break
+        default:
+          cmp = 0
+      }
+
+      if (cmp !== 0) return cmp
+      return compareMaybeString(a.id, b.id, sortDir)
+    })
+  }, [models, sortDir, sortKey])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -243,19 +408,50 @@ export function ModelsPage(): React.JSX.Element {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t("modelsPage.columns.name")}</TableHead>
-                <TableHead className={cn(modelsTableColVisibility[1])}>
-                  {t("modelsPage.columns.endpoints")}
-                </TableHead>
-                <TableHead className={cn(modelsTableColVisibility[2])}>
-                  {t("modelsPage.columns.originalId")}
-                </TableHead>
-                <TableHead className={cn(modelsTableColVisibility[3])}>
-                  {t("modelsPage.columns.aliases")}
-                </TableHead>
-                <TableHead>{t("modelsPage.columns.context")}</TableHead>
-                <TableHead>{t("modelsPage.columns.features")}</TableHead>
-                <TableHead>{t("modelsPage.columns.multiplier")}</TableHead>
+                <SortableTableHead
+                  columnKey="name"
+                  label={t("modelsPage.columns.name")}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableTableHead
+                  columnKey="endpoints"
+                  label={t("modelsPage.columns.endpoints")}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                  className={cn(modelsTableColVisibility[1])}
+                />
+                <SortableTableHead
+                  columnKey="originalId"
+                  label={t("modelsPage.columns.originalId")}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                  className={cn(modelsTableColVisibility[2])}
+                />
+                <SortableTableHead
+                  columnKey="context"
+                  label={t("modelsPage.columns.context")}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableTableHead
+                  columnKey="features"
+                  label={t("modelsPage.columns.features")}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableTableHead
+                  columnKey="multiplier"
+                  label={t("modelsPage.columns.multiplier")}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -272,7 +468,7 @@ export function ModelsPage(): React.JSX.Element {
                   </TableCell>
                 </TableRow>
               ) : (
-                models.map((model) => (
+                sortedModels.map((model) => (
                   <TableRow key={model.id}>
                     <TableCell>
                       <div className="flex items-center gap-2">
@@ -287,11 +483,15 @@ export function ModelsPage(): React.JSX.Element {
                     <TableCell className={cn(modelsTableColVisibility[1], "max-w-[26rem]")}>
                       <EndpointBadges endpoints={model.supported_endpoints} />
                     </TableCell>
-                    <TableCell className={cn(modelsTableColVisibility[2], "font-mono text-xs")}>
-                      {model.id}
-                    </TableCell>
-                    <TableCell className={cn(modelsTableColVisibility[3], "max-w-[18rem]")}>
-                      <AliasBadges aliases={model.aliases} />
+                    <TableCell className={cn(modelsTableColVisibility[2], "max-w-[26rem]")}>
+                      <div className="flex flex-wrap items-center gap-1 whitespace-normal">
+                        <span className="font-mono text-xs">{model.id}</span>
+                        {model.aliases.map((alias) => (
+                          <Badge key={alias} variant="outline" className="font-mono text-xs">
+                            {alias}
+                          </Badge>
+                        ))}
+                      </div>
                     </TableCell>
                     <TableCell>
                       <ContextCell limits={model.capabilities.limits} />

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+
+import {
+  AdminApiError,
+  type AdminModelDetailsItem,
+  getAdminModelDetails,
+} from "@/lib/admin-api"
+import { i18n } from "@/lib/i18n"
+import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
+import { InlineAlert } from "@/components/ui/inline-alert"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+const modelsTableColVisibility = [
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+] as const
+
+function fmtTokensCompact(n?: number): string {
+  if (n == null) return ""
+  if (!Number.isFinite(n) || n <= 0) return ""
+  if (n >= 1000) return `${Math.floor(n / 1000)}K`
+  return String(Math.floor(n))
+}
+
+function ModelsTableSkeleton({ rows }: { rows: number }): React.JSX.Element {
+  const cols = modelsTableColVisibility.length
+
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, i) => (
+        <TableRow key={i}>
+          {Array.from({ length: cols }).map((__, j) => (
+            <TableCell key={j} className={cn("py-3", modelsTableColVisibility[j])}>
+              <Skeleton className={j === 0 ? "h-4 w-48" : "h-4 w-28"} />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  )
+}
+
+function FeatureBadges({
+  supports,
+}: {
+  supports: AdminModelDetailsItem["capabilities"]["supports"]
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const features: Array<{ key: string; label: string }> = []
+
+  if (supports.tool_calls) {
+    features.push({ key: "tool_calls", label: t("modelsPage.features.tools") })
+  }
+
+  if (supports.vision) {
+    features.push({ key: "vision", label: t("modelsPage.features.vision") })
+  }
+
+  if (supports.structured_outputs) {
+    features.push({
+      key: "structured_outputs",
+      label: t("modelsPage.features.structuredOutputs"),
+    })
+  }
+
+  if (supports.streaming) {
+    features.push({ key: "streaming", label: t("modelsPage.features.streaming") })
+  }
+
+  if (supports.parallel_tool_calls) {
+    features.push({
+      key: "parallel_tool_calls",
+      label: t("modelsPage.features.parallelTools"),
+    })
+  }
+
+  if (features.length === 0) {
+    return <span className="text-muted-foreground">—</span>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1 whitespace-normal">
+      {features.map((f) => (
+        <Badge key={f.key} variant="outline" className="text-xs">
+          {f.label}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+function EndpointBadges({
+  endpoints,
+}: {
+  endpoints: AdminModelDetailsItem["supported_endpoints"]
+}): React.JSX.Element {
+  if (!endpoints || endpoints.length === 0) {
+    return <span className="text-muted-foreground">—</span>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1 whitespace-normal">
+      {endpoints.map((ep) => (
+        <Badge key={ep} variant="secondary" className="font-mono text-xs">
+          {ep}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+function AliasBadges({ aliases }: { aliases: string[] }): React.JSX.Element {
+  if (aliases.length === 0) {
+    return <span className="text-muted-foreground">—</span>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1 whitespace-normal">
+      {aliases.map((alias) => (
+        <Badge key={alias} variant="outline" className="font-mono text-xs">
+          {alias}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+function ContextCell({
+  limits,
+}: {
+  limits: AdminModelDetailsItem["capabilities"]["limits"]
+}): React.JSX.Element {
+  const ctx = fmtTokensCompact(limits.max_context_window_tokens)
+  const out = fmtTokensCompact(limits.max_output_tokens)
+
+  return (
+    <div className="flex items-center gap-3 tabular-nums">
+      <span className="text-muted-foreground">↓</span>
+      <span>{ctx || "—"}</span>
+      <span className="text-muted-foreground">↑</span>
+      <span>{out || "—"}</span>
+    </div>
+  )
+}
+
+function MultiplierCell({
+  billing,
+}: {
+  billing: AdminModelDetailsItem["billing"]
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const mult = billing?.multiplier
+  if (mult == null) {
+    return <span className="text-muted-foreground">—</span>
+  }
+
+  return (
+    <div className="flex items-center gap-2 tabular-nums">
+      <span>{mult}x</span>
+      {billing?.is_premium ? (
+        <Badge variant="default" className="text-xs">
+          {t("modelsPage.badges.premium")}
+        </Badge>
+      ) : null}
+    </div>
+  )
+}
+
+export function ModelsPage(): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [models, setModels] = useState<AdminModelDetailsItem[]>([])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await getAdminModelDetails()
+      setModels(res.items)
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      setError(msg)
+      toast.error(i18n.t("modelsPage.toast.loadFailed"), { description: msg })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <InlineAlert
+          variant="error"
+          title={t("modelsPage.loadFailedTitle")}
+          description={error}
+          actionLabel={t("common.retry")}
+          onAction={() => void load()}
+        />
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("modelsPage.title")}</CardTitle>
+          <CardDescription>{t("modelsPage.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="text-muted-foreground text-sm">
+            {t("modelsPage.totalCount", { count: models.length })}
+          </div>
+
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("modelsPage.columns.name")}</TableHead>
+                <TableHead className={cn(modelsTableColVisibility[1])}>
+                  {t("modelsPage.columns.endpoints")}
+                </TableHead>
+                <TableHead className={cn(modelsTableColVisibility[2])}>
+                  {t("modelsPage.columns.originalId")}
+                </TableHead>
+                <TableHead className={cn(modelsTableColVisibility[3])}>
+                  {t("modelsPage.columns.aliases")}
+                </TableHead>
+                <TableHead>{t("modelsPage.columns.context")}</TableHead>
+                <TableHead>{t("modelsPage.columns.features")}</TableHead>
+                <TableHead>{t("modelsPage.columns.multiplier")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading && models.length === 0 ? (
+                <ModelsTableSkeleton rows={10} />
+              ) : models.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={modelsTableColVisibility.length}>
+                    <InlineAlert
+                      variant="info"
+                      title={t("modelsPage.empty.title")}
+                      description={t("modelsPage.empty.description")}
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : (
+                models.map((model) => (
+                  <TableRow key={model.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span>{model.name}</span>
+                        {model.preview ? (
+                          <Badge variant="outline" className="text-xs">
+                            {t("modelsPage.badges.preview")}
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                    <TableCell className={cn(modelsTableColVisibility[1], "max-w-[26rem]")}>
+                      <EndpointBadges endpoints={model.supported_endpoints} />
+                    </TableCell>
+                    <TableCell className={cn(modelsTableColVisibility[2], "font-mono text-xs")}>
+                      {model.id}
+                    </TableCell>
+                    <TableCell className={cn(modelsTableColVisibility[3], "max-w-[18rem]")}>
+                      <AliasBadges aliases={model.aliases} />
+                    </TableCell>
+                    <TableCell>
+                      <ContextCell limits={model.capabilities.limits} />
+                    </TableCell>
+                    <TableCell>
+                      <FeatureBadges supports={model.capabilities.supports} />
+                    </TableCell>
+                    <TableCell>
+                      <MultiplierCell billing={model.billing} />
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -291,7 +291,7 @@ function MultiplierCell({
 export function ModelsPage(): React.JSX.Element {
   const { t } = useTranslation()
 
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [models, setModels] = useState<AdminModelDetailsItem[]>([])
 

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -773,10 +773,17 @@ adminApiRoutes.get("/models/details", (c) => {
       rawModels.push(...(accountModels.data as Array<unknown>))
     }
 
-    const items = rawModels
-      .map((raw) => parseAdminModelDetailsItem(raw, aliasesByTarget))
-      .filter((item): item is AdminModelDetailsItem => item !== null)
-      .sort((a, b) => a.id.localeCompare(b.id))
+    const itemsById = new Map<string, AdminModelDetailsItem>()
+    for (const raw of rawModels) {
+      const item = parseAdminModelDetailsItem(raw, aliasesByTarget)
+      if (!item) continue
+      if (itemsById.has(item.id)) continue
+      itemsById.set(item.id, item)
+    }
+
+    const items = Array.from(itemsById.values()).sort((a, b) =>
+      a.id.localeCompare(b.id),
+    )
 
     return c.json({ items })
   } catch (error) {

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -7,6 +7,7 @@ import { listAccountsFromRegistry } from "~/lib/accounts-registry"
 import {
   getConfig,
   getModelAliases,
+  getModelAliasesInfo,
   isFreeModelLoadBalancingEnabled,
   mergeConfigWithDefaults,
   type AppConfig,
@@ -620,6 +621,98 @@ adminApiRoutes.get("/models", (c) => {
   } catch {
     return jsonError(c, 500, {
       message: "Failed to load models.",
+      type: "internal_error",
+    })
+  }
+})
+
+type AdminModelDetailsItem = {
+  id: string
+  name: string
+  preview: boolean
+  billing?: {
+    is_premium?: boolean
+    multiplier?: number
+  }
+  supported_endpoints?: Array<string>
+  capabilities: {
+    limits: {
+      max_context_window_tokens?: number
+      max_output_tokens?: number
+    }
+    supports: {
+      tool_calls?: boolean
+      parallel_tool_calls?: boolean
+      structured_outputs?: boolean
+      streaming?: boolean
+      vision?: boolean
+    }
+  }
+  aliases: Array<string>
+}
+
+type AdminModelsDetailsResponse = {
+  items: Array<AdminModelDetailsItem>
+}
+
+adminApiRoutes.get("/models/details", (c) => {
+  try {
+    const accountModels = accountsManager.getFirstAccountModels()
+    const aliasInfo = getModelAliasesInfo()
+
+    const aliasesByTarget = new Map<string, Array<string>>()
+    for (const [alias, spec] of Object.entries(aliasInfo)) {
+      const targetKey = spec.target.toLowerCase()
+      const current = aliasesByTarget.get(targetKey)
+      if (current) {
+        current.push(alias)
+      } else {
+        aliasesByTarget.set(targetKey, [alias])
+      }
+    }
+
+    for (const arr of aliasesByTarget.values()) {
+      arr.sort()
+    }
+
+    const items: AdminModelsDetailsResponse["items"] =
+      accountModels?.data
+        .filter(
+          (model) => typeof model.id === "string" && model.id.trim().length > 0,
+        )
+        .map((model) => {
+          const aliases = aliasesByTarget.get(model.id.toLowerCase()) ?? []
+          return {
+            id: model.id,
+            name: model.name,
+            preview: model.preview,
+            billing: model.billing,
+            supported_endpoints: model.supported_endpoints,
+            capabilities: {
+              limits: {
+                max_context_window_tokens:
+                  model.capabilities.limits.max_context_window_tokens,
+                max_output_tokens: model.capabilities.limits.max_output_tokens,
+              },
+              supports: {
+                tool_calls: model.capabilities.supports.tool_calls,
+                parallel_tool_calls:
+                  model.capabilities.supports.parallel_tool_calls,
+                structured_outputs:
+                  model.capabilities.supports.structured_outputs,
+                streaming: model.capabilities.supports.streaming,
+                vision: model.capabilities.supports.vision,
+              },
+            },
+            aliases,
+          } satisfies AdminModelDetailsItem
+        })
+        .sort((a, b) => a.id.localeCompare(b.id)) ?? []
+
+    return c.json({ items })
+  } catch {
+    return jsonError(c, 500, {
+      message: "Failed to load model details.",
       type: "internal_error",
     })
   }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -651,8 +651,97 @@ type AdminModelDetailsItem = {
   aliases: Array<string>
 }
 
-type AdminModelsDetailsResponse = {
-  items: Array<AdminModelDetailsItem>
+function parseNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseOptionalFiniteNumber(value: unknown): number | undefined {
+  if (typeof value !== "number") return undefined
+  return Number.isFinite(value) ? value : undefined
+}
+
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function parseStringArray(value: unknown): Array<string> | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const out = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+
+  return out.length > 0 ? out : undefined
+}
+
+function parseBilling(value: unknown): AdminModelDetailsItem["billing"] {
+  if (!isPlainObject(value)) return undefined
+
+  const multiplier = parseOptionalFiniteNumber(value.multiplier)
+  const is_premium = parseOptionalBoolean(value.is_premium)
+
+  if (multiplier === undefined && is_premium === undefined) return undefined
+  return { multiplier, is_premium }
+}
+
+function parseCapabilities(
+  value: unknown,
+): AdminModelDetailsItem["capabilities"] {
+  if (!isPlainObject(value)) {
+    return {
+      limits: {},
+      supports: {},
+    }
+  }
+
+  const limitsRaw = isPlainObject(value.limits) ? value.limits : undefined
+  const supportsRaw = isPlainObject(value.supports) ? value.supports : undefined
+
+  return {
+    limits: {
+      max_context_window_tokens: parseOptionalFiniteNumber(
+        limitsRaw?.max_context_window_tokens,
+      ),
+      max_output_tokens: parseOptionalFiniteNumber(
+        limitsRaw?.max_output_tokens,
+      ),
+    },
+    supports: {
+      tool_calls: parseOptionalBoolean(supportsRaw?.tool_calls),
+      parallel_tool_calls: parseOptionalBoolean(
+        supportsRaw?.parallel_tool_calls,
+      ),
+      structured_outputs: parseOptionalBoolean(supportsRaw?.structured_outputs),
+      streaming: parseOptionalBoolean(supportsRaw?.streaming),
+      vision: parseOptionalBoolean(supportsRaw?.vision),
+    },
+  }
+}
+
+function parseAdminModelDetailsItem(
+  raw: unknown,
+  aliasesByTarget: Map<string, Array<string>>,
+): AdminModelDetailsItem | null {
+  if (!isPlainObject(raw)) return null
+
+  const id = parseNonEmptyString(raw.id)
+  if (!id) return null
+
+  const name = parseNonEmptyString(raw.name) ?? id
+  const preview = parseOptionalBoolean(raw.preview) ?? false
+
+  return {
+    id,
+    name,
+    preview,
+    billing: parseBilling(raw.billing),
+    supported_endpoints: parseStringArray(raw.supported_endpoints),
+    capabilities: parseCapabilities(raw.capabilities),
+    aliases: aliasesByTarget.get(id.toLowerCase()) ?? [],
+  }
 }
 
 adminApiRoutes.get("/models/details", (c) => {
@@ -671,46 +760,23 @@ adminApiRoutes.get("/models/details", (c) => {
       }
     }
 
-    for (const arr of aliasesByTarget.values()) {
-      arr.sort()
+    for (const aliases of aliasesByTarget.values()) {
+      aliases.sort()
     }
 
-    const items: AdminModelsDetailsResponse["items"] =
-      accountModels?.data
-        .filter(
-          (model) => typeof model.id === "string" && model.id.trim().length > 0,
-        )
-        .map((model) => {
-          const aliases = aliasesByTarget.get(model.id.toLowerCase()) ?? []
-          return {
-            id: model.id,
-            name: model.name,
-            preview: model.preview,
-            billing: model.billing,
-            supported_endpoints: model.supported_endpoints,
-            capabilities: {
-              limits: {
-                max_context_window_tokens:
-                  model.capabilities.limits.max_context_window_tokens,
-                max_output_tokens: model.capabilities.limits.max_output_tokens,
-              },
-              supports: {
-                tool_calls: model.capabilities.supports.tool_calls,
-                parallel_tool_calls:
-                  model.capabilities.supports.parallel_tool_calls,
-                structured_outputs:
-                  model.capabilities.supports.structured_outputs,
-                streaming: model.capabilities.supports.streaming,
-                vision: model.capabilities.supports.vision,
-              },
-            },
-            aliases,
-          } satisfies AdminModelDetailsItem
-        })
-        .sort((a, b) => a.id.localeCompare(b.id)) ?? []
+    const rawModels: Array<unknown> = []
+    if (Array.isArray(accountModels?.data)) {
+      rawModels.push(...(accountModels.data as Array<unknown>))
+    }
+
+    const items = rawModels
+      .map((raw) => parseAdminModelDetailsItem(raw, aliasesByTarget))
+      .filter((item): item is AdminModelDetailsItem => item !== null)
+      .sort((a, b) => a.id.localeCompare(b.id))
 
     return c.json({ items })
-  } catch {
+  } catch (error) {
+    console.error("Failed to load model details.", error)
     return jsonError(c, 500, {
       message: "Failed to load model details.",
       type: "internal_error",

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -638,6 +638,7 @@ type AdminModelDetailsItem = {
   capabilities: {
     limits: {
       max_context_window_tokens?: number
+      max_prompt_tokens?: number
       max_output_tokens?: number
     }
     supports: {
@@ -704,6 +705,9 @@ function parseCapabilities(
     limits: {
       max_context_window_tokens: parseOptionalFiniteNumber(
         limitsRaw?.max_context_window_tokens,
+      ),
+      max_prompt_tokens: parseOptionalFiniteNumber(
+        limitsRaw?.max_prompt_tokens,
       ),
       max_output_tokens: parseOptionalFiniteNumber(
         limitsRaw?.max_output_tokens,

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -663,7 +663,7 @@ function parseOptionalFiniteNumber(value: unknown): number | undefined {
   return Number.isFinite(value) ? value : undefined
 }
 
-function parseOptionalBoolean(value: unknown): boolean | undefined {
+function toBooleanOrUndefined(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined
 }
 
@@ -682,7 +682,7 @@ function parseBilling(value: unknown): AdminModelDetailsItem["billing"] {
   if (!isPlainObject(value)) return undefined
 
   const multiplier = parseOptionalFiniteNumber(value.multiplier)
-  const is_premium = parseOptionalBoolean(value.is_premium)
+  const is_premium = toBooleanOrUndefined(value.is_premium)
 
   if (multiplier === undefined && is_premium === undefined) return undefined
   return { multiplier, is_premium }
@@ -714,13 +714,13 @@ function parseCapabilities(
       ),
     },
     supports: {
-      tool_calls: parseOptionalBoolean(supportsRaw?.tool_calls),
-      parallel_tool_calls: parseOptionalBoolean(
+      tool_calls: toBooleanOrUndefined(supportsRaw?.tool_calls),
+      parallel_tool_calls: toBooleanOrUndefined(
         supportsRaw?.parallel_tool_calls,
       ),
-      structured_outputs: parseOptionalBoolean(supportsRaw?.structured_outputs),
-      streaming: parseOptionalBoolean(supportsRaw?.streaming),
-      vision: parseOptionalBoolean(supportsRaw?.vision),
+      structured_outputs: toBooleanOrUndefined(supportsRaw?.structured_outputs),
+      streaming: toBooleanOrUndefined(supportsRaw?.streaming),
+      vision: toBooleanOrUndefined(supportsRaw?.vision),
     },
   }
 }
@@ -735,7 +735,7 @@ function parseAdminModelDetailsItem(
   if (!id) return null
 
   const name = parseNonEmptyString(raw.name) ?? id
-  const preview = parseOptionalBoolean(raw.preview) ?? false
+  const preview = toBooleanOrUndefined(raw.preview) ?? false
 
   return {
     id,

--- a/tests/admin-models-details.test.ts
+++ b/tests/admin-models-details.test.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { Model } from "~/services/copilot/get-models"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+
+type ModelsResponse = { data: Array<Model>; object: string }
+
+type ModelAliasSpec = {
+  target: string
+  allowOriginal?: boolean
+}
+
+type TestConfig = {
+  modelAliases: Record<string, ModelAliasSpec | string>
+  allowOriginalModelNamesForAliases: boolean
+  smallModel: string
+}
+
+const buildModel = (id: string, overrides?: Partial<Model>): Model => ({
+  id,
+  name: id,
+  vendor: "upstream",
+  object: "model",
+  preview: false,
+  version: "test",
+  model_picker_enabled: true,
+  capabilities: {
+    family: "test",
+    limits: {
+      max_context_window_tokens: 128_000,
+      max_output_tokens: 32_000,
+    },
+    object: "capabilities",
+    supports: {
+      tool_calls: true,
+      vision: false,
+      structured_outputs: true,
+      streaming: true,
+      parallel_tool_calls: true,
+    },
+    tokenizer: "test",
+    type: "chat",
+  },
+  billing: {
+    multiplier: 1,
+    is_premium: false,
+  },
+  supported_endpoints: ["/responses", "/chat/completions"],
+  ...overrides,
+})
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+
+  try {
+    await run()
+  } finally {
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (original === null) {
+      await fs.rm(PATHS.CONFIG_PATH, { force: true })
+    } else {
+      await fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    }
+    mergeConfigWithDefaults()
+  }
+}
+
+const withMockedModels = async (run: () => Promise<void>) => {
+  const originalGetFirstAccountModels =
+    accountsManager.getFirstAccountModels.bind(accountsManager)
+
+  accountsManager.getFirstAccountModels = () =>
+    ({
+      data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+      object: "list",
+    }) as ModelsResponse
+
+  try {
+    await run()
+  } finally {
+    // eslint-disable-next-line require-atomic-updates
+    accountsManager.getFirstAccountModels = originalGetFirstAccountModels
+  }
+}
+
+test("GET /api/admin/models/details returns model details with aliases", async () => {
+  await withConfig(
+    {
+      modelAliases: {
+        fast: { target: "gpt-5-mini" },
+      },
+      allowOriginalModelNamesForAliases: true,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      await withMockedModels(async () => {
+        const { server } = await import("../src/server")
+        const res = await server.fetch(
+          new Request("http://localhost/api/admin/models/details"),
+        )
+
+        expect(res.status).toBe(200)
+
+        const body = (await res.json()) as {
+          items: Array<{
+            id: string
+            name: string
+            aliases: Array<string>
+            supported_endpoints?: Array<string>
+            billing?: { multiplier?: number }
+            capabilities: {
+              limits: {
+                max_context_window_tokens?: number
+                max_output_tokens?: number
+              }
+              supports: { tool_calls?: boolean }
+            }
+          }>
+        }
+
+        // Stable ordering by id.
+        expect(body.items.map((m) => m.id)).toEqual(["gpt-4", "gpt-5-mini"])
+
+        const mini = body.items.find((m) => m.id === "gpt-5-mini")
+        expect(mini).toBeTruthy()
+        expect(mini?.aliases).toEqual(["fast"])
+        expect(mini?.supported_endpoints).toEqual([
+          "/responses",
+          "/chat/completions",
+        ])
+        expect(mini?.billing?.multiplier).toBe(1)
+        expect(mini?.capabilities.limits.max_context_window_tokens).toBe(
+          128_000,
+        )
+        expect(mini?.capabilities.supports.tool_calls).toBe(true)
+      })
+    },
+  )
+})

--- a/tests/admin-models-details.test.ts
+++ b/tests/admin-models-details.test.ts
@@ -33,6 +33,7 @@ const buildModel = (id: string, overrides?: Partial<Model>): Model => ({
     family: "test",
     limits: {
       max_context_window_tokens: 128_000,
+      max_prompt_tokens: 96_000,
       max_output_tokens: 32_000,
     },
     object: "capabilities",
@@ -126,6 +127,7 @@ test("GET /api/admin/models/details returns model details with aliases", async (
             capabilities: {
               limits: {
                 max_context_window_tokens?: number
+                max_prompt_tokens?: number
                 max_output_tokens?: number
               }
               supports: { tool_calls?: boolean }
@@ -147,6 +149,8 @@ test("GET /api/admin/models/details returns model details with aliases", async (
         expect(mini?.capabilities.limits.max_context_window_tokens).toBe(
           128_000,
         )
+        expect(mini?.capabilities.limits.max_prompt_tokens).toBe(96_000)
+        expect(mini?.capabilities.limits.max_output_tokens).toBe(32_000)
         expect(mini?.capabilities.supports.tool_calls).toBe(true)
       })
     },

--- a/tests/admin-models-details.test.ts
+++ b/tests/admin-models-details.test.ts
@@ -81,13 +81,16 @@ const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
   }
 }
 
-const withMockedModels = async (run: () => Promise<void>) => {
+const withMockedModels = async (
+  models: Array<Model>,
+  run: () => Promise<void>,
+) => {
   const originalGetFirstAccountModels =
     accountsManager.getFirstAccountModels.bind(accountsManager)
 
   accountsManager.getFirstAccountModels = () =>
     ({
-      data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+      data: models,
       object: "list",
     }) as ModelsResponse
 
@@ -109,50 +112,81 @@ test("GET /api/admin/models/details returns model details with aliases", async (
       smallModel: "gpt-5-mini",
     },
     async () => {
-      await withMockedModels(async () => {
-        const { server } = await import("../src/server")
-        const res = await server.fetch(
-          new Request("http://localhost/api/admin/models/details"),
-        )
+      await withMockedModels(
+        [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+        async () => {
+          const { server } = await import("../src/server")
+          const res = await server.fetch(
+            new Request("http://localhost/api/admin/models/details"),
+          )
 
-        expect(res.status).toBe(200)
+          expect(res.status).toBe(200)
 
-        const body = (await res.json()) as {
-          items: Array<{
-            id: string
-            name: string
-            aliases: Array<string>
-            supported_endpoints?: Array<string>
-            billing?: { multiplier?: number }
-            capabilities: {
-              limits: {
-                max_context_window_tokens?: number
-                max_prompt_tokens?: number
-                max_output_tokens?: number
+          const body = (await res.json()) as {
+            items: Array<{
+              id: string
+              name: string
+              aliases: Array<string>
+              supported_endpoints?: Array<string>
+              billing?: { multiplier?: number }
+              capabilities: {
+                limits: {
+                  max_context_window_tokens?: number
+                  max_prompt_tokens?: number
+                  max_output_tokens?: number
+                }
+                supports: { tool_calls?: boolean }
               }
-              supports: { tool_calls?: boolean }
-            }
-          }>
-        }
+            }>
+          }
 
-        // Stable ordering by id.
-        expect(body.items.map((m) => m.id)).toEqual(["gpt-4", "gpt-5-mini"])
+          // Stable ordering by id.
+          expect(body.items.map((m) => m.id)).toEqual(["gpt-4", "gpt-5-mini"])
 
-        const mini = body.items.find((m) => m.id === "gpt-5-mini")
-        expect(mini).toBeTruthy()
-        expect(mini?.aliases).toEqual(["fast"])
-        expect(mini?.supported_endpoints).toEqual([
-          "/responses",
-          "/chat/completions",
-        ])
-        expect(mini?.billing?.multiplier).toBe(1)
-        expect(mini?.capabilities.limits.max_context_window_tokens).toBe(
-          128_000,
-        )
-        expect(mini?.capabilities.limits.max_prompt_tokens).toBe(96_000)
-        expect(mini?.capabilities.limits.max_output_tokens).toBe(32_000)
-        expect(mini?.capabilities.supports.tool_calls).toBe(true)
-      })
+          const mini = body.items.find((m) => m.id === "gpt-5-mini")
+          expect(mini).toBeTruthy()
+          expect(mini?.aliases).toEqual(["fast"])
+          expect(mini?.supported_endpoints).toEqual([
+            "/responses",
+            "/chat/completions",
+          ])
+          expect(mini?.billing?.multiplier).toBe(1)
+          expect(mini?.capabilities.limits.max_context_window_tokens).toBe(
+            128_000,
+          )
+          expect(mini?.capabilities.limits.max_prompt_tokens).toBe(96_000)
+          expect(mini?.capabilities.limits.max_output_tokens).toBe(32_000)
+          expect(mini?.capabilities.supports.tool_calls).toBe(true)
+        },
+      )
+    },
+  )
+})
+
+test("GET /api/admin/models/details de-duplicates duplicate ids", async () => {
+  await withConfig(
+    {
+      modelAliases: {},
+      allowOriginalModelNamesForAliases: true,
+      smallModel: "gpt-5-mini",
+    },
+    async () => {
+      await withMockedModels(
+        [buildModel("gpt-4"), buildModel("gpt-4"), buildModel("gpt-5-mini")],
+        async () => {
+          const { server } = await import("../src/server")
+          const res = await server.fetch(
+            new Request("http://localhost/api/admin/models/details"),
+          )
+
+          expect(res.status).toBe(200)
+
+          const body = (await res.json()) as { items: Array<{ id: string }> }
+
+          expect(body.items).toHaveLength(2)
+          expect(body.items.map((m) => m.id)).toEqual(["gpt-4", "gpt-5-mini"])
+        },
+      )
     },
   )
 })


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/models/details` to expose model metadata (aliases, endpoints, limits, supports, billing multiplier).
- Add Admin-UI “Models” page in top nav to list all available upstream models.

## Test plan
- [x] bun test
- [x] bun run lint
- [x] bun run build
- [ ] Open `/admin/#/models` and verify table renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“模型”页面：可查看并按多列排序的模型列表，展示端点、能力、上下文限制、计费倍数、预览与别名，含加载、错误与空状态提示
  * 导航栏新增“模型”入口，便捷访问模型列表
  * 后端新增模型详情接口，页面可获取聚合后的模型信息与本地化文案（中英文）

* **测试**
  * 为模型详情接口添加端到端测试，覆盖别名处理、去重、排序与数据完整性验证
<!-- end of auto-generated comment: release notes by coderabbit.ai -->