### PR TITLE
feat(admin): expose missing config settings

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -33,6 +33,7 @@
 - 支持请求级限速（`--rate-limit`）与等待模式（`--wait`）
 - 支持手动审批请求（`--manual`）
 - 支持 API Key 鉴权中间件（`auth.apiKeys`，兼容旧字段）
+- 支持多 Provider Anthropic 上游代理路由（`/:provider/v1/messages`、`/:provider/v1/models`），并支持按模型配置默认参数（temperature/topP/topK）
 - 内置 Admin UI 与 Admin API（账户状态、请求日志、配置管理）
 - 请求历史落库 SQLite（默认 14 天保留、上限 200000 行）
 - 支持 `--claude-code` 一键生成 Claude Code 环境变量命令
@@ -263,26 +264,34 @@ Admin API 规则独立于业务 API：
 
 ## 配置文件（config.json）
 
-路径：`~/.local/share/copilot-api/config.json`
+路径：`~/.local/share/copilot-api/config.json`（Linux/macOS）或 `%USERPROFILE%\\.local\\share\\copilot-api\\config.json`（Windows）
 
 默认值（按当前代码）：
 
 ```json
 {
-  "auth": { "apiKeys": [] },
+  "auth": {
+    "apiKeys": []
+  },
+  "providers": {},
   "extraPrompts": {
     "gpt-5-mini": "<built-in prompt>",
-    "gpt-5.1-codex-max": "<built-in prompt>",
-    "gpt-5.3-codex": "<built-in prompt>"
+    "gpt-5.3-codex": "<built-in prompt>",
+    "gpt-5.4": "<built-in prompt>"
   },
   "smallModel": "gpt-5-mini",
   "freeModelLoadBalancing": true,
+  "responsesApiContextManagementModels": [],
   "modelReasoningEfforts": {
-    "gpt-5-mini": "low"
+    "gpt-5-mini": "low",
+    "gpt-5.3-codex": "xhigh",
+    "gpt-5.4": "xhigh"
   },
   "allowOriginalModelNamesForAliases": false,
   "useFunctionApplyPatch": true,
+  "forceAgent": false,
   "compactUseSmallModel": true,
+  "useMessagesApi": true,
   "messageStartInputTokensFallback": false,
   "modelRefreshIntervalHours": 24
 }
@@ -294,24 +303,58 @@ Admin API 规则独立于业务 API：
 | --- | --- |
 | `auth.apiKeys` | 业务 API 鉴权 key 列表（推荐） |
 | `apiKey` | 旧版单 key（弃用兼容） |
-| `extraPrompts` | 按模型附加系统提示词 |
+| `providers` | 上游 provider 映射（Anthropic 兼容代理路由）：每个 key 会生成 `/:provider/v1/messages`、`/:provider/v1/models` 等路由前缀；目前仅支持 `type: "anthropic"`；可选 `models` 定义 `temperature/topP/topK` 默认值（仅在请求未显式指定时生效）。 |
+| `extraPrompts` | 按模型附加 system prompt（在 Anthropic 请求翻译时注入） |
 | `smallModel` | 小模型（预热/compact 场景回落） |
 | `freeModelLoadBalancing` | 免费模型是否轮询分发 |
+| `responsesApiContextManagementModels` | 需要注入 Responses API `context_management` 压缩指令的模型 ID 列表（用于支持服务端 context management 的模型）。 |
 | `modelReasoningEfforts` | Responses API 的模型推理强度配置 |
 | `modelAliases` | 模型别名映射（支持 `allowOriginal`） |
 | `allowOriginalModelNamesForAliases` | 别名目标模型原名是否全局可用 |
 | `useFunctionApplyPatch` | 是否将 `custom/apply_patch` 转换为 function tool |
 | `forceAgent` | Responses 中 assistant 角色判定策略 |
 | `compactUseSmallModel` | compact 请求自动使用 smallModel |
+| `useMessagesApi` | 是否允许 `/v1/messages` 优先尝试 Copilot 原生 Messages API；关闭时将跳过该候选并从 `/responses`（如支持）或 `/chat/completions` 回退。 |
 | `messageStartInputTokensFallback` | Anthropic 流式首包 token 估算回退 |
 | `modelRefreshIntervalHours` | 模型刷新周期（小时，`0` 关闭） |
 
+### providers 示例（Anthropic 上游代理）
+
+`providers` 用于将本服务作为“Anthropic 兼容代理”，转发请求到你自定义的 Anthropic-compatible 上游。
+
+- provider key 会作为路由前缀（例如 `custom` -> `http://localhost:4141/custom/v1/messages`）
+- `baseUrl` 为上游 API base URL（不要带尾部 `/v1/messages`）
+- `enabled` 省略时默认 `true`
+- `models` 为可选的按模型默认参数配置（仅在请求未显式指定时生效）
+
+```json
+{
+  "providers": {
+    "custom": {
+      "type": "anthropic",
+      "enabled": true,
+      "baseUrl": "https://api.anthropic.com",
+      "apiKey": "sk-your-provider-key",
+      "models": {
+        "kimi-k2.5": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 50
+        }
+      }
+    }
+  }
+}
+```
+
 ### 配置热更新
 
-可通过 Admin API 修改配置：
+可通过 Admin UI 或 Admin API 修改配置：
 
-- `GET /api/admin/config`
-- `POST /api/admin/config`
+- Admin UI：`/admin#/settings`
+- Admin API：
+  - `GET /api/admin/config`
+  - `POST /api/admin/config`
 
 `POST` 支持部分字段 patch，包含类型校验与安全键过滤（如 `__proto__` 会被拒绝）。更新成功后会立即应用关键运行参数（如免费模型负载均衡、模型刷新间隔）。
 
@@ -342,6 +385,9 @@ Admin API 规则独立于业务 API：
 | --- | --- | --- |
 | `/v1/messages` | `POST` | Messages 接口 |
 | `/v1/messages/count_tokens` | `POST` | Token 计数 |
+| `/:provider/v1/messages` | `POST` | 代理转发 Anthropic Messages API 到配置的 provider |
+| `/:provider/v1/models` | `GET` | 代理转发 Anthropic Models API 到配置的 provider |
+| `/:provider/v1/messages/count_tokens` | `POST` | provider 路由的 token 计数（本地计算） |
 
 ### 使用与状态
 
@@ -368,11 +414,15 @@ Admin API 规则独立于业务 API：
 
 ### 0) Messages 上游回退链路
 
-`POST /v1/messages` 在选择可用上游时，会按候选顺序尝试：
+`POST /v1/messages` 在选择可用上游时，会按候选顺序尝试（候选集受 `useMessagesApi` 影响）：
 
-1. `"/v1/messages"`
-2. `"/responses"`
-3. `"/chat/completions"`
+- 当 `useMessagesApi=true`（默认）：
+  1. `"/v1/messages"`
+  2. `"/responses"`
+  3. `"/chat/completions"`
+- 当 `useMessagesApi=false`：
+  1. `"/responses"`
+  2. `"/chat/completions"`
 
 系统会结合模型可用性、账号状态与配额结果选择最终路径。
 

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -89,15 +89,31 @@ export type ModelAliasSpec = {
   allowOriginal?: boolean
 }
 
