### PR TITLE
feat: add thinkingTextFallback config

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -101,6 +101,7 @@ export type AdminConfig = {
   forceAgent?: boolean
   compactUseSmallModel?: boolean
   messageStartInputTokensFallback?: boolean
+  thinkingTextFallback?: boolean
   modelRefreshIntervalHours?: number
 }
 

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -343,7 +343,9 @@
       "compactUseSmallModelLabel": "Compact uses small model",
       "compactUseSmallModelHint": "When enabled, compact requests use the configured smallModel; otherwise they use the requested model.",
       "messageStartInputTokensFallbackLabel": "Estimate input tokens at stream start",
-      "messageStartInputTokensFallbackHint": "When enabled, estimates message_start input tokens when upstream usage is unavailable."
+      "messageStartInputTokensFallbackHint": "When enabled, estimates message_start input tokens when upstream usage is unavailable.",
+      "thinkingTextFallbackLabel": "Fill missing thinking text (Thinking...)",
+      "thinkingTextFallbackHint": "When enabled, if upstream returns a thinking signature/opaque without any summary/text, the server fills thinking with \"Thinking...\" for client compatibility. When disabled, thinking text remains empty (some clients may drop empty thinking blocks, potentially affecting cache reuse)."
     }
   },
   "notFound": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -343,7 +343,9 @@
       "compactUseSmallModelLabel": "compact 使用小模型",
       "compactUseSmallModelHint": "启用后，compact 请求使用配置的小模型；否则使用请求的模型。",
       "messageStartInputTokensFallbackLabel": "在流开始时估算输入 tokens",
