### PR TITLE
feat: auto refresh models list

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -101,6 +101,7 @@ export type AdminConfig = {
   forceAgent?: boolean
   compactUseSmallModel?: boolean
   messageStartInputTokensFallback?: boolean
+  modelRefreshIntervalHours?: number
 }
 
 export type AdminConfigResponse = AdminConfig & {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -326,6 +326,9 @@
     "advanced": {
       "title": "Advanced",
       "description": "Feature flags and experimental toggles.",
+      "modelRefreshIntervalLabel": "Model refresh interval (hours)",
+      "modelRefreshIntervalHint": "Set to 0 to disable automatic refresh.",
+      "modelRefreshIntervalError": "Must be a non-negative number.",
       "allowOriginalModelNamesLabel": "Allow original model names",
       "allowOriginalModelNamesHint": "Default behavior when aliases do not override original model IDs.",
       "useFunctionApplyPatchLabel": "Use function apply_patch",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -326,6 +326,9 @@
     "advanced": {
       "title": "高级",
       "description": "功能开关与实验选项。",
+      "modelRefreshIntervalLabel": "模型列表刷新间隔（小时）",
+      "modelRefreshIntervalHint": "设置为 0 表示关闭自动刷新。",
+      "modelRefreshIntervalError": "必须是非负数字。",
       "allowOriginalModelNamesLabel": "允许原始模型名",
       "allowOriginalModelNamesHint": "当别名未覆盖时的默认行为。",
       "useFunctionApplyPatchLabel": "启用 function apply_patch",

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1336,12 +1336,15 @@ function ModelAliasesCard({
 
 type AdvancedSettingsCardProps = {
   loadBalancingEnabled: boolean
+  modelRefreshIntervalInput: string
+  modelRefreshIntervalIssue: string | null
   allowOriginalModelNamesForAliases: boolean
   useFunctionApplyPatch: boolean
   forceAgent: boolean
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
   onToggleLoadBalancing: (value: boolean) => void
+  onModelRefreshIntervalChange: (value: string) => void
   onToggleAllowOriginalModelNamesForAliases: (value: boolean) => void
   onToggleUseFunctionApplyPatch: (value: boolean) => void
   onToggleForceAgent: (value: boolean) => void
@@ -1351,12 +1354,15 @@ type AdvancedSettingsCardProps = {
 
 function AdvancedSettingsCard({
   loadBalancingEnabled,
+  modelRefreshIntervalInput,
+  modelRefreshIntervalIssue,
   allowOriginalModelNamesForAliases,
   useFunctionApplyPatch,
   forceAgent,
   compactUseSmallModel,
   messageStartInputTokensFallback,
   onToggleLoadBalancing,
+  onModelRefreshIntervalChange,
   onToggleAllowOriginalModelNamesForAliases,
   onToggleUseFunctionApplyPatch,
   onToggleForceAgent,
@@ -1387,6 +1393,27 @@ function AdvancedSettingsCard({
             checked={loadBalancingEnabled}
             onCheckedChange={onToggleLoadBalancing}
           />
+        </div>
+
+        <div className="grid gap-2">
+          <Label className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.modelRefreshIntervalLabel")}
+          </Label>
+          <Input
+            type="number"
+            min="0"
+            step="0.5"
+            value={modelRefreshIntervalInput}
+            onChange={(e) => onModelRefreshIntervalChange(e.target.value)}
+          />
+          <div className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.modelRefreshIntervalHint")}
+          </div>
+          {modelRefreshIntervalIssue ? (
+            <div className="text-destructive text-xs">
+              {modelRefreshIntervalIssue}
+            </div>
+          ) : null}
         </div>
 
         <div className="flex items-center justify-between gap-4">
@@ -1483,6 +1510,9 @@ type SettingsPageViewProps = {
   onApiKeyChange: (value: string) => void
   loadBalancingEnabled: boolean
   onLoadBalancingToggle: (value: boolean) => void
+  modelRefreshIntervalInput: string
+  modelRefreshIntervalIssue: string | null
+  onModelRefreshIntervalChange: (value: string) => void
   reasoningMode: JsonMode
   reasoningJson: string
   reasoningJsonIssue: string | null
@@ -1532,6 +1562,11 @@ function useSettingsPageState(): SettingsPageViewProps {
 
   const [models, setModels] = useState<Array<string>>([])
   const [draft, setDraft] = useState<AdminConfig>({})
+  const [modelRefreshIntervalInput, setModelRefreshIntervalInput] =
+    useState<string>("")
+  const [modelRefreshIntervalIssue, setModelRefreshIntervalIssue] = useState<
+    string | null
+  >(null)
 
   const extraEditor = useExtraPromptEditor((record) =>
     setDraft((prev) => ({ ...prev, extraPrompts: record })),
@@ -1588,14 +1623,25 @@ function useSettingsPageState(): SettingsPageViewProps {
       const { _configPath, ...configData } = config
       const aliasItems = aliasItemsFromRecord(configData.modelAliases)
       const normalizedAliases = aliasRecordFromItems(aliasItems)
+      const intervalValue = configData.modelRefreshIntervalHours
 
       setConfigPath(_configPath ?? null)
       setDraft({ ...configData, modelAliases: normalizedAliases })
       setExtraFromRecord(configData.extraPrompts)
       setReasoningFromRecord(configData.modelReasoningEfforts)
       setAliasFromRecord(normalizedAliases)
+      setModelRefreshIntervalInput(
+        typeof intervalValue === "number" ? String(intervalValue) : "",
+      )
+      setModelRefreshIntervalIssue(null)
     },
-    [setExtraFromRecord, setReasoningFromRecord, setAliasFromRecord],
+    [
+      setExtraFromRecord,
+      setReasoningFromRecord,
+      setAliasFromRecord,
+      setModelRefreshIntervalInput,
+      setModelRefreshIntervalIssue,
+    ],
   )
 
   const load = useCallback(async () => {
@@ -1692,6 +1738,37 @@ function useSettingsPageState(): SettingsPageViewProps {
     [setDraft],
   )
 
+  const handleModelRefreshIntervalChange = useCallback(
+    (value: string) => {
+      setModelRefreshIntervalInput(value)
+
+      const trimmed = value.trim()
+      if (!trimmed) {
+        setModelRefreshIntervalIssue(null)
+        setDraft((prev) => ({
+          ...prev,
+          modelRefreshIntervalHours: undefined,
+        }))
+        return
+      }
+
+      const parsed = Number(trimmed)
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        setModelRefreshIntervalIssue(
+          t("settingsPage.advanced.modelRefreshIntervalError"),
+        )
+        return
+      }
+
+      setModelRefreshIntervalIssue(null)
+      setDraft((prev) => ({
+        ...prev,
+        modelRefreshIntervalHours: parsed,
+      }))
+    },
+    [setDraft, setModelRefreshIntervalInput, setModelRefreshIntervalIssue, t],
+  )
+
   const handleAllowOriginalModelNamesForAliasesToggle = useCallback(
     (value: boolean) => {
       setDraft((prev) => ({ ...prev, allowOriginalModelNamesForAliases: value }))
@@ -1735,6 +1812,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     && !(extraMode === "json" && extraJsonIssue)
     && !(reasoningMode === "json" && reasoningJsonIssue)
     && !(aliasMode === "json" && aliasJsonIssue)
+    && !modelRefreshIntervalIssue
 
   const envOverrideNote = t("settingsPage.envOverrideNote", {
     env: "COPILOT_API_KEY",
@@ -1775,6 +1853,9 @@ function useSettingsPageState(): SettingsPageViewProps {
     onApiKeyChange: handleApiKeyChange,
     loadBalancingEnabled,
     onLoadBalancingToggle: handleLoadBalancingToggle,
+    modelRefreshIntervalInput,
+    modelRefreshIntervalIssue,
+    onModelRefreshIntervalChange: handleModelRefreshIntervalChange,
     allowOriginalModelNamesForAliases,
     reasoningMode,
     reasoningJson,
@@ -1837,6 +1918,9 @@ function SettingsPageView({
   onApiKeyChange,
   loadBalancingEnabled,
   onLoadBalancingToggle,
+  modelRefreshIntervalInput,
+  modelRefreshIntervalIssue,
+  onModelRefreshIntervalChange,
   reasoningMode,
   reasoningJson,
   reasoningJsonIssue,
@@ -2036,12 +2120,15 @@ function SettingsPageView({
           >
             <AdvancedSettingsCard
               loadBalancingEnabled={loadBalancingEnabled}
+              modelRefreshIntervalInput={modelRefreshIntervalInput}
+              modelRefreshIntervalIssue={modelRefreshIntervalIssue}
               allowOriginalModelNamesForAliases={allowOriginalModelNamesForAliases}
               useFunctionApplyPatch={useFunctionApplyPatch}
               forceAgent={forceAgent}
               compactUseSmallModel={compactUseSmallModel}
               messageStartInputTokensFallback={messageStartInputTokensFallback}
               onToggleLoadBalancing={onLoadBalancingToggle}
+              onModelRefreshIntervalChange={onModelRefreshIntervalChange}
               onToggleAllowOriginalModelNamesForAliases={
                 onAllowOriginalModelNamesForAliasesToggle
               }

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import consola from "consola"
 import fs from "node:fs"
 
@@ -96,7 +97,13 @@ export class AccountsManager {
     AccountRuntime,
     AuthSnapshot
   >()
+  private modelsRefreshSnapshotByAccount = new WeakMap<
+    AccountRuntime,
+    AuthSnapshot
+  >()
   private tokenRefreshEnabledAccounts = new WeakSet<AccountRuntime>()
+  private modelsRefreshTimer?: ReturnType<typeof setTimeout>
+  private modelsRefreshIntervalMs = 0
 
   // Registry file watcher for hot reload
   private registryWatcher?: fs.FSWatcher
@@ -156,6 +163,12 @@ export class AccountsManager {
 
   setFreeModelLoadBalancingEnabled(enabled: boolean): void {
     this.freeModelLoadBalancingEnabled = enabled
+  }
+
+  setModelsRefreshIntervalMs(intervalMs: number): void {
+    this.modelsRefreshIntervalMs =
+      Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : 0
+    this.scheduleModelsRefresh()
   }
 
   private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
@@ -258,6 +271,7 @@ export class AccountsManager {
       if (!applyModelsIfCurrent(account, snapshot, models)) {
         return
       }
+      account.lastModelsFetch = Date.now()
 
       // Refresh quota
       await this.refreshQuota(account)
@@ -338,6 +352,126 @@ export class AccountsManager {
     if (this.temporaryAccount) {
       this.stopTokenRefresh(this.temporaryAccount)
     }
+  }
+
+  private scheduleModelsRefresh(): void {
+    this.stopModelsRefresh()
+
+    if (!this.modelsRefreshIntervalMs || this.modelsRefreshIntervalMs <= 0) {
+      return
+    }
+
+    this.modelsRefreshTimer = setTimeout(() => {
+      void this.runModelsRefreshTick()
+    }, this.modelsRefreshIntervalMs)
+  }
+
+  private stopModelsRefresh(): void {
+    if (this.modelsRefreshTimer) {
+      clearTimeout(this.modelsRefreshTimer)
+      this.modelsRefreshTimer = undefined
+    }
+  }
+
+  private async runModelsRefreshTick(): Promise<void> {
+    try {
+      await this.refreshAllModels()
+    } catch (error) {
+      consola.error("Failed to refresh models:", error)
+    } finally {
+      this.scheduleModelsRefresh()
+    }
+  }
+
+  private finalizeModelsRefreshPromise(
+    account: AccountRuntime,
+    promise: Promise<void>,
+  ): void {
+    if (account.modelsRefreshPromise !== promise) {
+      return
+    }
+
+    account.isRefreshingModels = false
+    account.modelsRefreshPromise = undefined
+    this.modelsRefreshSnapshotByAccount.delete(account)
+  }
+
+  private async refreshModels(account: AccountRuntime): Promise<void> {
+    if (!account.copilotToken) {
+      consola.debug(
+        `Skip model refresh for ${account.id}: missing Copilot token`,
+      )
+      return
+    }
+
+    const snapshot = takeAuthSnapshot(account)
+
+    if (account.modelsRefreshPromise) {
+      const existingSnapshot = this.modelsRefreshSnapshotByAccount.get(account)
+      if (isSameAuthSnapshot(existingSnapshot, snapshot)) {
+        await account.modelsRefreshPromise
+        return
+      }
+    }
+
+    account.isRefreshingModels = true
+
+    const ctx = toAccountContextFromSnapshot(
+      account,
+      snapshot,
+      account.copilotToken,
+    )
+
+    const promise = (async () => {
+      try {
+        const models = await getModels(ctx)
+        const applied = applyModelsIfCurrent(account, snapshot, models)
+        if (applied) {
+          account.lastModelsFetch = Date.now()
+          account.failed = false
+          account.failureReason = undefined
+        }
+      } catch (error) {
+        if (error instanceof HTTPError && error.response.status === 401) {
+          applyUnauthorizedIfCurrent(account, snapshot, "Unauthorized (401)")
+          return
+        }
+
+        consola.error(`Failed to refresh models for ${account.id}:`, error)
+      }
+    })()
+
+    account.modelsRefreshPromise = promise
+    this.modelsRefreshSnapshotByAccount.set(account, snapshot)
+
+    void promise.finally(() => {
+      this.finalizeModelsRefreshPromise(account, promise)
+    })
+
+    await promise
+  }
+
+  private async refreshAllModels(): Promise<void> {
+    const accounts: Array<AccountRuntime> = []
+
+    if (this.temporaryAccount) {
+      accounts.push(this.temporaryAccount)
+    }
+
+    for (const id of this.accountOrder) {
+      const account = this.accounts.get(id)
+      if (account) {
+        accounts.push(account)
+      }
+    }
+
+    if (accounts.length === 0) {
+      return
+    }
+
+    await Promise.allSettled(
+      accounts.map((account) => this.refreshModels(account)),
+    )
   }
 
   /** Refresh quota information for an account. */
@@ -1055,6 +1189,7 @@ export class AccountsManager {
   shutdown(): void {
     this.stopRegistryWatcher()
     this.stopAllTokenRefresh()
+    this.stopModelsRefresh()
     this.accounts.clear()
     this.accountOrder = []
     this.temporaryAccount = undefined

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -428,8 +428,6 @@ export class AccountsManager {
         const applied = applyModelsIfCurrent(account, snapshot, models)
         if (applied) {
           account.lastModelsFetch = Date.now()
-          account.failed = false
-          account.failureReason = undefined
         }
       } catch (error) {
         if (error instanceof HTTPError && error.response.status === 401) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,7 @@ export interface AppConfig {
   forceAgent?: boolean
   compactUseSmallModel?: boolean
   messageStartInputTokensFallback?: boolean
+  modelRefreshIntervalHours?: number
 }
 
 const gpt5ExplorationPrompt = `## Exploration and reading files
@@ -41,9 +42,19 @@ const defaultConfig: AppConfig = {
   useFunctionApplyPatch: true,
   compactUseSmallModel: true,
   messageStartInputTokensFallback: false,
+  modelRefreshIntervalHours: 24,
 }
 
 let cachedConfig: AppConfig | null = null
+
+function normalizeModelRefreshIntervalHours(
+  value: unknown,
+): number | undefined {
+  if (typeof value !== "number") return undefined
+  if (!Number.isFinite(value)) return undefined
+  if (value < 0) return undefined
+  return value
+}
 
 function ensureConfigFile(): void {
   try {
@@ -133,6 +144,27 @@ function mergeDefaultFreeModelLoadBalancing(config: AppConfig): {
   }
 }
 
+function mergeDefaultModelRefreshInterval(config: AppConfig): {
+  mergedConfig: AppConfig
+  changed: boolean
+} {
+  const normalized = normalizeModelRefreshIntervalHours(
+    config.modelRefreshIntervalHours,
+  )
+
+  if (normalized !== undefined) {
+    return { mergedConfig: config, changed: false }
+  }
+
+  return {
+    mergedConfig: {
+      ...config,
+      modelRefreshIntervalHours: defaultConfig.modelRefreshIntervalHours ?? 24,
+    },
+    changed: true,
+  }
+}
+
 type ConfigMergeResult = {
   mergedConfig: AppConfig
   changed: boolean
@@ -162,6 +194,7 @@ export function mergeConfigWithDefaults(): AppConfig {
   const { mergedConfig, changed } = applyConfigMerges(config, [
     mergeDefaultExtraPrompts,
     mergeDefaultFreeModelLoadBalancing,
+    mergeDefaultModelRefreshInterval,
   ])
 
   if (changed) {
@@ -378,6 +411,20 @@ export function getSmallModel(): string {
 export function isFreeModelLoadBalancingEnabled(): boolean {
   const config = getConfig()
   return config.freeModelLoadBalancing ?? true
+}
+
+export function getModelRefreshIntervalHours(): number {
+  const config = getConfig()
+  const normalized = normalizeModelRefreshIntervalHours(
+    config.modelRefreshIntervalHours,
+  )
+  return normalized ?? defaultConfig.modelRefreshIntervalHours ?? 24
+}
+
+export function getModelRefreshIntervalMs(): number {
+  const hours = getModelRefreshIntervalHours()
+  if (!Number.isFinite(hours) || hours <= 0) return 0
+  return hours * 60 * 60 * 1000
 }
 
 export function isMessageStartInputTokensFallbackEnabled(): boolean {

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -63,6 +63,12 @@ export interface AccountRuntime extends AccountMeta {
   vsCodeVersion?: string
   /** Cached available models for this account */
   models?: ModelsResponse
+  /** Timestamp of last models fetch */
+  lastModelsFetch?: number
+  /** Whether models refresh is in progress */
+  isRefreshingModels?: boolean
+  /** Promise for an in-flight models refresh */
+  modelsRefreshPromise?: Promise<void>
   /** Total premium interactions quota entitlement */
   premiumEntitlement?: number
   /** Remaining premium interactions quota */

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { Hono, type Context } from "hono"
 import { randomUUID } from "node:crypto"
 import fs from "node:fs/promises"
@@ -8,6 +9,7 @@ import {
   getConfig,
   getModelAliases,
   getModelAliasesInfo,
+  getModelRefreshIntervalMs,
   isFreeModelLoadBalancingEnabled,
   mergeConfigWithDefaults,
   type AppConfig,
@@ -154,6 +156,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "forceAgent",
   "compactUseSmallModel",
   "messageStartInputTokensFallback",
+  "modelRefreshIntervalHours",
 ])
 
 const REASONING_EFFORTS = new Set<ReasoningEffort>([
@@ -205,6 +208,18 @@ function parseOptionalBoolean(
 ): ParseFieldResult<boolean> {
   if (value === null || value === undefined) return { clear: true }
   if (typeof value !== "boolean") return { error: `${field} must be a boolean` }
+  return { value }
+}
+
+function parseOptionalNonNegativeNumber(
+  value: unknown,
+  field: string,
+): ParseFieldResult<number> {
+  if (value === null || value === undefined) return { clear: true }
+  if (typeof value !== "number") return { error: `${field} must be a number` }
+  if (!Number.isFinite(value) || value < 0) {
+    return { error: `${field} must be a non-negative number` }
+  }
   return { value }
 }
 
@@ -389,6 +404,21 @@ function applyOptionalBoolean(
   return undefined
 }
 
+function applyOptionalNumber(
+  next: AppConfig,
+  key: "modelRefreshIntervalHours",
+  value: unknown,
+): string | undefined {
+  const parsed = parseOptionalNonNegativeNumber(value, key)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    next[key] = undefined
+    return undefined
+  }
+  next[key] = parsed.value
+  return undefined
+}
+
 function applyExtraPrompts(
   next: AppConfig,
   value: unknown,
@@ -498,6 +528,10 @@ function applyConfigPatch(
         )
         break
       }
+      case "modelRefreshIntervalHours": {
+        error = applyOptionalNumber(next, "modelRefreshIntervalHours", value)
+        break
+      }
       default: {
         return { error: `Unsupported config key: ${rawKey}` }
       }
@@ -597,6 +631,7 @@ adminApiRoutes.post("/config", async (c) => {
     accountsManager.setFreeModelLoadBalancingEnabled(
       isFreeModelLoadBalancingEnabled(),
     )
+    accountsManager.setModelsRefreshIntervalMs(getModelRefreshIntervalMs())
     return c.json({ ...merged, _configPath: PATHS.CONFIG_PATH })
   } catch {
     return jsonError(c, 500, {

--- a/src/start.ts
+++ b/src/start.ts
@@ -9,6 +9,7 @@ import invariant from "tiny-invariant"
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
 import {
+  getModelRefreshIntervalMs,
   isFreeModelLoadBalancingEnabled,
   mergeConfigWithDefaults,
 } from "./lib/config"
@@ -79,6 +80,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   accountsManager.setFreeModelLoadBalancingEnabled(
     isFreeModelLoadBalancingEnabled(),
   )
+  accountsManager.setModelsRefreshIntervalMs(getModelRefreshIntervalMs())
 
   if (options.proxyEnv) {
     initProxyFromEnv()
@@ -123,6 +125,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
       // Re-initialize accounts manager with the new account
       accountsManager.shutdown()
       await accountsManager.initialize(state.vsCodeVersion)
+      accountsManager.setModelsRefreshIntervalMs(getModelRefreshIntervalMs())
     } catch (error) {
       consola.error("Failed to add account:", error)
       process.exit(1)


### PR DESCRIPTION
## Summary\n- add configurable model refresh interval (hours) with default 24 and 0 to disable\n- schedule background model refresh per account without blocking request handling\n- expose setting in Admin UI Advanced and persist via admin config\n\n## Testing\n- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 管理员可在高级设置中按小时配置模型列表自动刷新间隔，设置为 0 可禁用自动刷新
  * 根据配置，系统将在后台按间隔自动刷新各账户的模型列表；保存受输入校验影响，存在错误时无法保存
* **本地化**
  * 新增中英文界面文案：标签、提示与错误信息，改善设置可用性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->