### PR TITLE
feat: validate admin token on save

### DIFF
--- a/admin-ui/src/components/token-dialog.tsx
+++ b/admin-ui/src/components/token-dialog.tsx
@@ -79,6 +79,7 @@ export function TokenDialog(): React.JSX.Element {
     }
     setSaving(true)
     setSaveError(null)
+    setMeta(null)
     try {
       const m = await getAdminMeta(trimmed)
       setMeta(m)
@@ -177,7 +178,7 @@ export function TokenDialog(): React.JSX.Element {
             className="h-9 px-4"
             disabled={testing || saving}
           >
-            {t("common.save")}
+            {saving ? t("common.saving") : t("common.save")}
           </RainbowButton>
         </DialogFooter>
       </DialogContent>

--- a/admin-ui/src/components/token-dialog.tsx
+++ b/admin-ui/src/components/token-dialog.tsx
@@ -31,6 +31,8 @@ export function TokenDialog(): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [draft, setDraft] = useState(token)
   const [testing, setTesting] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [meta, setMeta] = useState<AdminMeta | null>(null)
 
   const tokenStatus = token ? t("common.set") : t("common.unset")
@@ -50,11 +52,13 @@ export function TokenDialog(): React.JSX.Element {
 
   useEffect(() => {
     if (open) setDraft(token)
+    if (open) setSaveError(null)
   }, [open, token])
 
   async function testToken(): Promise<void> {
     setTesting(true)
     setMeta(null)
+    setSaveError(null)
     try {
       const m = await getAdminMeta(draft)
       setMeta(m)
@@ -67,16 +71,33 @@ export function TokenDialog(): React.JSX.Element {
     }
   }
 
-  function save(): void {
-    setToken(draft)
-    toast.success(
-      draft.trim() ? t("tokenDialog.toast.tokenSaved") : t("tokenDialog.toast.tokenCleared")
-    )
+  async function save(): Promise<void> {
+    const trimmed = draft.trim()
+    if (!trimmed) {
+      setSaveError(t("tokenDialog.validation.empty"))
+      return
+    }
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const m = await getAdminMeta(trimmed)
+      setMeta(m)
+      setToken(trimmed)
+      setOpen(false)
+      toast.success(t("tokenDialog.toast.tokenSaved"))
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      setSaveError(msg)
+    } finally {
+      setSaving(false)
+    }
   }
 
   function clear(): void {
     clearToken()
     setDraft("")
+    setSaveError(null)
+    setMeta(null)
     toast.success(t("tokenDialog.toast.tokenCleared"))
   }
 
@@ -112,9 +133,15 @@ export function TokenDialog(): React.JSX.Element {
             type="password"
             placeholder={t("tokenDialog.inputPlaceholder")}
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e) => {
+              setDraft(e.target.value)
+              if (saveError) setSaveError(null)
+            }}
             autoComplete="off"
           />
+          {saveError ? (
+            <p className="text-destructive text-xs">{saveError}</p>
+          ) : null}
           <p className="text-muted-foreground text-xs">
             <Trans i18nKey="tokenDialog.remoteNote">
               If the server is not running on localhost, you must set <code>ADMIN_TOKEN</code> on the server to enable remote access.
@@ -131,13 +158,25 @@ export function TokenDialog(): React.JSX.Element {
         </div>
 
         <DialogFooter className="gap-2 sm:gap-2">
-          <Button variant="secondary" onClick={testToken} disabled={testing}>
+          <Button
+            variant="secondary"
+            onClick={testToken}
+            disabled={testing || saving}
+          >
             {testing ? t("common.testing") : t("common.test")}
           </Button>
-          <Button variant="outline" onClick={clear} disabled={!token && !draft.trim()}>
+          <Button
+            variant="outline"
+            onClick={clear}
+            disabled={(!token && !draft.trim()) || testing || saving}
+          >
             {t("common.clear")}
           </Button>
-          <RainbowButton onClick={save} className="h-9 px-4">
+          <RainbowButton
+            onClick={save}
+            className="h-9 px-4"
+            disabled={testing || saving}
+          >
             {t("common.save")}
           </RainbowButton>
         </DialogFooter>

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -34,6 +34,7 @@
     "testing": "Testing...",
     "clear": "Clear",
     "save": "Save",
+    "saving": "Saving...",
     "refresh": "Refresh",
     "refreshing": "Refreshing...",
     "retry": "Retry",

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -81,6 +81,9 @@
     "inputPlaceholder": "Enter token",
     "remoteNote": "If the server is not running on localhost, you must set <1>ADMIN_TOKEN</1> on the server to enable remote access.",
     "connected": "Connected: DB v{{version}} · {{path}}",
+    "validation": {
+      "empty": "Token cannot be empty."
+    },
     "toast": {
       "adminApiOk": "Admin API access OK",
       "adminApiFailed": "Admin API access failed",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -34,6 +34,7 @@
     "testing": "测试中…",
     "clear": "清除",
     "save": "保存",
+    "saving": "保存中…",
     "refresh": "刷新",
     "refreshing": "刷新中…",
     "retry": "重试",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -81,6 +81,9 @@
     "inputPlaceholder": "输入 Token",
     "remoteNote": "如果服务端不在 localhost 运行，你必须在服务端设置 <1>ADMIN_TOKEN</1> 才能启用远程访问。",
     "connected": "已连接：DB v{{version}} · {{path}}",
+    "validation": {
+      "empty": "Token 不能为空。"
+    },
     "toast": {
       "adminApiOk": "Admin API 访问正常",
       "adminApiFailed": "Admin API 访问失败",


### PR DESCRIPTION
## Summary
- validate admin token on save and close dialog on success
- show inline error on failure

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为令牌输入新增空值校验与本地化提示（中文/英文）。
  * 保存流程支持异步保存状态，按钮在保存中显示“保存中…”并禁用相关操作。
* **改进**
  * 编辑输入时即时清除先前错误提示；测试/清除操作在执行前也会重置错误信息。
  * 当保存失败时在输入下方展示错误信息，保存成功显示成功提示并关闭对话。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->