-      "messageStartInputTokensFallbackHint": "启用后，当上游 usage 不可用时，会估算 message_start 的 input tokens。"
+      "messageStartInputTokensFallbackHint": "启用后，当上游 usage 不可用时，会估算 message_start 的 input tokens。",
+      "thinkingTextFallbackLabel": "自动补齐空 thinking（Thinking...）",
+      "thinkingTextFallbackHint": "启用后，当上游返回 signature/opaque 但缺少 thinking 文本时，会将 thinking 填充为“Thinking...”，以兼容可能丢弃空 thinking block 的客户端。关闭后将返回空 thinking（部分客户端可能会丢弃该 block，并可能影响缓存命中）。"
     }
   },
   "notFound": {

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1343,6 +1343,7 @@ type AdvancedSettingsCardProps = {
   forceAgent: boolean
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
+  thinkingTextFallback: boolean
   onToggleLoadBalancing: (value: boolean) => void
   onModelRefreshIntervalChange: (value: string) => void
   onToggleAllowOriginalModelNamesForAliases: (value: boolean) => void
@@ -1350,6 +1351,7 @@ type AdvancedSettingsCardProps = {
   onToggleForceAgent: (value: boolean) => void
   onToggleCompactUseSmallModel: (value: boolean) => void
   onToggleMessageStartInputTokensFallback: (value: boolean) => void
+  onToggleThinkingTextFallback: (value: boolean) => void
 }
 
 function AdvancedSettingsCard({
@@ -1361,6 +1363,7 @@ function AdvancedSettingsCard({
   forceAgent,
   compactUseSmallModel,
   messageStartInputTokensFallback,
+  thinkingTextFallback,
   onToggleLoadBalancing,
   onModelRefreshIntervalChange,
   onToggleAllowOriginalModelNamesForAliases,
@@ -1368,6 +1371,7 @@ function AdvancedSettingsCard({
   onToggleForceAgent,
   onToggleCompactUseSmallModel,
   onToggleMessageStartInputTokensFallback,
+  onToggleThinkingTextFallback,
 }: AdvancedSettingsCardProps): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -1485,6 +1489,21 @@ function AdvancedSettingsCard({
             onCheckedChange={onToggleMessageStartInputTokensFallback}
           />
         </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.advanced.thinkingTextFallbackLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.advanced.thinkingTextFallbackHint")}
+            </div>
+          </div>
+          <Switch
+            checked={thinkingTextFallback}
+            onCheckedChange={onToggleThinkingTextFallback}
+          />
+        </div>
       </CardContent>
     </Card>
   )
@@ -1545,11 +1564,13 @@ type SettingsPageViewProps = {
   forceAgent: boolean
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
+  thinkingTextFallback: boolean
   onAllowOriginalModelNamesForAliasesToggle: (value: boolean) => void
   onUseFunctionApplyPatchToggle: (value: boolean) => void
   onForceAgentToggle: (value: boolean) => void
   onCompactUseSmallModelToggle: (value: boolean) => void
   onMessageStartInputTokensFallbackToggle: (value: boolean) => void
+  onThinkingTextFallbackToggle: (value: boolean) => void
 }
 
 function useSettingsPageState(): SettingsPageViewProps {
@@ -1804,6 +1825,13 @@ function useSettingsPageState(): SettingsPageViewProps {
     [setDraft],
   )
 
+  const handleThinkingTextFallbackToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, thinkingTextFallback: value }))
+    },
+    [setDraft],
+  )
+
   const hasModels = models.length > 0
   const smallModelValue = draft.smallModel ? draft.smallModel : "__default__"
   const canSave =
@@ -1832,6 +1860,7 @@ function useSettingsPageState(): SettingsPageViewProps {
   const compactUseSmallModel = draft.compactUseSmallModel ?? true
   const messageStartInputTokensFallback =
     draft.messageStartInputTokensFallback ?? false
+  const thinkingTextFallback = draft.thinkingTextFallback ?? true
 
   return {
     loading,
@@ -1888,6 +1917,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     forceAgent,
     compactUseSmallModel,
     messageStartInputTokensFallback,
+    thinkingTextFallback,
     onAllowOriginalModelNamesForAliasesToggle:
       handleAllowOriginalModelNamesForAliasesToggle,
     onUseFunctionApplyPatchToggle: handleUseFunctionApplyPatchToggle,
@@ -1895,6 +1925,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     onCompactUseSmallModelToggle: handleCompactUseSmallModelToggle,
     onMessageStartInputTokensFallbackToggle:
       handleMessageStartInputTokensFallbackToggle,
+    onThinkingTextFallbackToggle: handleThinkingTextFallbackToggle,
   }
 }
 
@@ -1953,11 +1984,13 @@ function SettingsPageView({
   forceAgent,
   compactUseSmallModel,
   messageStartInputTokensFallback,
+  thinkingTextFallback,
   onAllowOriginalModelNamesForAliasesToggle,
   onUseFunctionApplyPatchToggle,
   onForceAgentToggle,
   onCompactUseSmallModelToggle,
   onMessageStartInputTokensFallbackToggle,
+  onThinkingTextFallbackToggle,
 }: SettingsPageViewProps): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -2127,6 +2160,7 @@ function SettingsPageView({
               forceAgent={forceAgent}
               compactUseSmallModel={compactUseSmallModel}
               messageStartInputTokensFallback={messageStartInputTokensFallback}
+              thinkingTextFallback={thinkingTextFallback}
               onToggleLoadBalancing={onLoadBalancingToggle}
               onModelRefreshIntervalChange={onModelRefreshIntervalChange}
               onToggleAllowOriginalModelNamesForAliases={
@@ -2138,6 +2172,7 @@ function SettingsPageView({
               onToggleMessageStartInputTokensFallback={
                 onMessageStartInputTokensFallbackToggle
               }
+              onToggleThinkingTextFallback={onThinkingTextFallbackToggle}
             />
           </SettingsSectionCard>
         </main>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,7 @@ export interface AppConfig {
   forceAgent?: boolean
   compactUseSmallModel?: boolean
   messageStartInputTokensFallback?: boolean
+  thinkingTextFallback?: boolean
   modelRefreshIntervalHours?: number
 }
 
@@ -42,6 +43,7 @@ const defaultConfig: AppConfig = {
   useFunctionApplyPatch: true,
   compactUseSmallModel: true,
   messageStartInputTokensFallback: false,
+  thinkingTextFallback: true,
   modelRefreshIntervalHours: 24,
 }
 
@@ -430,6 +432,11 @@ export function getModelRefreshIntervalMs(): number {
 export function isMessageStartInputTokensFallbackEnabled(): boolean {
   const config = getConfig()
   return config.messageStartInputTokensFallback ?? false
+}
+
+export function isThinkingTextFallbackEnabled(): boolean {
+  const config = getConfig()
+  return config.thinkingTextFallback ?? true
 }
 
 export function getReasoningEffortForModel(

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { Hono, type Context } from "hono"
 import { randomUUID } from "node:crypto"
 import fs from "node:fs/promises"
@@ -156,6 +155,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "forceAgent",
   "compactUseSmallModel",
   "messageStartInputTokensFallback",
+  "thinkingTextFallback",
   "modelRefreshIntervalHours",
 ])
 
@@ -391,6 +391,7 @@ function applyOptionalBoolean(
     | "forceAgent"
     | "compactUseSmallModel"
     | "messageStartInputTokensFallback"
+    | "thinkingTextFallback"
     | "allowOriginalModelNamesForAliases",
   value: unknown,
 ): string | undefined {
@@ -461,6 +462,36 @@ function applyModelAliases(
   return undefined
 }
 
+type ConfigPatchHandler = (
+  next: AppConfig,
+  value: unknown,
+) => string | undefined
+
+const CONFIG_PATCH_HANDLERS: Readonly<
+  Partial<Record<keyof AppConfig, ConfigPatchHandler>>
+> = {
+  extraPrompts: applyExtraPrompts,
+  smallModel: (next, value) => applyOptionalString(next, "smallModel", value),
+  freeModelLoadBalancing: (next, value) =>
+    applyOptionalBoolean(next, "freeModelLoadBalancing", value),
+  apiKey: (next, value) => applyOptionalString(next, "apiKey", value),
+  modelReasoningEfforts: applyReasoningEfforts,
+  modelAliases: applyModelAliases,
+  allowOriginalModelNamesForAliases: (next, value) =>
+    applyOptionalBoolean(next, "allowOriginalModelNamesForAliases", value),
+  useFunctionApplyPatch: (next, value) =>
+    applyOptionalBoolean(next, "useFunctionApplyPatch", value),
+  forceAgent: (next, value) => applyOptionalBoolean(next, "forceAgent", value),
+  compactUseSmallModel: (next, value) =>
+    applyOptionalBoolean(next, "compactUseSmallModel", value),
+  messageStartInputTokensFallback: (next, value) =>
+    applyOptionalBoolean(next, "messageStartInputTokensFallback", value),
+  thinkingTextFallback: (next, value) =>
+    applyOptionalBoolean(next, "thinkingTextFallback", value),
+  modelRefreshIntervalHours: (next, value) =>
+    applyOptionalNumber(next, "modelRefreshIntervalHours", value),
+}
+
 function applyConfigPatch(
   base: AppConfig,
   input: Record<string, unknown>,
@@ -473,70 +504,12 @@ function applyConfigPatch(
       return { error: `Unknown config key: ${rawKey}` }
     }
 
-    let error: string | undefined
-
-    switch (rawKey) {
-      case "extraPrompts": {
-        error = applyExtraPrompts(next, value)
-        break
-      }
-      case "smallModel": {
-        error = applyOptionalString(next, "smallModel", value)
-        break
-      }
-      case "freeModelLoadBalancing": {
-        error = applyOptionalBoolean(next, "freeModelLoadBalancing", value)
-        break
-      }
-      case "apiKey": {
-        error = applyOptionalString(next, "apiKey", value)
-        break
-      }
-      case "modelReasoningEfforts": {
-        error = applyReasoningEfforts(next, value)
-        break
-      }
-      case "modelAliases": {
-        error = applyModelAliases(next, value)
-        break
-      }
-      case "allowOriginalModelNamesForAliases": {
-        error = applyOptionalBoolean(
-          next,
-          "allowOriginalModelNamesForAliases",
-          value,
-        )
-        break
-      }
-      case "useFunctionApplyPatch": {
-        error = applyOptionalBoolean(next, "useFunctionApplyPatch", value)
-        break
-      }
-      case "forceAgent": {
-        error = applyOptionalBoolean(next, "forceAgent", value)
-        break
-      }
-      case "compactUseSmallModel": {
-        error = applyOptionalBoolean(next, "compactUseSmallModel", value)
-        break
-      }
-      case "messageStartInputTokensFallback": {
-        error = applyOptionalBoolean(
-          next,
-          "messageStartInputTokensFallback",
-          value,
-        )
-        break
-      }
-      case "modelRefreshIntervalHours": {
-        error = applyOptionalNumber(next, "modelRefreshIntervalHours", value)
-        break
-      }
-      default: {
-        return { error: `Unsupported config key: ${rawKey}` }
-      }
+    const handler = CONFIG_PATCH_HANDLERS[key]
+    if (!handler) {
+      return { error: `Unsupported config key: ${rawKey}` }
     }
 
+    const error = handler(next, value)
     if (error) return { error }
   }
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -13,6 +13,7 @@ import {
   getReasoningEffortForModel,
   getSmallModel,
   isMessageStartInputTokensFallbackEnabled,
+  isThinkingTextFallbackEnabled,
   shouldCompactUseSmallModel,
 } from "~/lib/config"
 import {
@@ -580,7 +581,10 @@ async function handleChatCompletionsNonStreaming(params: {
       JSON.stringify(response),
     )
 
-    const anthropicResponse = translateToAnthropic(response)
+    const thinkingTextFallbackEnabled = isThinkingTextFallbackEnabled()
+    const anthropicResponse = translateToAnthropic(response, {
+      thinkingTextFallback: thinkingTextFallbackEnabled,
+    })
     logger.debug(
       "Translated Anthropic response:",
       JSON.stringify(anthropicResponse),
@@ -634,6 +638,8 @@ async function streamChatCompletionsAndLog(params: {
   const { stream, response, instr, estimatedInputTokens, historicalUsage } =
     params
 
+  const thinkingTextFallbackEnabled = isThinkingTextFallbackEnabled()
+
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
 
@@ -679,7 +685,9 @@ async function streamChatCompletionsAndLog(params: {
         lastUsage = normalizeChatCompletionsUsage(chunk.usage)
       }
 
-      const events = translateChunkToAnthropicEvents(chunk, streamState)
+      const events = translateChunkToAnthropicEvents(chunk, streamState, {
+        thinkingTextFallback: thinkingTextFallbackEnabled,
+      })
       for (const event of events) {
         logger.debug("Translated Anthropic event:", JSON.stringify(event))
 
@@ -784,7 +792,10 @@ async function handleResponsesNonStreaming(params: {
       JSON.stringify(result).slice(-400),
     )
 
-    const anthropicResponse = translateResponsesResultToAnthropic(result)
+    const thinkingTextFallbackEnabled = isThinkingTextFallbackEnabled()
+    const anthropicResponse = translateResponsesResultToAnthropic(result, {
+      thinkingTextFallback: thinkingTextFallbackEnabled,
+    })
     logger.debug(
       "Translated Anthropic response:",
       JSON.stringify(anthropicResponse),
@@ -862,6 +873,8 @@ async function streamResponsesAndLog(params: {
   const { stream, response, instr, estimatedInputTokens, historicalUsage } =
     params
 
+  const thinkingTextFallbackEnabled = isThinkingTextFallbackEnabled()
+
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
 
@@ -900,7 +913,9 @@ async function streamResponsesAndLog(params: {
         lastUsage = u
       }
 
-      const events = translateResponsesStreamEvent(parsed, streamState)
+      const events = translateResponsesStreamEvent(parsed, streamState, {
+        thinkingTextFallback: thinkingTextFallbackEnabled,
+      })
       for (const event of events) {
         const eventData = JSON.stringify(event)
         logger.debug("Translated Anthropic event:", eventData)

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -29,6 +29,10 @@ import { mapOpenAIStopReasonToAnthropic } from "./utils"
 // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we need add a default thinking text
 export const THINKING_TEXT = "Thinking..."
 
+type ThinkingTextFallbackOptions = {
+  thinkingTextFallback?: boolean
+}
+
 // Payload translation
 export function translateToOpenAI(
   payload: AnthropicMessagesPayload,
@@ -358,7 +362,10 @@ function translateAnthropicToolChoiceToOpenAI(
 
 export function translateToAnthropic(
   response: ChatCompletionResponse,
+  options?: ThinkingTextFallbackOptions,
 ): AnthropicResponse {
+  const thinkingTextFallbackEnabled = options?.thinkingTextFallback ?? true
+
   // Merge content from all choices
   const assistantContentBlocks: Array<AnthropicAssistantContentBlock> = []
   let stopReason = response.choices[0]?.finish_reason ?? null
@@ -369,6 +376,7 @@ export function translateToAnthropic(
     const thinkBlocks = getAnthropicThinkBlocks(
       choice.message.reasoning_text,
       choice.message.reasoning_opaque,
+      thinkingTextFallbackEnabled,
     )
     const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
 
@@ -388,18 +396,27 @@ export function translateToAnthropic(
     content: assistantContentBlocks,
     stop_reason: mapOpenAIStopReasonToAnthropic(stopReason),
     stop_sequence: null,
-    usage: {
-      input_tokens:
-        (response.usage?.prompt_tokens ?? 0)
-        - (response.usage?.prompt_tokens_details?.cached_tokens ?? 0),
-      output_tokens: response.usage?.completion_tokens ?? 0,
-      ...(response.usage?.prompt_tokens_details?.cached_tokens
-        !== undefined && {
-        cache_read_input_tokens:
-          response.usage.prompt_tokens_details.cached_tokens,
-      }),
-    },
+    usage: mapChatCompletionsUsage(response.usage),
   }
+}
+
+function mapChatCompletionsUsage(
+  usage: ChatCompletionResponse["usage"],
+): AnthropicResponse["usage"] {
+  const promptTokens = usage?.prompt_tokens ?? 0
+  const cachedTokens = usage?.prompt_tokens_details?.cached_tokens
+  const completionTokens = usage?.completion_tokens ?? 0
+
+  const result: AnthropicResponse["usage"] = {
+    input_tokens: promptTokens - (cachedTokens ?? 0),
+    output_tokens: completionTokens,
+  }
+
+  if (cachedTokens !== undefined) {
+    result.cache_read_input_tokens = cachedTokens
+  }
+
+  return result
 }
 
 function getAnthropicTextBlocks(
@@ -421,6 +438,7 @@ function getAnthropicTextBlocks(
 function getAnthropicThinkBlocks(
   reasoningText: string | null | undefined,
   reasoningOpaque: string | null | undefined,
+  thinkingTextFallbackEnabled: boolean,
 ): Array<AnthropicThinkingBlock> {
   if (reasoningText && reasoningText.length > 0) {
     return [
@@ -435,7 +453,8 @@ function getAnthropicThinkBlocks(
     return [
       {
         type: "thinking",
-        thinking: THINKING_TEXT, // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
+        // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
+        thinking: thinkingTextFallbackEnabled ? THINKING_TEXT : "",
         signature: reasoningOpaque,
       },
     ]

--- a/src/routes/messages/responses-stream-translation.ts
+++ b/src/routes/messages/responses-stream-translation.ts
@@ -24,6 +24,10 @@ import {
 
 const MAX_CONSECUTIVE_FUNCTION_CALL_WHITESPACE = 20
 
+type ThinkingTextFallbackOptions = {
+  thinkingTextFallback?: boolean
+}
+
 class FunctionCallArgumentsValidationError extends Error {
   constructor(message: string) {
     super(message)
@@ -91,7 +95,9 @@ export const createResponsesStreamState = (): ResponsesStreamState => ({
 export const translateResponsesStreamEvent = (
   rawEvent: ResponseStreamEvent,
   state: ResponsesStreamState,
+  options?: ThinkingTextFallbackOptions,
 ): Array<AnthropicStreamEventData> => {
+  const thinkingTextFallbackEnabled = options?.thinkingTextFallback ?? true
   const eventType = rawEvent.type
   switch (eventType) {
     case "response.created": {
@@ -118,7 +124,7 @@ export const translateResponsesStreamEvent = (
       return handleOutputTextDone(rawEvent, state)
     }
     case "response.output_item.done": {
-      return handleOutputItemDone(rawEvent, state)
+      return handleOutputItemDone(rawEvent, state, thinkingTextFallbackEnabled)
     }
 
     case "response.function_call_arguments.delta": {
@@ -193,6 +199,7 @@ const handleOutputItemAdded = (
 const handleOutputItemDone = (
   rawEvent: ResponseOutputItemDoneEvent,
   state: ResponsesStreamState,
+  thinkingTextFallbackEnabled: boolean,
 ): Array<AnthropicStreamEventData> => {
   const events = new Array<AnthropicStreamEventData>()
   const item = rawEvent.item
@@ -206,7 +213,10 @@ const handleOutputItemDone = (
   const signature = (item.encrypted_content ?? "") + "@" + item.id
   if (signature) {
     // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
-    if (!item.summary || item.summary.length === 0) {
+    if (
+      thinkingTextFallbackEnabled
+      && (!item.summary || item.summary.length === 0)
+    ) {
       events.push({
         type: "content_block_delta",
         index: blockIndex,

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -47,6 +47,10 @@ const MESSAGE_TYPE = "message"
 
 export const THINKING_TEXT = "Thinking..."
 
+type ThinkingTextFallbackOptions = {
+  thinkingTextFallback?: boolean
+}
+
 export const translateAnthropicMessagesToResponsesPayload = (
   payload: AnthropicMessagesPayload,
   modelOverride?: string,
@@ -351,8 +355,14 @@ const convertAnthropicToolChoice = (
 
 export const translateResponsesResultToAnthropic = (
   response: ResponsesResult,
+  options?: ThinkingTextFallbackOptions,
 ): AnthropicResponse => {
-  const contentBlocks = mapOutputToAnthropicContent(response.output)
+  const thinkingTextFallbackEnabled = options?.thinkingTextFallback ?? true
+
+  const contentBlocks = mapOutputToAnthropicContent(
+    response.output,
+    thinkingTextFallbackEnabled,
+  )
   const usage = mapResponsesUsage(response)
   let anthropicContent = fallbackContentBlocks(response.output_text)
   if (contentBlocks.length > 0) {
@@ -375,18 +385,24 @@ export const translateResponsesResultToAnthropic = (
 
 const mapOutputToAnthropicContent = (
   output: Array<ResponseOutputItem>,
+  thinkingTextFallbackEnabled: boolean,
 ): Array<AnthropicAssistantContentBlock> => {
   const contentBlocks: Array<AnthropicAssistantContentBlock> = []
 
   for (const item of output) {
     switch (item.type) {
       case "reasoning": {
-        const thinkingText = extractReasoningText(item)
-        if (thinkingText.length > 0) {
+        const signature = (item.encrypted_content ?? "") + "@" + item.id
+        const thinkingText = extractReasoningText(
+          item,
+          thinkingTextFallbackEnabled,
+        )
+
+        if (signature.length > 0 || thinkingText.length > 0) {
           contentBlocks.push({
             type: "thinking",
             thinking: thinkingText,
-            signature: (item.encrypted_content ?? "") + "@" + item.id,
+            signature,
           })
         }
         break
@@ -454,7 +470,10 @@ const combineMessageTextContent = (
   return aggregated
 }
 
-const extractReasoningText = (item: ResponseOutputReasoning): string => {
+const extractReasoningText = (
+  item: ResponseOutputReasoning,
+  thinkingTextFallbackEnabled: boolean,
+): string => {
   const segments: Array<string> = []
 
   const collectFromBlocks = (blocks?: Array<ResponseReasoningBlock>) => {
@@ -472,7 +491,7 @@ const extractReasoningText = (item: ResponseOutputReasoning): string => {
 
   // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
   if (!item.summary || item.summary.length === 0) {
-    return THINKING_TEXT
+    return thinkingTextFallbackEnabled ? THINKING_TEXT : ""
   }
 
   collectFromBlocks(item.summary)

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -11,6 +11,15 @@ import {
 import { THINKING_TEXT } from "./non-stream-translation"
 import { mapOpenAIStopReasonToAnthropic } from "./utils"
 
+type ThinkingTextFallbackOptions = {
+  thinkingTextFallback?: boolean
+}
+
+type StreamTranslationContext = {
+  events: Array<AnthropicStreamEventData>
+  thinkingTextFallbackEnabled: boolean
+}
+
 function isToolBlockOpen(state: AnthropicStreamState): boolean {
   if (!state.contentBlockOpen) {
     return false
@@ -24,11 +33,18 @@ function isToolBlockOpen(state: AnthropicStreamState): boolean {
 export function translateChunkToAnthropicEvents(
   chunk: ChatCompletionChunk,
   state: AnthropicStreamState,
+  options?: ThinkingTextFallbackOptions,
 ): Array<AnthropicStreamEventData> {
   const events: Array<AnthropicStreamEventData> = []
 
   if (chunk.choices.length === 0) {
     return events
+  }
+
+  const thinkingTextFallbackEnabled = options?.thinkingTextFallback ?? true
+  const context: StreamTranslationContext = {
+    events,
+    thinkingTextFallbackEnabled,
   }
 
   const choice = chunk.choices[0]
@@ -40,9 +56,9 @@ export function translateChunkToAnthropicEvents(
 
   handleContent(delta, state, events)
 
-  handleToolCalls(delta, state, events)
+  handleToolCalls(delta, state, context)
 
-  handleFinish(choice, state, { events, chunk })
+  handleFinish(choice, state, { ...context, chunk })
 
   return events
 }
@@ -53,6 +69,7 @@ function handleFinish(
   context: {
     events: Array<AnthropicStreamEventData>
     chunk: ChatCompletionChunk
+    thinkingTextFallbackEnabled: boolean
   },
 ) {
   const { events, chunk } = context
@@ -66,7 +83,7 @@ function handleFinish(
       state.contentBlockOpen = false
       state.contentBlockIndex++
       if (!toolBlockOpen) {
-        handleReasoningOpaque(choice.delta, events, state)
+        handleReasoningOpaque(choice.delta, state, context)
       }
     }
 
@@ -99,12 +116,13 @@ function handleFinish(
 function handleToolCalls(
   delta: Delta,
   state: AnthropicStreamState,
-  events: Array<AnthropicStreamEventData>,
+  context: StreamTranslationContext,
 ) {
+  const { events } = context
   if (delta.tool_calls && delta.tool_calls.length > 0) {
     closeThinkingBlockIfOpen(state, events)
 
-    handleReasoningOpaqueInToolCalls(state, events, delta)
+    handleReasoningOpaqueInToolCalls(state, context, delta)
 
     for (const toolCall of delta.tool_calls) {
       if (toolCall.id && toolCall.function?.name) {
@@ -160,9 +178,10 @@ function handleToolCalls(
 
 function handleReasoningOpaqueInToolCalls(
   state: AnthropicStreamState,
-  events: Array<AnthropicStreamEventData>,
+  context: StreamTranslationContext,
   delta: Delta,
 ) {
+  const { events } = context
   if (state.contentBlockOpen && !isToolBlockOpen(state)) {
     events.push({
       type: "content_block_stop",
@@ -171,7 +190,7 @@ function handleReasoningOpaqueInToolCalls(
     state.contentBlockIndex++
     state.contentBlockOpen = false
   }
-  handleReasoningOpaque(delta, events, state)
+  handleReasoningOpaque(delta, state, context)
 }
 
 function handleContent(
@@ -288,27 +307,33 @@ function handleMessageStart(
 
 function handleReasoningOpaque(
   delta: Delta,
-  events: Array<AnthropicStreamEventData>,
   state: AnthropicStreamState,
+  context: StreamTranslationContext,
 ) {
+  const { events, thinkingTextFallbackEnabled } = context
   if (delta.reasoning_opaque && delta.reasoning_opaque.length > 0) {
-    events.push(
-      {
-        type: "content_block_start",
-        index: state.contentBlockIndex,
-        content_block: {
-          type: "thinking",
-          thinking: "",
-        },
+    events.push({
+      type: "content_block_start",
+      index: state.contentBlockIndex,
+      content_block: {
+        type: "thinking",
+        thinking: "",
       },
-      {
+    })
+
+    // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
+    if (thinkingTextFallbackEnabled) {
+      events.push({
         type: "content_block_delta",
         index: state.contentBlockIndex,
         delta: {
           type: "thinking_delta",
-          thinking: THINKING_TEXT, // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
+          thinking: THINKING_TEXT,
         },
-      },
+      })
+    }
+
+    events.push(
       {
         type: "content_block_delta",
         index: state.contentBlockIndex,

--- a/tests/anthropic-response.test.ts
+++ b/tests/anthropic-response.test.ts
@@ -67,6 +67,154 @@ function isValidAnthropicStreamEvent(payload: unknown): boolean {
   return anthropicStreamEventSchema.safeParse(payload).success
 }
 
+const OPENAI_SIMPLE_TEXT_STREAM: Array<ChatCompletionChunk> = [
+  {
+    id: "cmpl-1",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant" },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-1",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: { content: "Hello" },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-1",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: { content: " there" },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-1",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [{ index: 0, delta: {}, finish_reason: "stop", logprobs: null }],
+  },
+]
+
+const OPENAI_TOOL_CALL_STREAM: Array<ChatCompletionChunk> = [
+  {
+    id: "cmpl-2",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant" },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-2",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_xyz",
+              type: "function",
+              function: { name: "get_weather", arguments: "" },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-2",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [{ index: 0, function: { arguments: '{"loc' } }],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-2",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            { index: 0, function: { arguments: 'ation": "Paris"}' } },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "cmpl-2",
+    object: "chat.completion.chunk",
+    created: 1677652288,
+    model: "gpt-4o-2024-05-13",
+    choices: [
+      { index: 0, delta: {}, finish_reason: "tool_calls", logprobs: null },
+    ],
+  },
+]
+
+function createBaseStreamState(
+  overrides: Partial<AnthropicStreamState> = {},
+): AnthropicStreamState {
+  return {
+    messageStartSent: false,
+    contentBlockIndex: 0,
+    contentBlockOpen: false,
+    toolCalls: {},
+    thinkingBlockOpen: false,
+    ...overrides,
+  }
+}
+
 describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
   test("should translate a simple text response correctly", () => {
     const openAIResponse: ChatCompletionResponse = {
@@ -189,78 +337,115 @@ describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
     expect(isValidAnthropicResponse(anthropicResponse)).toBe(true)
     expect(anthropicResponse.stop_reason).toBe("max_tokens")
   })
+
+  test("should optionally fill missing thinking text when only reasoning_opaque is present", () => {
+    const openAIResponse: ChatCompletionResponse = {
+      id: "chatcmpl-thinking",
+      object: "chat.completion",
+      created: 1677652288,
+      model: "gpt-4o-2024-05-13",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Hello",
+            reasoning_opaque: "opaque_sig",
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+      },
+    }
+
+    const withFallback = translateToAnthropic(openAIResponse)
+    expect(withFallback.content[0]?.type).toBe("thinking")
+    if (withFallback.content[0]?.type === "thinking") {
+      expect(withFallback.content[0].thinking).toBe("Thinking...")
+      expect(withFallback.content[0].signature).toBe("opaque_sig")
+    }
+
+    const withoutFallback = translateToAnthropic(openAIResponse, {
+      thinkingTextFallback: false,
+    })
+    expect(withoutFallback.content[0]?.type).toBe("thinking")
+    if (withoutFallback.content[0]?.type === "thinking") {
+      expect(withoutFallback.content[0].thinking).toBe("")
+      expect(withoutFallback.content[0].signature).toBe("opaque_sig")
+    }
+  })
 })
 
 describe("OpenAI to Anthropic Streaming Response Translation", () => {
   test("should translate a simple text stream correctly", () => {
-    const openAIStream: Array<ChatCompletionChunk> = [
-      {
-        id: "cmpl-1",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: { role: "assistant" },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-1",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: { content: "Hello" },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-1",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: { content: " there" },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-1",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          { index: 0, delta: {}, finish_reason: "stop", logprobs: null },
-        ],
-      },
-    ]
-
-    const streamState: AnthropicStreamState = {
-      messageStartSent: false,
-      contentBlockIndex: 0,
-      contentBlockOpen: false,
-      toolCalls: {},
-      thinkingBlockOpen: false,
-    }
-    const translatedStream = openAIStream.flatMap((chunk) =>
+    const streamState = createBaseStreamState()
+    const translatedStream = OPENAI_SIMPLE_TEXT_STREAM.flatMap((chunk) =>
       translateChunkToAnthropicEvents(chunk, streamState),
     )
 
     for (const event of translatedStream) {
       expect(isValidAnthropicStreamEvent(event)).toBe(true)
     }
+  })
+
+  test("should optionally fill missing thinking delta when only reasoning_opaque is present", () => {
+    const chunk: ChatCompletionChunk = {
+      id: "cmpl-thinking",
+      object: "chat.completion.chunk",
+      created: 1677652288,
+      model: "gpt-4o-2024-05-13",
+      choices: [
+        {
+          index: 0,
+          delta: { content: "Hello", reasoning_opaque: "opaque_sig" },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+    }
+
+    const stateWithFallback = createBaseStreamState()
+
+    const eventsWithFallback = translateChunkToAnthropicEvents(
+      chunk,
+      stateWithFallback,
+    )
+    expect(
+      eventsWithFallback.some(
+        (event) =>
+          event.type === "content_block_delta"
+          && event.delta.type === "thinking_delta"
+          && event.delta.thinking === "Thinking...",
+      ),
+    ).toBe(true)
+
+    const stateWithoutFallback = createBaseStreamState()
+
+    const eventsWithoutFallback = translateChunkToAnthropicEvents(
+      chunk,
+      stateWithoutFallback,
+      { thinkingTextFallback: false },
+    )
+    expect(
+      eventsWithoutFallback.some(
+        (event) =>
+          event.type === "content_block_delta"
+          && event.delta.type === "thinking_delta",
+      ),
+    ).toBe(false)
+    expect(
+      eventsWithoutFallback.some(
+        (event) =>
+          event.type === "content_block_delta"
+          && event.delta.type === "signature_delta"
+          && event.delta.signature === "opaque_sig",
+      ),
+    ).toBe(true)
   })
 
   test("should use historical usage when upstream usage is missing", () => {
@@ -279,15 +464,10 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
       ],
     }
 
-    const streamState: AnthropicStreamState = {
-      messageStartSent: false,
-      contentBlockIndex: 0,
-      contentBlockOpen: false,
-      toolCalls: {},
-      thinkingBlockOpen: false,
+    const streamState = createBaseStreamState({
       historicalInputTokens: 42,
       historicalCachedInputTokens: 7,
-    }
+    })
 
     const events = translateChunkToAnthropicEvents(chunk, streamState)
     const messageStart = events.find((event) => event.type === "message_start")
@@ -300,98 +480,8 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
   })
 
   test("should translate a stream with tool calls", () => {
-    const openAIStream: Array<ChatCompletionChunk> = [
-      {
-        id: "cmpl-2",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: { role: "assistant" },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-2",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: {
-              tool_calls: [
-                {
-                  index: 0,
-                  id: "call_xyz",
-                  type: "function",
-                  function: { name: "get_weather", arguments: "" },
-                },
-              ],
-            },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-2",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: {
-              tool_calls: [{ index: 0, function: { arguments: '{"loc' } }],
-            },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-2",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          {
-            index: 0,
-            delta: {
-              tool_calls: [
-                { index: 0, function: { arguments: 'ation": "Paris"}' } },
-              ],
-            },
-            finish_reason: null,
-            logprobs: null,
-          },
-        ],
-      },
-      {
-        id: "cmpl-2",
-        object: "chat.completion.chunk",
-        created: 1677652288,
-        model: "gpt-4o-2024-05-13",
-        choices: [
-          { index: 0, delta: {}, finish_reason: "tool_calls", logprobs: null },
-        ],
-      },
-    ]
-
-    // Streaming translation requires state
-    const streamState: AnthropicStreamState = {
-      messageStartSent: false,
-      contentBlockIndex: 0,
-      contentBlockOpen: false,
-      toolCalls: {},
-      thinkingBlockOpen: false,
-    }
-    const translatedStream = openAIStream.flatMap((chunk) =>
+    const streamState = createBaseStreamState()
+    const translatedStream = OPENAI_TOOL_CALL_STREAM.flatMap((chunk) =>
       translateChunkToAnthropicEvents(chunk, streamState),
     )
 

--- a/tests/responses-translation.test.ts
+++ b/tests/responses-translation.test.ts
@@ -157,4 +157,72 @@ describe("translateResponsesResultToAnthropic", () => {
       expect(textBlock.text).toBe("Added the task to your todo list.")
     }
   })
+
+  it("optionally fills missing thinking text when reasoning summary is empty", () => {
+    const responsesResult: ResponsesResult = {
+      id: "resp_thinking",
+      object: "response",
+      created_at: 0,
+      model: "gpt-4.1",
+      output: [
+        {
+          id: "reason_empty",
+          type: "reasoning",
+          summary: [],
+          status: "completed",
+          encrypted_content: "encrypted_reasoning_content",
+        },
+        {
+          id: "message_1",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text: "Done.",
+              annotations: [],
+            },
+          ],
+        },
+      ],
+      output_text: "Done.",
+      status: "completed",
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+      },
+      error: null,
+      incomplete_details: null,
+      instructions: null,
+      metadata: null,
+      parallel_tool_calls: false,
+      temperature: null,
+      tool_choice: null,
+      tools: [],
+      top_p: null,
+    }
+
+    const withFallback = translateResponsesResultToAnthropic(responsesResult)
+    expect(withFallback.content[0]?.type).toBe("thinking")
+    if (withFallback.content[0]?.type === "thinking") {
+      expect(withFallback.content[0].thinking).toBe("Thinking...")
+      expect(withFallback.content[0].signature).toBe(
+        "encrypted_reasoning_content@reason_empty",
+      )
+    }
+
+    const withoutFallback = translateResponsesResultToAnthropic(
+      responsesResult,
+      { thinkingTextFallback: false },
+    )
+    expect(withoutFallback.content[0]?.type).toBe("thinking")
+    if (withoutFallback.content[0]?.type === "thinking") {
+      expect(withoutFallback.content[0].thinking).toBe("")
+      expect(withoutFallback.content[0].signature).toBe(
+        "encrypted_reasoning_content@reason_empty",
+      )
+    }
+  })
 })


### PR DESCRIPTION
## 变更说明
- 新增配置项 `thinkingTextFallback`（默认：true），用于控制是否在缺失 thinking 文本时自动填充 `Thinking...`
- Admin UI：Settings → Advanced 新增「自动补齐空 thinking（Thinking...）」开关
- 覆盖 `/v1/messages` 的 chat.completions 与 responses 两条链路（流式/非流式）
- 新增/更新测试用例

## 配置示例
```json
{
  "thinkingTextFallback": false
}
```

## 测试
- bun test
- bun run lint
- bun run lint:admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **New Features**
  * 在高级设置中新增"思维文本回退"开关，允许用户控制当上游响应缺少思维内容时，是否自动填充默认文本。

* **Tests**
  * 添加测试用例验证思维文本回退功能在启用和禁用状态下的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->