+export type ProviderModelConfig = {
+  temperature?: number
+  topP?: number
+  topK?: number
+}
+
+export type ProviderConfig = {
+  type?: string
+  enabled?: boolean
+  baseUrl?: string
+  apiKey?: string
+  models?: Record<string, ProviderModelConfig>
+}
+
 export type AdminConfig = {
   auth?: {
     apiKeys?: Array<string>
   }
+  providers?: Record<string, ProviderConfig>
   extraPrompts?: Record<string, string>
   smallModel?: string
   freeModelLoadBalancing?: boolean
   /** @deprecated */
   apiKey?: string
+  responsesApiContextManagementModels?: Array<string>
   modelReasoningEfforts?: Record<string, ReasoningEffort>
   modelAliases?: Record<string, ModelAliasSpec | string>
   allowOriginalModelNamesForAliases?: boolean
@@ -106,6 +122,7 @@ export type AdminConfig = {
   compactUseSmallModel?: boolean
   messageStartInputTokensFallback?: boolean
   modelRefreshIntervalHours?: number
+  useMessagesApi?: boolean
 }
 
 export type AdminConfigResponse = AdminConfig & {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -343,7 +343,27 @@
       "compactUseSmallModelLabel": "Compact uses small model",
       "compactUseSmallModelHint": "When enabled, compact requests use the configured smallModel; otherwise they use the requested model.",
       "messageStartInputTokensFallbackLabel": "Estimate input tokens at stream start",
-      "messageStartInputTokensFallbackHint": "When enabled, estimates message_start input tokens when upstream usage is unavailable."
+      "messageStartInputTokensFallbackHint": "When enabled, estimates message_start input tokens when upstream usage is unavailable.",
+      "useMessagesApiLabel": "Enable Messages API",
+      "useMessagesApiHint": "When enabled, Claude-family models may use Copilot's native /v1/messages endpoint.",
+      "responsesApiContextManagementModelsLabel": "Responses API context_management models",
+      "responsesApiContextManagementModelsPlaceholder": "one model id per line",
+      "responsesApiContextManagementModelsHint": "List of model IDs that should receive Responses API context_management compaction instructions.",
+      "providersTitle": "Providers",
+      "providersDescription": "Configure upstream providers (currently anthropic only). Each provider key becomes a route prefix (/:provider/v1/messages).",
+      "providersIssueTitle": "Invalid providers",
+      "providersEmptyState": "No providers configured.",
+      "providersAddProvider": "Add provider",
+      "providersNamePlaceholder": "Provider key (route prefix)",
+      "providersEnabledLabel": "Enabled",
+      "providersBaseUrlLabel": "Base URL",
+      "providersBaseUrlPlaceholder": "https://api.anthropic.com",
+      "providersApiKeyLabel": "API key",
+      "providersApiKeyPlaceholder": "sk-...",
+      "providersModelsLabel": "Model defaults",
+      "providersModelsEmptyState": "No per-model defaults.",
+      "providersAddModel": "Add model",
+      "providersModelIdPlaceholder": "Model id"
     }
   },
   "notFound": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -343,7 +343,27 @@
       "compactUseSmallModelLabel": "compact 使用小模型",
       "compactUseSmallModelHint": "启用后，compact 请求使用配置的小模型；否则使用请求的模型。",
       "messageStartInputTokensFallbackLabel": "在流开始时估算输入 tokens",
-      "messageStartInputTokensFallbackHint": "启用后，当上游 usage 不可用时，会估算 message_start 的 input tokens。"
+      "messageStartInputTokensFallbackHint": "启用后，当上游 usage 不可用时，会估算 message_start 的 input tokens。",
+      "useMessagesApiLabel": "启用 Messages API",
+      "useMessagesApiHint": "启用后，支持 Copilot 原生 /v1/messages 的 Claude 系列模型将优先走 Messages API。",
+      "responsesApiContextManagementModelsLabel": "Responses API context_management 模型列表",
+      "responsesApiContextManagementModelsPlaceholder": "每行一个 model id",
+      "responsesApiContextManagementModelsHint": "这些模型将收到 Responses API 的 context_management 压缩指令。",
+      "providersTitle": "上游 Providers",
+      "providersDescription": "配置上游 provider（目前仅支持 anthropic）。每个 provider key 会作为路由前缀（/:provider/v1/messages）。",
+      "providersIssueTitle": "Providers 配置无效",
+      "providersEmptyState": "未配置 providers。",
+      "providersAddProvider": "添加 provider",
+      "providersNamePlaceholder": "Provider key（路由前缀）",
+      "providersEnabledLabel": "启用",
+      "providersBaseUrlLabel": "Base URL",
+      "providersBaseUrlPlaceholder": "https://api.anthropic.com",
+      "providersApiKeyLabel": "API Key",
+      "providersApiKeyPlaceholder": "sk-...",
+      "providersModelsLabel": "模型默认参数",
+      "providersModelsEmptyState": "未配置按模型的默认参数。",
+      "providersAddModel": "添加模型",
+      "providersModelIdPlaceholder": "Model id"
     }
   },
   "notFound": {

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -327,6 +327,99 @@ function providerHasMeaningfulContent(item: ProviderItem): boolean {
   )
 }
 
+type ParsedProviderModelItem =
+  | {
+      modelId: string
+      config: ProviderModelConfig
+    }
+  | null
+
+function parseSingleModelItem(
+  modelItem: ProviderModelItem,
+  providerName: string,
+  seenModels: Set<string>,
+): ParseResult<ParsedProviderModelItem> {
+  const modelId = modelItem.model.trim()
+  const temperatureInput = modelItem.temperature.trim()
+  const topPInput = modelItem.topP.trim()
+  const topKInput = modelItem.topK.trim()
+
+  const hasNumericOverride = Boolean(temperatureInput || topPInput || topKInput)
+
+  if (!modelId) {
+    if (hasNumericOverride) {
+      return {
+        error: `Provider '${providerName}': model id is required when setting overrides.`,
+      }
+    }
+    return { record: null }
+  }
+
+  const normalizedModelId = modelId.toLowerCase()
+  if (BLOCKED_PROVIDER_KEYS.has(normalizedModelId)) {
+    return { error: `Provider '${providerName}' model '${modelId}' is not allowed.` }
+  }
+  if (seenModels.has(normalizedModelId)) {
+    return { error: `Provider '${providerName}' model '${modelId}' is duplicated.` }
+  }
+
+  const config: ProviderModelConfig = {}
+
+  if (temperatureInput) {
+    const parsed = Number(temperatureInput)
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return {
+        error: `Provider '${providerName}' model '${modelId}': temperature must be a non-negative number.`,
+      }
+    }
+    config.temperature = parsed
+  }
+
+  if (topPInput) {
+    const parsed = Number(topPInput)
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return {
+        error: `Provider '${providerName}' model '${modelId}': topP must be a non-negative number.`,
+      }
+    }
+    config.topP = parsed
+  }
+
+  if (topKInput) {
+    const parsed = Number(topKInput)
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return {
+        error: `Provider '${providerName}' model '${modelId}': topK must be a non-negative number.`,
+      }
+    }
+    config.topK = parsed
+  }
+
+  if (Object.keys(config).length === 0) {
+    return { record: null }
+  }
+
+  seenModels.add(normalizedModelId)
+  return { record: { modelId, config } }
+}
+
+function parseProviderModelItems(
+  items: Array<ProviderModelItem>,
+  providerName: string,
+): ParseResult<Record<string, ProviderModelConfig>> {
+  const modelsRecord = Object.create(null) as Record<string, ProviderModelConfig>
+  const seenModels = new Set<string>()
+
+  for (const modelItem of items) {
+    const result = parseSingleModelItem(modelItem, providerName, seenModels)
+    if ("error" in result) return result
+    if (!result.record) continue
+    modelsRecord[result.record.modelId] = result.record.config
+  }
+
+  return { record: modelsRecord }
+}
+
 function providerRecordFromItems(items: Array<ProviderItem>): ParseResult<ProviderRecord> {
   const record: ProviderRecord = Object.create(null) as ProviderRecord
   const seenProviders = new Set<string>()
@@ -360,76 +453,11 @@ function providerRecordFromItems(items: Array<ProviderItem>): ParseResult<Provid
       apiKey: apiKey || undefined,
     }
 
-    const modelsRecord = Object.create(null) as Record<string, ProviderModelConfig>
-    const seenModels = new Set<string>()
+    const modelItemsResult = parseProviderModelItems(item.models, providerName)
+    if ("error" in modelItemsResult) return modelItemsResult
 
