### PR TITLE
feat(admin-ui): this month stats window and force magic motion

### DIFF
--- a/admin-ui/src/components/app-shell.tsx
+++ b/admin-ui/src/components/app-shell.tsx
@@ -12,7 +12,6 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 import { LocaleToggle } from "@/components/locale-toggle"
-import { MotionToggle } from "@/components/motion-toggle"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { TokenDialog } from "@/components/token-dialog"
 import { cn } from "@/lib/utils"
@@ -99,7 +98,6 @@ export function AppShell(): React.JSX.Element {
 
           <div className="ml-auto flex items-center gap-2">
             <LocaleToggle />
-            <MotionToggle />
             <ThemeToggle />
             <TokenDialog />
           </div>

--- a/admin-ui/src/lib/motion-preference.tsx
+++ b/admin-ui/src/lib/motion-preference.tsx
@@ -1,32 +1,6 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
-
-import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion"
+import { createContext, useContext, useEffect } from "react"
 
 export type MotionPreference = "magic" | "subtle" | "off"
-
-const MOTION_STORAGE_KEY = "motion"
-
-function normalizeMotionPreference(value: string | null): MotionPreference {
-  if (value === "magic" || value === "subtle" || value === "off") return value
-  return "magic"
-}
-
-function readMotionPreference(): MotionPreference {
-  if (typeof window === "undefined") return "magic"
-  try {
-    return normalizeMotionPreference(window.localStorage.getItem(MOTION_STORAGE_KEY))
-  } catch {
-    return "magic"
-  }
-}
-
-function writeMotionPreference(value: MotionPreference): void {
-  try {
-    window.localStorage.setItem(MOTION_STORAGE_KEY, value)
-  } catch {
-    // ignore
-  }
-}
 
 export type MotionPreferenceContextValue = {
   preference: MotionPreference
@@ -37,37 +11,28 @@ export type MotionPreferenceContextValue = {
 
 const MotionPreferenceContext = createContext<MotionPreferenceContextValue | null>(null)
 
+const FIXED_MOTION: MotionPreference = "magic"
+
+const FIXED_VALUE: MotionPreferenceContextValue = {
+  preference: FIXED_MOTION,
+  effective: FIXED_MOTION,
+  reducedMotion: false,
+  setPreference: () => {
+    // no-op: motion is fixed to "magic"
+  },
+}
+
 export function MotionPreferenceProvider({
   children,
 }: {
   children: React.ReactNode
 }): React.JSX.Element {
-  const reducedMotion = usePrefersReducedMotion()
-
-  const [preference, setPreferenceState] = useState<MotionPreference>(() =>
-    readMotionPreference()
-  )
-
-  const setPreference = useCallback((value: MotionPreference) => {
-    setPreferenceState(value)
+  useEffect(() => {
+    document.documentElement.dataset.motion = FIXED_MOTION
   }, [])
 
-  const effective = reducedMotion ? "off" : preference
-
-  useEffect(() => {
-    writeMotionPreference(preference)
-  }, [preference])
-
-  useEffect(() => {
-    document.documentElement.dataset.motion = effective
-  }, [effective])
-
-  const value = useMemo<MotionPreferenceContextValue>(() => {
-    return { preference, effective, reducedMotion, setPreference }
-  }, [effective, preference, reducedMotion, setPreference])
-
   return (
-    <MotionPreferenceContext.Provider value={value}>
+    <MotionPreferenceContext.Provider value={FIXED_VALUE}>
       {children}
     </MotionPreferenceContext.Provider>
   )

--- a/admin-ui/src/lib/motion-preference.tsx
+++ b/admin-ui/src/lib/motion-preference.tsx
@@ -11,6 +11,8 @@ export type MotionPreferenceContextValue = {
 
 const MotionPreferenceContext = createContext<MotionPreferenceContextValue | null>(null)
 
+// Motion is intentionally fixed to "magic" for all users, including those
+// with prefers-reduced-motion enabled. See PR #39 for rationale.
 const FIXED_MOTION: MotionPreference = "magic"
 
 const FIXED_VALUE: MotionPreferenceContextValue = {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -97,7 +97,8 @@
     "statsWindowLabel": "Stats window",
     "window": {
       "last24h": "Last 24h",
-      "last7d": "Last 7d"
+      "last7d": "Last 7d",
+      "thisMonth": "This month"
     },
     "dbInfo": "DB v{{version}} · {{path}}",
     "tableDescription": "Click an account to filter requests.",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -97,7 +97,8 @@
     "statsWindowLabel": "统计窗口",
     "window": {
       "last24h": "最近 24 小时",
-      "last7d": "最近 7 天"
+      "last7d": "最近 7 天",
+      "thisMonth": "本月"
     },
     "dbInfo": "DB v{{version}} · {{path}}",
     "tableDescription": "点击账号可筛选请求。",

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -12,7 +12,6 @@ import {
 import { fmtLocalDateTime, fmtNum } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
-import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion"
 import { Badge } from "@/components/ui/badge"
 import { InlineAlert } from "@/components/ui/inline-alert"
 import { Input } from "@/components/ui/input"
@@ -45,12 +44,27 @@ import { MagicCard } from "@/components/ui/magic-card"
 import { NumberTicker } from "@/components/ui/number-ticker"
 import { RainbowButton } from "@/components/ui/rainbow-button"
 
-type WindowPreset = "86400000" | "604800000"
+type WindowPreset = "86400000" | "604800000" | "this_month"
 
 type SortBy = "account" | "requests" | "errors" | "tokens" | "last_req"
 
 function sum(items: Array<number | undefined>): number {
   return items.reduce<number>((acc, x) => acc + (x ?? 0), 0)
+}
+
+function windowPresetToRange(
+  preset: WindowPreset,
+  nowMs: number
+): { sinceMs: number; fromMs: string; toMs: string } {
+  if (preset === "this_month") {
+    const now = new Date(nowMs)
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime()
+    return { sinceMs: startOfMonth, fromMs: String(startOfMonth), toMs: String(nowMs) }
+  }
+
+  const windowMs = Number(preset)
+  const sinceMs = nowMs - windowMs
+  return { sinceMs, fromMs: String(sinceMs), toMs: String(nowMs) }
 }
 
 function clampPercent(value: number): number {
@@ -85,19 +99,6 @@ function KpiValue({
   value: number
   decimalPlaces?: number
 }): React.JSX.Element {
-  const reducedMotion = usePrefersReducedMotion()
-
-  if (reducedMotion) {
-    return (
-      <span className="tabular-nums">
-        {Intl.NumberFormat("en-US", {
-          minimumFractionDigits: decimalPlaces,
-          maximumFractionDigits: decimalPlaces,
-        }).format(value)}
-      </span>
-    )
-  }
-
   return <NumberTicker value={value} decimalPlaces={decimalPlaces} />
 }
 
@@ -133,7 +134,7 @@ function AccountsTableSkeleton({ rows }: { rows: number }): React.JSX.Element {
 export function AccountsPage(): React.JSX.Element {
   const { t } = useTranslation()
 
-  const [windowPreset, setWindowPreset] = useState<WindowPreset>("86400000")
+  const [windowPreset, setWindowPreset] = useState<WindowPreset>("this_month")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -149,8 +150,8 @@ export function AccountsPage(): React.JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const windowMs = Number(windowPreset)
-      const sinceMs = Date.now() - windowMs
+      const nowMs = Date.now()
+      const { sinceMs } = windowPresetToRange(windowPreset, nowMs)
 
       const [accRes, metaRes] = await Promise.all([
         getAdminAccounts({ sinceMs, includeStats: true }),
@@ -227,10 +228,8 @@ export function AccountsPage(): React.JSX.Element {
     return out
   }, [accounts, query, sortBy])
 
-  const windowMs = Number(windowPreset)
   const nowMs = Date.now()
-  const fromMs = String(nowMs - windowMs)
-  const toMs = String(nowMs)
+  const { fromMs, toMs } = windowPresetToRange(windowPreset, nowMs)
 
   return (
     <div className="space-y-4">
@@ -244,6 +243,7 @@ export function AccountsPage(): React.JSX.Element {
             <SelectContent>
               <SelectItem value="86400000">{t("accountsPage.window.last24h")}</SelectItem>
               <SelectItem value="604800000">{t("accountsPage.window.last7d")}</SelectItem>
+              <SelectItem value="this_month">{t("accountsPage.window.thisMonth")}</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- Accounts page: add "This month" stats window preset (natural month) and set as default
- Remove motion strength selector; force magic motion across Admin UI

## Testing
- bun run typecheck:admin
- bun run lint:admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 账户页面新增“本月”时间窗口选项，并设为默认。

* **变更**
  * 移除界面上的动作偏好切换控件，动作偏好改为统一固定策略。
  * KPI 数值展示不再区分减动作偏好，始终使用动画数值展示。
  * 本地化：新增“本月”对应的中/英文翻译项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->