-    for (const modelItem of item.models) {
-      const modelId = modelItem.model.trim()
-      const temperatureInput = modelItem.temperature.trim()
-      const topPInput = modelItem.topP.trim()
-      const topKInput = modelItem.topK.trim()
-
-      const hasNumericOverride = Boolean(temperatureInput || topPInput || topKInput)
-
-      if (!modelId) {
-        if (hasNumericOverride) {
-          return {
-            error: `Provider '${providerName}': model id is required when setting overrides.`,
-          }
-        }
-        continue
-      }
-
-      const normalizedModelId = modelId.toLowerCase()
-      if (BLOCKED_PROVIDER_KEYS.has(normalizedModelId)) {
-        return { error: `Provider '${providerName}' model '${modelId}' is not allowed.` }
-      }
-      if (seenModels.has(normalizedModelId)) {
-        return { error: `Provider '${providerName}' model '${modelId}' is duplicated.` }
-      }
-
-      const config: ProviderModelConfig = {}
-
-      if (temperatureInput) {
-        const parsed = Number(temperatureInput)
-        if (!Number.isFinite(parsed) || parsed < 0) {
-          return {
-            error: `Provider '${providerName}' model '${modelId}': temperature must be a non-negative number.`,
-          }
-        }
-        config.temperature = parsed
-      }
-
-      if (topPInput) {
-        const parsed = Number(topPInput)
-        if (!Number.isFinite(parsed) || parsed < 0) {
-          return {
-            error: `Provider '${providerName}' model '${modelId}': topP must be a non-negative number.`,
-          }
-        }
-        config.topP = parsed
-      }
-
-      if (topKInput) {
-        const parsed = Number(topKInput)
-        if (!Number.isFinite(parsed) || parsed < 0) {
-          return {
-            error: `Provider '${providerName}' model '${modelId}': topK must be a non-negative number.`,
-          }
-        }
-        config.topK = parsed
-      }
-
-      if (Object.keys(config).length === 0) {
-        continue
-      }
-
-      seenModels.add(normalizedModelId)
-      modelsRecord[modelId] = config
-    }
-
-    if (Object.keys(modelsRecord).length > 0) {
-      provider.models = modelsRecord
+    if (Object.keys(modelItemsResult.record).length > 0) {
+      provider.models = modelItemsResult.record
     }
 
     record[providerName] = provider

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -7,6 +7,8 @@ import {
   type AdminConfig,
   type AdminConfigResponse,
   type ModelAliasSpec,
+  type ProviderConfig,
+  type ProviderModelConfig,
   type ReasoningEffort,
   getAdminConfig,
   getAdminModels,
@@ -79,6 +81,25 @@ type ModelAliasItem = {
 type ModelAliasRecord = Record<string, ModelAliasSpec>
 
 type ModelAliasRecordInput = Record<string, ModelAliasSpec | string>
+
+type ProviderModelItem = {
+  id: string
+  model: string
+  temperature: string
+  topP: string
+  topK: string
+}
+
+type ProviderItem = {
+  id: string
+  name: string
+  enabled: boolean
+  baseUrl: string
+  apiKey: string
+  models: Array<ProviderModelItem>
+}
+
+type ProviderRecord = Record<string, ProviderConfig>
 
 type ParseResult<T> = { record: T } | { error: string }
 
@@ -164,12 +185,18 @@ function getAuthApiKeysFromConfig(config: AdminConfig): Array<string> {
 }
 
 function parseAuthApiKeysInput(value: string): Array<string> {
-  return [...new Set(
-    value
-      .split(/\r?\n|,/)
-      .map((item) => item.trim())
-      .filter((item) => item.length > 0),
-  )]
+  return parseStringListInput(value)
+}
+
+function parseStringListInput(value: string): Array<string> {
+  return [
+    ...new Set(
+      value
+        .split(/\r?\n|,/)
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0),
+    ),
+  ]
 }
 
 function extraPromptItemsFromRecord(
@@ -264,6 +291,287 @@ function aliasRecordFromItems(items: Array<ModelAliasItem>): ModelAliasRecord {
   }
 
   return record
+}
+
+const BLOCKED_PROVIDER_KEYS = new Set(["__proto__", "constructor", "prototype"])
+
+function providerItemsFromRecord(record: ProviderRecord | undefined): Array<ProviderItem> {
+  if (!record) return []
+
+  return Object.entries(record).map(([name, provider]) => ({
+    id: createItemId(),
+    name,
+    enabled: provider.enabled ?? true,
+    baseUrl: provider.baseUrl ?? "",
+    apiKey: provider.apiKey ?? "",
+    models: Object.entries(provider.models ?? {}).map(([model, config]) => ({
+      id: createItemId(),
+      model,
+      temperature: config.temperature === undefined ? "" : String(config.temperature),
+      topP: config.topP === undefined ? "" : String(config.topP),
+      topK: config.topK === undefined ? "" : String(config.topK),
+    })),
+  }))
+}
+
+function providerHasMeaningfulContent(item: ProviderItem): boolean {
+  if (item.enabled === false) return true
+  if (item.baseUrl.trim() || item.apiKey.trim()) return true
+
+  return item.models.some(
+    (model) =>
+      Boolean(model.model.trim())
+      || Boolean(model.temperature.trim())
+      || Boolean(model.topP.trim())
+      || Boolean(model.topK.trim()),
+  )
+}
+
+function providerRecordFromItems(items: Array<ProviderItem>): ParseResult<ProviderRecord> {
+  const record: ProviderRecord = Object.create(null) as ProviderRecord
+  const seenProviders = new Set<string>()
+
+  for (const item of items) {
+    const providerName = item.name.trim()
+    if (!providerName) {
+      if (providerHasMeaningfulContent(item)) {
+        return { error: "Provider name is required." }
+      }
+      continue
+    }
+
+    const normalizedProviderName = providerName.toLowerCase()
+    if (BLOCKED_PROVIDER_KEYS.has(normalizedProviderName)) {
+      return { error: `Provider '${providerName}' is not allowed.` }
+    }
+    if (seenProviders.has(normalizedProviderName)) {
+      return { error: `Provider '${providerName}' is duplicated.` }
+    }
+
+    seenProviders.add(normalizedProviderName)
+
+    const baseUrl = item.baseUrl.trim()
+    const apiKey = item.apiKey.trim()
+
+    const provider: ProviderConfig = {
+      type: "anthropic",
+      enabled: item.enabled,
+      baseUrl: baseUrl || undefined,
+      apiKey: apiKey || undefined,
+    }
+
+    const modelsRecord = Object.create(null) as Record<string, ProviderModelConfig>
+    const seenModels = new Set<string>()
+
+    for (const modelItem of item.models) {
+      const modelId = modelItem.model.trim()
+      const temperatureInput = modelItem.temperature.trim()
+      const topPInput = modelItem.topP.trim()
+      const topKInput = modelItem.topK.trim()
+
+      const hasNumericOverride = Boolean(temperatureInput || topPInput || topKInput)
+
+      if (!modelId) {
+        if (hasNumericOverride) {
+          return {
+            error: `Provider '${providerName}': model id is required when setting overrides.`,
+          }
+        }
+        continue
+      }
+
+      const normalizedModelId = modelId.toLowerCase()
+      if (BLOCKED_PROVIDER_KEYS.has(normalizedModelId)) {
+        return { error: `Provider '${providerName}' model '${modelId}' is not allowed.` }
+      }
+      if (seenModels.has(normalizedModelId)) {
+        return { error: `Provider '${providerName}' model '${modelId}' is duplicated.` }
+      }
+
+      const config: ProviderModelConfig = {}
+
+      if (temperatureInput) {
+        const parsed = Number(temperatureInput)
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          return {
+            error: `Provider '${providerName}' model '${modelId}': temperature must be a non-negative number.`,
+          }
+        }
+        config.temperature = parsed
+      }
+
+      if (topPInput) {
+        const parsed = Number(topPInput)
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          return {
+            error: `Provider '${providerName}' model '${modelId}': topP must be a non-negative number.`,
+          }
+        }
+        config.topP = parsed
+      }
+
+      if (topKInput) {
+        const parsed = Number(topKInput)
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          return {
+            error: `Provider '${providerName}' model '${modelId}': topK must be a non-negative number.`,
+          }
+        }
+        config.topK = parsed
+      }
+
+      if (Object.keys(config).length === 0) {
+        continue
+      }
+
+      seenModels.add(normalizedModelId)
+      modelsRecord[modelId] = config
+    }
+
+    if (Object.keys(modelsRecord).length > 0) {
+      provider.models = modelsRecord
+    }
+
+    record[providerName] = provider
+  }
+
+  return { record }
+}
+
+type ProvidersEditor = {
+  items: Array<ProviderItem>
+  issue: string | null
+  onAddProvider: () => void
+  onRemoveProvider: (id: string) => void
+  onUpdateProvider: (id: string, patch: Partial<ProviderItem>) => void
+  onAddModel: (providerId: string) => void
+  onRemoveModel: (providerId: string, modelItemId: string) => void
+  onUpdateModel: (
+    providerId: string,
+    modelItemId: string,
+    patch: Partial<ProviderModelItem>,
+  ) => void
+  setFromRecord: (record?: ProviderRecord) => void
+}
+
+function useProvidersEditor(
+  onRecordChange: (record: ProviderRecord) => void,
+): ProvidersEditor {
+  const [items, setItems] = useState<Array<ProviderItem>>([])
+  const [issue, setIssue] = useState<string | null>(null)
+
+  const setFromRecord = useCallback((record?: ProviderRecord) => {
+    setItems(providerItemsFromRecord(record))
+    setIssue(null)
+  }, [])
+
+  const updateItems = useCallback(
+    (nextItems: Array<ProviderItem>) => {
+      setItems(nextItems)
+      const result = providerRecordFromItems(nextItems)
+      if ("error" in result) {
+        setIssue(result.error)
+        return
+      }
+      setIssue(null)
+      onRecordChange(result.record)
+    },
+    [onRecordChange],
+  )
+
+  const onAddProvider = useCallback(() => {
+    updateItems(
+      items.concat({
+        id: createItemId(),
+        name: "",
+        enabled: true,
+        baseUrl: "",
+        apiKey: "",
+        models: [],
+      }),
+    )
+  }, [items, updateItems])
+
+  const onRemoveProvider = useCallback(
+    (id: string) => {
+      updateItems(items.filter((item) => item.id !== id))
+    },
+    [items, updateItems],
+  )
+
+  const onUpdateProvider = useCallback(
+    (id: string, patch: Partial<ProviderItem>) => {
+      const next = items.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  const onAddModel = useCallback(
+    (providerId: string) => {
+      const next = items.map((provider) => {
+        if (provider.id !== providerId) return provider
+        return {
+          ...provider,
+          models: provider.models.concat({
+            id: createItemId(),
+            model: "",
+            temperature: "",
+            topP: "",
+            topK: "",
+          }),
+        }
+      })
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  const onRemoveModel = useCallback(
+    (providerId: string, modelItemId: string) => {
+      const next = items.map((provider) => {
+        if (provider.id !== providerId) return provider
+        return {
+          ...provider,
+          models: provider.models.filter((model) => model.id !== modelItemId),
+        }
+      })
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  const onUpdateModel = useCallback(
+    (
+      providerId: string,
+      modelItemId: string,
+      patch: Partial<ProviderModelItem>,
+    ) => {
+      const next = items.map((provider) => {
+        if (provider.id !== providerId) return provider
+        return {
+          ...provider,
+          models: provider.models.map((model) =>
+            model.id === modelItemId ? { ...model, ...patch } : model,
+          ),
+        }
+      })
+      updateItems(next)
+    },
+    [items, updateItems],
+  )
+
+  return {
+    items,
+    issue,
+    onAddProvider,
+    onRemoveProvider,
+    onUpdateProvider,
+    onAddModel,
+    onRemoveModel,
+    onUpdateModel,
+    setFromRecord,
+  }
 }
 
 function parseExtraPromptsJson(
@@ -1378,6 +1686,8 @@ type AdvancedSettingsCardProps = {
   forceAgent: boolean
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
+  useMessagesApi: boolean
+  responsesApiContextManagementModelsValue: string
   onToggleLoadBalancing: (value: boolean) => void
   onModelRefreshIntervalChange: (value: string) => void
   onToggleAllowOriginalModelNamesForAliases: (value: boolean) => void
@@ -1385,6 +1695,8 @@ type AdvancedSettingsCardProps = {
   onToggleForceAgent: (value: boolean) => void
   onToggleCompactUseSmallModel: (value: boolean) => void
   onToggleMessageStartInputTokensFallback: (value: boolean) => void
+  onToggleUseMessagesApi: (value: boolean) => void
+  onResponsesApiContextManagementModelsChange: (value: string) => void
 }
 
 function AdvancedSettingsCard({
@@ -1396,6 +1708,8 @@ function AdvancedSettingsCard({
   forceAgent,
   compactUseSmallModel,
   messageStartInputTokensFallback,
+  useMessagesApi,
+  responsesApiContextManagementModelsValue,
   onToggleLoadBalancing,
   onModelRefreshIntervalChange,
   onToggleAllowOriginalModelNamesForAliases,
@@ -1403,6 +1717,8 @@ function AdvancedSettingsCard({
   onToggleForceAgent,
   onToggleCompactUseSmallModel,
   onToggleMessageStartInputTokensFallback,
+  onToggleUseMessagesApi,
+  onResponsesApiContextManagementModelsChange,
 }: AdvancedSettingsCardProps): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -1520,6 +1836,289 @@ function AdvancedSettingsCard({
             onCheckedChange={onToggleMessageStartInputTokensFallback}
           />
         </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.advanced.useMessagesApiLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.advanced.useMessagesApiHint")}
+            </div>
+          </div>
+          <Switch checked={useMessagesApi} onCheckedChange={onToggleUseMessagesApi} />
+        </div>
+
+        <div className="grid gap-2">
+          <Label className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.responsesApiContextManagementModelsLabel")}
+          </Label>
+          <Textarea
+            autoComplete="off"
+            placeholder={t(
+              "settingsPage.advanced.responsesApiContextManagementModelsPlaceholder",
+            )}
+            value={responsesApiContextManagementModelsValue}
+            onChange={(e) =>
+              onResponsesApiContextManagementModelsChange(e.target.value)
+            }
+            className="min-h-[96px] font-mono text-xs"
+          />
+          <div className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.responsesApiContextManagementModelsHint")}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+type ProviderModelRowProps = {
+  providerId: string
+  item: ProviderModelItem
+  onRemoveModel: (providerId: string, modelItemId: string) => void
+  onUpdateModel: (
+    providerId: string,
+    modelItemId: string,
+    patch: Partial<ProviderModelItem>,
+  ) => void
+}
+
+function ProviderModelRow({
+  providerId,
+  item,
+  onRemoveModel,
+  onUpdateModel,
+}: ProviderModelRowProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Input
+        className="min-w-[180px]"
+        placeholder={t("settingsPage.advanced.providersModelIdPlaceholder")}
+        value={item.model}
+        onChange={(e) => onUpdateModel(providerId, item.id, { model: e.target.value })}
+      />
+      <Input
+        className="w-28"
+        type="number"
+        step="0.1"
+        min="0"
+        placeholder="temperature"
+        value={item.temperature}
+        onChange={(e) =>
+          onUpdateModel(providerId, item.id, { temperature: e.target.value })
+        }
+      />
+      <Input
+        className="w-28"
+        type="number"
+        step="0.01"
+        min="0"
+        placeholder="topP"
+        value={item.topP}
+        onChange={(e) => onUpdateModel(providerId, item.id, { topP: e.target.value })}
+      />
+      <Input
+        className="w-28"
+        type="number"
+        step="1"
+        min="0"
+        placeholder="topK"
+        value={item.topK}
+        onChange={(e) => onUpdateModel(providerId, item.id, { topK: e.target.value })}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onRemoveModel(providerId, item.id)}
+      >
+        {t("settingsPage.common.remove")}
+      </Button>
+    </div>
+  )
+}
+
+type ProviderItemCardProps = {
+  item: ProviderItem
+  onRemoveProvider: (id: string) => void
+  onUpdateProvider: (id: string, patch: Partial<ProviderItem>) => void
+  onAddModel: (providerId: string) => void
+  onRemoveModel: (providerId: string, modelItemId: string) => void
+  onUpdateModel: (
+    providerId: string,
+    modelItemId: string,
+    patch: Partial<ProviderModelItem>,
+  ) => void
+}
+
+function ProviderItemCard({
+  item,
+  onRemoveProvider,
+  onUpdateProvider,
+  onAddModel,
+  onRemoveModel,
+  onUpdateModel,
+}: ProviderItemCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <div className="grid gap-3 rounded-lg border p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          className="min-w-[200px]"
+          placeholder={t("settingsPage.advanced.providersNamePlaceholder")}
+          value={item.name}
+          onChange={(e) => onUpdateProvider(item.id, { name: e.target.value })}
+        />
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={item.enabled}
+            onCheckedChange={(value) => onUpdateProvider(item.id, { enabled: value })}
+          />
+          <Label className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.providersEnabledLabel")}
+          </Label>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onRemoveProvider(item.id)}
+        >
+          {t("settingsPage.common.remove")}
+        </Button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="grid gap-2">
+          <Label className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.providersBaseUrlLabel")}
+          </Label>
+          <Input
+            autoComplete="off"
+            placeholder={t("settingsPage.advanced.providersBaseUrlPlaceholder")}
+            value={item.baseUrl}
+            onChange={(e) => onUpdateProvider(item.id, { baseUrl: e.target.value })}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.providersApiKeyLabel")}
+          </Label>
+          <Input
+            type="password"
+            autoComplete="off"
+            placeholder={t("settingsPage.advanced.providersApiKeyPlaceholder")}
+            value={item.apiKey}
+            onChange={(e) => onUpdateProvider(item.id, { apiKey: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="text-sm font-medium">
+            {t("settingsPage.advanced.providersModelsLabel")}
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onAddModel(item.id)}
+          >
+            {t("settingsPage.advanced.providersAddModel")}
+          </Button>
+        </div>
+
+        {item.models.length === 0 ? (
+          <div className="text-muted-foreground text-xs">
+            {t("settingsPage.advanced.providersModelsEmptyState")}
+          </div>
+        ) : (
+          item.models.map((model) => (
+            <ProviderModelRow
+              key={model.id}
+              providerId={item.id}
+              item={model}
+              onUpdateModel={onUpdateModel}
+              onRemoveModel={onRemoveModel}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+type ProvidersSettingsCardProps = {
+  items: Array<ProviderItem>
+  issue: string | null
+  onAddProvider: () => void
+  onRemoveProvider: (id: string) => void
+  onUpdateProvider: (id: string, patch: Partial<ProviderItem>) => void
+  onAddModel: (providerId: string) => void
+  onRemoveModel: (providerId: string, modelItemId: string) => void
+  onUpdateModel: (
+    providerId: string,
+    modelItemId: string,
+    patch: Partial<ProviderModelItem>,
+  ) => void
+}
+
+function ProvidersSettingsCard({
+  items,
+  issue,
+  onAddProvider,
+  onRemoveProvider,
+  onUpdateProvider,
+  onAddModel,
+  onRemoveModel,
+  onUpdateModel,
+}: ProvidersSettingsCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>{t("settingsPage.advanced.providersTitle")}</CardTitle>
+        <CardDescription className="hidden sm:block">
+          {t("settingsPage.advanced.providersDescription")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-4">
+        {issue ? (
+          <InlineAlert
+            variant="warning"
+            title={t("settingsPage.advanced.providersIssueTitle")}
+            description={issue}
+          />
+        ) : null}
+
+        {items.length === 0 ? (
+          <div className="text-muted-foreground text-sm">
+            {t("settingsPage.advanced.providersEmptyState")}
+          </div>
+        ) : (
+          items.map((item) => (
+            <ProviderItemCard
+              key={item.id}
+              item={item}
+              onRemoveProvider={onRemoveProvider}
+              onUpdateProvider={onUpdateProvider}
+              onAddModel={onAddModel}
+              onRemoveModel={onRemoveModel}
+              onUpdateModel={onUpdateModel}
+            />
+          ))
+        )}
+
+        <Button type="button" variant="outline" size="sm" onClick={onAddProvider}>
+          {t("settingsPage.advanced.providersAddProvider")}
+        </Button>
       </CardContent>
     </Card>
   )
@@ -1580,6 +2179,22 @@ type SettingsPageViewProps = {
   forceAgent: boolean
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
+  useMessagesApi: boolean
+  responsesApiContextManagementModelsValue: string
+  onUseMessagesApiToggle: (value: boolean) => void
+  onResponsesApiContextManagementModelsChange: (value: string) => void
+  providersItems: Array<ProviderItem>
+  providersIssue: string | null
+  onProvidersAddProvider: () => void
+  onProvidersRemoveProvider: (id: string) => void
+  onProvidersUpdateProvider: (id: string, patch: Partial<ProviderItem>) => void
+  onProvidersAddModel: (providerId: string) => void
+  onProvidersRemoveModel: (providerId: string, modelItemId: string) => void
+  onProvidersUpdateModel: (
+    providerId: string,
+    modelItemId: string,
+    patch: Partial<ProviderModelItem>,
+  ) => void
   onAllowOriginalModelNamesForAliasesToggle: (value: boolean) => void
   onUseFunctionApplyPatchToggle: (value: boolean) => void
   onForceAgentToggle: (value: boolean) => void
@@ -1602,6 +2217,10 @@ function useSettingsPageState(): SettingsPageViewProps {
   const [modelRefreshIntervalIssue, setModelRefreshIntervalIssue] = useState<
     string | null
   >(null)
+  const [
+    responsesApiContextManagementModelsValue,
+    setResponsesApiContextManagementModelsValue,
+  ] = useState<string>("")
 
   const extraEditor = useExtraPromptEditor((record) =>
     setDraft((prev) => ({ ...prev, extraPrompts: record })),
@@ -1612,6 +2231,10 @@ function useSettingsPageState(): SettingsPageViewProps {
 
   const aliasEditor = useModelAliasEditor((record) =>
     setDraft((prev) => ({ ...prev, modelAliases: record })),
+  )
+
+  const providersEditor = useProvidersEditor((record) =>
+    setDraft((prev) => ({ ...prev, providers: record })),
   )
 
   const {
@@ -1653,6 +2276,18 @@ function useSettingsPageState(): SettingsPageViewProps {
     setFromRecord: setAliasFromRecord,
   } = aliasEditor
 
+  const {
+    items: providersItems,
+    issue: providersIssue,
+    onAddProvider: onProvidersAddProvider,
+    onRemoveProvider: onProvidersRemoveProvider,
+    onUpdateProvider: onProvidersUpdateProvider,
+    onAddModel: onProvidersAddModel,
+    onRemoveModel: onProvidersRemoveModel,
+    onUpdateModel: onProvidersUpdateModel,
+    setFromRecord: setProvidersFromRecord,
+  } = providersEditor
+
   const applyConfigResponse = useCallback(
     (config: AdminConfigResponse) => {
       const { _configPath, ...configData } = config
@@ -1670,17 +2305,23 @@ function useSettingsPageState(): SettingsPageViewProps {
       setExtraFromRecord(configData.extraPrompts)
       setReasoningFromRecord(configData.modelReasoningEfforts)
       setAliasFromRecord(normalizedAliases)
+      setProvidersFromRecord(configData.providers)
       setModelRefreshIntervalInput(
         typeof intervalValue === "number" ? String(intervalValue) : "",
       )
       setModelRefreshIntervalIssue(null)
+      setResponsesApiContextManagementModelsValue(
+        configData.responsesApiContextManagementModels?.join("\n") ?? "",
+      )
     },
     [
       setExtraFromRecord,
       setReasoningFromRecord,
       setAliasFromRecord,
+      setProvidersFromRecord,
       setModelRefreshIntervalInput,
       setModelRefreshIntervalIssue,
+      setResponsesApiContextManagementModelsValue,
     ],
   )
 
@@ -1851,6 +2492,25 @@ function useSettingsPageState(): SettingsPageViewProps {
     [setDraft],
   )
 
+  const handleUseMessagesApiToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, useMessagesApi: value }))
+    },
+    [setDraft],
+  )
+
+  const handleResponsesApiContextManagementModelsChange = useCallback(
+    (value: string) => {
+      setResponsesApiContextManagementModelsValue(value)
+      const models = parseStringListInput(value)
+      setDraft((prev) => ({
+        ...prev,
+        responsesApiContextManagementModels: models,
+      }))
+    },
+    [setDraft, setResponsesApiContextManagementModelsValue],
+  )
+
   const hasModels = models.length > 0
   const smallModelValue = draft.smallModel ? draft.smallModel : "__default__"
   const canSave =
@@ -1860,6 +2520,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     && !(reasoningMode === "json" && reasoningJsonIssue)
     && !(aliasMode === "json" && aliasJsonIssue)
     && !modelRefreshIntervalIssue
+    && !providersIssue
 
   const legacyAuthNote = t("settingsPage.general.legacyAuthNote", {
     env: "COPILOT_API_KEY",
@@ -1879,6 +2540,7 @@ function useSettingsPageState(): SettingsPageViewProps {
   const compactUseSmallModel = draft.compactUseSmallModel ?? true
   const messageStartInputTokensFallback =
     draft.messageStartInputTokensFallback ?? false
+  const useMessagesApi = draft.useMessagesApi ?? true
 
   return {
     loading,
@@ -1935,6 +2597,19 @@ function useSettingsPageState(): SettingsPageViewProps {
     forceAgent,
     compactUseSmallModel,
     messageStartInputTokensFallback,
+    useMessagesApi,
+    responsesApiContextManagementModelsValue,
+    onUseMessagesApiToggle: handleUseMessagesApiToggle,
+    onResponsesApiContextManagementModelsChange:
+      handleResponsesApiContextManagementModelsChange,
+    providersItems,
+    providersIssue,
+    onProvidersAddProvider,
+    onProvidersRemoveProvider,
+    onProvidersUpdateProvider,
+    onProvidersAddModel,
+    onProvidersRemoveModel,
+    onProvidersUpdateModel,
     onAllowOriginalModelNamesForAliasesToggle:
       handleAllowOriginalModelNamesForAliasesToggle,
     onUseFunctionApplyPatchToggle: handleUseFunctionApplyPatchToggle,
@@ -2000,6 +2675,18 @@ function SettingsPageView({
   forceAgent,
   compactUseSmallModel,
   messageStartInputTokensFallback,
+  useMessagesApi,
+  responsesApiContextManagementModelsValue,
+  onUseMessagesApiToggle,
+  onResponsesApiContextManagementModelsChange,
+  providersItems,
+  providersIssue,
+  onProvidersAddProvider,
+  onProvidersRemoveProvider,
+  onProvidersUpdateProvider,
+  onProvidersAddModel,
+  onProvidersRemoveModel,
+  onProvidersUpdateModel,
   onAllowOriginalModelNamesForAliasesToggle,
   onUseFunctionApplyPatchToggle,
   onForceAgentToggle,
@@ -2165,27 +2852,50 @@ function SettingsPageView({
             isActive={activeSection === "advanced"}
             ref={(el) => registerSection("advanced", el)}
           >
-            <AdvancedSettingsCard
-              loadBalancingEnabled={loadBalancingEnabled}
-              modelRefreshIntervalInput={modelRefreshIntervalInput}
-              modelRefreshIntervalIssue={modelRefreshIntervalIssue}
-              allowOriginalModelNamesForAliases={allowOriginalModelNamesForAliases}
-              useFunctionApplyPatch={useFunctionApplyPatch}
-              forceAgent={forceAgent}
-              compactUseSmallModel={compactUseSmallModel}
-              messageStartInputTokensFallback={messageStartInputTokensFallback}
-              onToggleLoadBalancing={onLoadBalancingToggle}
-              onModelRefreshIntervalChange={onModelRefreshIntervalChange}
-              onToggleAllowOriginalModelNamesForAliases={
-                onAllowOriginalModelNamesForAliasesToggle
-              }
-              onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
-              onToggleForceAgent={onForceAgentToggle}
-              onToggleCompactUseSmallModel={onCompactUseSmallModelToggle}
-              onToggleMessageStartInputTokensFallback={
-                onMessageStartInputTokensFallbackToggle
-              }
-            />
+            <div className="space-y-6">
+              <AdvancedSettingsCard
+                loadBalancingEnabled={loadBalancingEnabled}
+                modelRefreshIntervalInput={modelRefreshIntervalInput}
+                modelRefreshIntervalIssue={modelRefreshIntervalIssue}
+                allowOriginalModelNamesForAliases={
+                  allowOriginalModelNamesForAliases
+                }
+                useFunctionApplyPatch={useFunctionApplyPatch}
+                forceAgent={forceAgent}
+                compactUseSmallModel={compactUseSmallModel}
+                messageStartInputTokensFallback={messageStartInputTokensFallback}
+                useMessagesApi={useMessagesApi}
+                responsesApiContextManagementModelsValue={
+                  responsesApiContextManagementModelsValue
+                }
+                onToggleLoadBalancing={onLoadBalancingToggle}
+                onModelRefreshIntervalChange={onModelRefreshIntervalChange}
+                onToggleAllowOriginalModelNamesForAliases={
+                  onAllowOriginalModelNamesForAliasesToggle
+                }
+                onToggleUseFunctionApplyPatch={onUseFunctionApplyPatchToggle}
+                onToggleForceAgent={onForceAgentToggle}
+                onToggleCompactUseSmallModel={onCompactUseSmallModelToggle}
+                onToggleMessageStartInputTokensFallback={
+                  onMessageStartInputTokensFallbackToggle
+                }
+                onToggleUseMessagesApi={onUseMessagesApiToggle}
+                onResponsesApiContextManagementModelsChange={
+                  onResponsesApiContextManagementModelsChange
+                }
+              />
+
+              <ProvidersSettingsCard
+                items={providersItems}
+                issue={providersIssue}
+                onAddProvider={onProvidersAddProvider}
+                onRemoveProvider={onProvidersRemoveProvider}
+                onUpdateProvider={onProvidersUpdateProvider}
+                onAddModel={onProvidersAddModel}
+                onRemoveModel={onProvidersRemoveModel}
+                onUpdateModel={onProvidersUpdateModel}
+              />
+            </div>
           </SettingsSectionCard>
         </main>
       </div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,6 +34,10 @@ export interface ModelConfig {
   topK?: number
 }
 
+export const PROVIDER_TYPE_ANTHROPIC = "anthropic" as const
+
+export type ProviderType = typeof PROVIDER_TYPE_ANTHROPIC
+
 export interface ProviderConfig {
   type?: string
   enabled?: boolean
@@ -44,7 +48,7 @@ export interface ProviderConfig {
 
 export interface ResolvedProviderConfig {
   name: string
-  type: "anthropic"
+  type: ProviderType
   baseUrl: string
   apiKey: string
   models?: Record<string, ModelConfig>
@@ -603,8 +607,8 @@ export function getProviderConfig(name: string): ResolvedProviderConfig | null {
     return null
   }
 
-  const type = provider.type ?? "anthropic"
-  if (type !== "anthropic") {
+  const type = provider.type ?? PROVIDER_TYPE_ANTHROPIC
+  if (type !== PROVIDER_TYPE_ANTHROPIC) {
     consola.warn(
       `Provider ${providerName} is ignored because only anthropic type is supported`,
     )
@@ -622,7 +626,7 @@ export function getProviderConfig(name: string): ResolvedProviderConfig | null {
 
   return {
     name: providerName,
-    type,
+    type: PROVIDER_TYPE_ANTHROPIC,
     baseUrl,
     apiKey,
     models: provider.models,

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -12,6 +12,7 @@ import {
   getModelRefreshIntervalMs,
   isFreeModelLoadBalancingEnabled,
   mergeConfigWithDefaults,
+  PROVIDER_TYPE_ANTHROPIC,
   type AppConfig,
   type ModelConfig,
   type ProviderConfig,
@@ -475,10 +476,10 @@ function applyProviderType(
   const parsed = parseOptionalString(value.type, `${field}.type`)
   if ("error" in parsed) return parsed.error
   if ("value" in parsed) {
-    if (parsed.value !== "anthropic") {
-      return `${field}.type must be "anthropic"`
+    if (parsed.value !== PROVIDER_TYPE_ANTHROPIC) {
+      return `${field}.type must be "${PROVIDER_TYPE_ANTHROPIC}"`
     }
-    provider.type = parsed.value
+    provider.type = PROVIDER_TYPE_ANTHROPIC
   }
 
   return undefined
@@ -579,6 +580,7 @@ function parseProviders(
   }
 
   const record = Object.create(null) as Record<string, ProviderConfig>
+  const seenProviderNames = new Set<string>()
 
   for (const [rawProviderName, rawProviderConfig] of Object.entries(value)) {
     if (BLOCKED_KEYS.has(rawProviderName)) {
@@ -598,18 +600,20 @@ function parseProviders(
       return { error: `providers.${providerName} is not allowed` }
     }
 
+    const normalizedProviderName = providerName.toLowerCase()
+    if (seenProviderNames.has(normalizedProviderName)) {
+      return {
+        error: `providers.${rawProviderName} conflicts with another provider`,
+      }
+    }
+    seenProviderNames.add(normalizedProviderName)
+
     const parsed = parseProviderConfig(
       rawProviderConfig,
       `providers.${providerName}`,
     )
     if ("error" in parsed) return parsed
     if ("clear" in parsed) continue
-
-    if (Object.hasOwn(record, providerName)) {
-      return {
-        error: `providers.${rawProviderName} conflicts with another provider`,
-      }
-    }
 
     record[providerName] = parsed.value
   }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -13,6 +13,8 @@ import {
   isFreeModelLoadBalancingEnabled,
   mergeConfigWithDefaults,
   type AppConfig,
+  type ModelConfig,
+  type ProviderConfig,
 } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
 import {
@@ -150,6 +152,8 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "smallModel",
   "freeModelLoadBalancing",
   "apiKey",
+  "providers",
+  "responsesApiContextManagementModels",
   "modelReasoningEfforts",
   "modelAliases",
   "allowOriginalModelNamesForAliases",
@@ -158,6 +162,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "compactUseSmallModel",
   "messageStartInputTokensFallback",
   "modelRefreshIntervalHours",
+  "useMessagesApi",
 ])
 
 const REASONING_EFFORTS = new Set<ReasoningEffort>([
@@ -226,6 +231,30 @@ function parseOptionalNonNegativeNumber(
   return { value }
 }
 
+function parseOptionalStringArray(
+  value: unknown,
+  field: string,
+): ParseFieldResult<Array<string>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!Array.isArray(value)) {
+    return { error: `${field} must be an array of strings` }
+  }
+
+  const out: Array<string> = []
+  for (const [index, entry] of value.entries()) {
+    if (typeof entry !== "string") {
+      return { error: `${field}[${index}] must be a string` }
+    }
+    const trimmed = entry.trim()
+    if (!trimmed) {
+      return { error: `${field}[${index}] must be a non-empty string` }
+    }
+    out.push(trimmed)
+  }
+
+  return { value: [...new Set(out)] }
+}
+
 function parseAuthConfig(value: unknown): ParseFieldResult<AuthConfig> {
   if (value === null || value === undefined) return { clear: true }
   if (!isPlainObject(value)) {
@@ -280,6 +309,309 @@ function parseStringRecord(
       return { error: `${field}.${key} must be a string` }
     }
     record[key] = entry
+  }
+
+  return { value: record }
+}
+
+const PROVIDER_MODEL_CONFIG_FIELDS = ["temperature", "topP", "topK"] as const
+
+type ProviderModelConfigField = (typeof PROVIDER_MODEL_CONFIG_FIELDS)[number]
+
+const PROVIDER_MODEL_CONFIG_KEYS = new Set<ProviderModelConfigField>(
+  PROVIDER_MODEL_CONFIG_FIELDS,
+)
+
+const PROVIDER_CONFIG_FIELDS = [
+  "type",
+  "enabled",
+  "baseUrl",
+  "apiKey",
+  "models",
+] as const
+
+type ProviderConfigField = (typeof PROVIDER_CONFIG_FIELDS)[number]
+
+const PROVIDER_CONFIG_KEYS = new Set<ProviderConfigField>(
+  PROVIDER_CONFIG_FIELDS,
+)
+
+function validateAllowedObjectKeys(
+  value: Record<string, unknown>,
+  field: string,
+  allowed: ReadonlySet<string>,
+): string | undefined {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      return `${field}.${key} is not supported`
+    }
+  }
+  return undefined
+}
+
+function applyProviderModelTemperature(
+  config: ModelConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "temperature")) return undefined
+
+  const parsed = parseOptionalNonNegativeNumber(
+    value.temperature,
+    `${field}.temperature`,
+  )
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) config.temperature = parsed.value
+  return undefined
+}
+
+function applyProviderModelTopP(
+  config: ModelConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "topP")) return undefined
+
+  const parsed = parseOptionalNonNegativeNumber(value.topP, `${field}.topP`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) config.topP = parsed.value
+  return undefined
+}
+
+function applyProviderModelTopK(
+  config: ModelConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "topK")) return undefined
+
+  const parsed = parseOptionalNonNegativeNumber(value.topK, `${field}.topK`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) config.topK = parsed.value
+  return undefined
+}
+
+function parseProviderModelConfig(
+  value: unknown,
+  field: string,
+): ParseFieldResult<ModelConfig> {
+  if (value === null || value === undefined) {
+    return { error: `${field} must be an object` }
+  }
+  if (!isPlainObject(value)) {
+    return { error: `${field} must be an object` }
+  }
+
+  const keyError = validateAllowedObjectKeys(
+    value,
+    field,
+    PROVIDER_MODEL_CONFIG_KEYS,
+  )
+  if (keyError) return { error: keyError }
+
+  const config: ModelConfig = {}
+
+  const temperatureError = applyProviderModelTemperature(config, value, field)
+  if (temperatureError) return { error: temperatureError }
+
+  const topPError = applyProviderModelTopP(config, value, field)
+  if (topPError) return { error: topPError }
+
+  const topKError = applyProviderModelTopK(config, value, field)
+  if (topKError) return { error: topKError }
+
+  return { value: config }
+}
+
+function parseProviderModelsRecord(
+  value: unknown,
+  field: string,
+): ParseFieldResult<Record<string, ModelConfig>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: `${field} must be an object` }
+  }
+
+  const record = Object.create(null) as Record<string, ModelConfig>
+
+  for (const [rawModelId, rawModelConfig] of Object.entries(value)) {
+    if (BLOCKED_KEYS.has(rawModelId)) {
+      return { error: `${field}.${rawModelId} is not allowed` }
+    }
+
+    const modelId = rawModelId.trim()
+    if (!modelId) {
+      return { error: `${field} keys must be non-empty strings` }
+    }
+    if (rawModelId !== modelId) {
+      return {
+        error: `${field}.${rawModelId} must not include leading/trailing whitespace`,
+      }
+    }
+    if (BLOCKED_KEYS.has(modelId)) {
+      return { error: `${field}.${modelId} is not allowed` }
+    }
+
+    const parsed = parseProviderModelConfig(
+      rawModelConfig,
+      `${field}.${modelId}`,
+    )
+    if ("error" in parsed) return parsed
+    if ("clear" in parsed) continue
+
+    record[modelId] = parsed.value
+  }
+
+  return { value: record }
+}
+
+function applyProviderType(
+  provider: ProviderConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "type")) return undefined
+
+  const parsed = parseOptionalString(value.type, `${field}.type`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) {
+    if (parsed.value !== "anthropic") {
+      return `${field}.type must be "anthropic"`
+    }
+    provider.type = parsed.value
+  }
+
+  return undefined
+}
+
+function applyProviderEnabled(
+  provider: ProviderConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "enabled")) return undefined
+
+  const parsed = parseOptionalBoolean(value.enabled, `${field}.enabled`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) provider.enabled = parsed.value
+  return undefined
+}
+
+function applyProviderBaseUrl(
+  provider: ProviderConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "baseUrl")) return undefined
+
+  const parsed = parseOptionalString(value.baseUrl, `${field}.baseUrl`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) provider.baseUrl = parsed.value
+  return undefined
+}
+
+function applyProviderApiKey(
+  provider: ProviderConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "apiKey")) return undefined
+
+  const parsed = parseOptionalString(value.apiKey, `${field}.apiKey`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) provider.apiKey = parsed.value
+  return undefined
+}
+
+function applyProviderModels(
+  provider: ProviderConfig,
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  if (!Object.hasOwn(value, "models")) return undefined
+
+  const parsed = parseProviderModelsRecord(value.models, `${field}.models`)
+  if ("error" in parsed) return parsed.error
+  if ("value" in parsed) provider.models = parsed.value
+  return undefined
+}
+
+function parseProviderConfig(
+  value: unknown,
+  field: string,
+): ParseFieldResult<ProviderConfig> {
+  if (value === null || value === undefined) {
+    return { error: `${field} must be an object` }
+  }
+  if (!isPlainObject(value)) {
+    return { error: `${field} must be an object` }
+  }
+
+  const keyError = validateAllowedObjectKeys(value, field, PROVIDER_CONFIG_KEYS)
+  if (keyError) return { error: keyError }
+
+  const provider: ProviderConfig = {}
+
+  const typeError = applyProviderType(provider, value, field)
+  if (typeError) return { error: typeError }
+
+  const enabledError = applyProviderEnabled(provider, value, field)
+  if (enabledError) return { error: enabledError }
+
+  const baseUrlError = applyProviderBaseUrl(provider, value, field)
+  if (baseUrlError) return { error: baseUrlError }
+
+  const apiKeyError = applyProviderApiKey(provider, value, field)
+  if (apiKeyError) return { error: apiKeyError }
+
+  const modelsError = applyProviderModels(provider, value, field)
+  if (modelsError) return { error: modelsError }
+
+  return { value: provider }
+}
+
+function parseProviders(
+  value: unknown,
+): ParseFieldResult<Record<string, ProviderConfig>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: "providers must be an object" }
+  }
+
+  const record = Object.create(null) as Record<string, ProviderConfig>
+
+  for (const [rawProviderName, rawProviderConfig] of Object.entries(value)) {
+    if (BLOCKED_KEYS.has(rawProviderName)) {
+      return { error: `providers.${rawProviderName} is not allowed` }
+    }
+
+    const providerName = rawProviderName.trim()
+    if (!providerName) {
+      return { error: "providers keys must be non-empty strings" }
+    }
+    if (rawProviderName !== providerName) {
+      return {
+        error: `providers.${rawProviderName} must not include leading/trailing whitespace`,
+      }
+    }
+    if (BLOCKED_KEYS.has(providerName)) {
+      return { error: `providers.${providerName} is not allowed` }
+    }
+
+    const parsed = parseProviderConfig(
+      rawProviderConfig,
+      `providers.${providerName}`,
+    )
+    if ("error" in parsed) return parsed
+    if ("clear" in parsed) continue
+
+    if (Object.hasOwn(record, providerName)) {
+      return {
+        error: `providers.${rawProviderName} conflicts with another provider`,
+      }
+    }
+
+    record[providerName] = parsed.value
   }
 
   return { value: record }
@@ -440,6 +772,7 @@ function applyOptionalBoolean(
     | "freeModelLoadBalancing"
     | "useFunctionApplyPatch"
     | "forceAgent"
+    | "useMessagesApi"
     | "compactUseSmallModel"
     | "messageStartInputTokensFallback"
     | "allowOriginalModelNamesForAliases",
@@ -512,6 +845,37 @@ function applyModelAliases(
   return undefined
 }
 
+function applyResponsesApiContextManagementModels(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseOptionalStringArray(
+    value,
+    "responsesApiContextManagementModels",
+  )
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.responsesApiContextManagementModels
+    return undefined
+  }
+  next.responsesApiContextManagementModels = parsed.value
+  return undefined
+}
+
+function applyProvidersConfig(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseProviders(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.providers
+    return undefined
+  }
+  next.providers = parsed.value
+  return undefined
+}
+
 type ConfigPatchHandler = (
   next: AppConfig,
   value: unknown,
@@ -524,6 +888,8 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
   freeModelLoadBalancing: (next, value) =>
     applyOptionalBoolean(next, "freeModelLoadBalancing", value),
   apiKey: (next, value) => applyOptionalString(next, "apiKey", value),
+  providers: applyProvidersConfig,
+  responsesApiContextManagementModels: applyResponsesApiContextManagementModels,
   modelReasoningEfforts: applyReasoningEfforts,
   modelAliases: applyModelAliases,
   allowOriginalModelNamesForAliases: (next, value) =>
@@ -537,6 +903,8 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
     applyOptionalBoolean(next, "messageStartInputTokensFallback", value),
   modelRefreshIntervalHours: (next, value) =>
     applyOptionalNumber(next, "modelRefreshIntervalHours", value),
+  useMessagesApi: (next, value) =>
+    applyOptionalBoolean(next, "useMessagesApi", value),
 }
 
 function applyConfigPatch(

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -1,0 +1,240 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+
+type TestConfig = Record<string, unknown>
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+
+  try {
+    await run()
+  } finally {
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (original === null) {
+      await fs.rm(PATHS.CONFIG_PATH, { force: true })
+    } else {
+      await fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    }
+    mergeConfigWithDefaults()
+  }
+}
+
+test("POST /api/admin/config updates useMessagesApi", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ useMessagesApi: false }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as { useMessagesApi?: boolean }
+    expect(body.useMessagesApi).toBe(false)
+  })
+})
+
+test("POST /api/admin/config updates responsesApiContextManagementModels", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          responsesApiContextManagementModels: [" gpt-5-mini ", "gpt-5-mini"],
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      responsesApiContextManagementModels?: Array<string>
+    }
+    expect(body.responsesApiContextManagementModels).toEqual(["gpt-5-mini"])
+  })
+})
+
+test("POST /api/admin/config rejects invalid responsesApiContextManagementModels entries", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          responsesApiContextManagementModels: [""],
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain(
+      "responsesApiContextManagementModels[0]",
+    )
+  })
+})
+
+test("POST /api/admin/config updates providers", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providers: {
+            custom: {
+              type: "anthropic",
+              enabled: true,
+              baseUrl: "https://example.com",
+              apiKey: "sk-test",
+              models: {
+                "kimi-k2.5": {
+                  temperature: 1,
+                  topP: 0.95,
+                },
+              },
+            },
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      providers: {
+        custom: {
+          type: string
+          enabled: boolean
+          baseUrl: string
+          apiKey: string
+          models: {
+            "kimi-k2.5": {
+              temperature: number
+              topP: number
+            }
+          }
+        }
+      }
+    }
+
+    expect(body.providers.custom.type).toBe("anthropic")
+    expect(body.providers.custom.enabled).toBe(true)
+    expect(body.providers.custom.baseUrl).toBe("https://example.com")
+    expect(body.providers.custom.apiKey).toBe("sk-test")
+    expect(body.providers.custom.models["kimi-k2.5"].temperature).toBe(1)
+    expect(body.providers.custom.models["kimi-k2.5"].topP).toBe(0.95)
+  })
+})
+
+test("POST /api/admin/config rejects unsupported provider keys", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providers: {
+            custom: {
+              type: "anthropic",
+              foo: "bar",
+            },
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain("providers.custom.foo")
+  })
+})
+
+test("POST /api/admin/config rejects unsupported provider types", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providers: {
+            custom: {
+              type: "openai",
+            },
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain("providers.custom.type")
+  })
+})
+
+test("POST /api/admin/config rejects unknown top-level config keys", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          notARealKey: true,
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain("Unknown config key: notARealKey")
+  })
+})

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -161,6 +161,32 @@ test("POST /api/admin/config updates providers", async () => {
   })
 })
 
+test("POST /api/admin/config rejects case-insensitive duplicate providers", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providers: {
+            Anthropic: { type: "anthropic" },
+            anthropic: { type: "anthropic" },
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain("conflicts with another provider")
+  })
+})
+
 test("POST /api/admin/config rejects unsupported provider keys", async () => {
   await withConfig({}, async () => {
     const { server } = await import("../src/server")


### PR DESCRIPTION
## Summary
- Add missing config items to Admin UI settings (/admin#/settings): providers, useMessagesApi, responsesApiContextManagementModels
- Extend Admin API config patch validation for the new keys
- Add tests for /api/admin/config

## Testing
- bun test tests/admin-config.test.ts
- bun run typecheck
- bun run typecheck:admin
- bun run lint
- bun run lint:admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增提供商配置管理：可添加/编辑提供商与按模型默认参数（温度、topP、topK）、启用开关、基础 URL 与 API Key，并支持将提供商配置持久化到系统配置。
  * 新增 Messages API 切换与 Responses API 上下文管理模型列表设置。

* **本地化**
  * 在高级设置中补充中/英界面文本、标签、占位与提示。

* **文档**
  * 更新中文文档，新增 providers 配置示例与路由说明，说明 useMessagesApi 行为。

* **测试**
  * 增加管理配置 API 的端到端测试，覆盖验证与错误处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->