### PR TITLE
fix(messages): align warmup routing heuristic with caozhiyuan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM oven/bun:1.3.7-alpine AS builder
+FROM oven/bun:1.3.7 AS builder
 WORKDIR /app
 
 COPY ./package.json ./bun.lock ./
-RUN bun install --frozen-lockfile --registry https://registry.npmjs.org --network-concurrency 8 --no-verify
+RUN bun install --frozen-lockfile --registry https://registry.npmjs.org --network-concurrency 1 --no-verify
 
 COPY ./admin-ui/package.json ./admin-ui/bun.lock ./admin-ui/
-RUN bun install --frozen-lockfile --cwd admin-ui --registry https://registry.npmjs.org --network-concurrency 8 --no-verify
+RUN bun install --frozen-lockfile --cwd admin-ui --registry https://registry.npmjs.org --network-concurrency 1 --no-verify
 
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1.3.7-alpine AS runner
+FROM oven/bun:1.3.7 AS runner
 WORKDIR /app
 
 COPY ./package.json ./
@@ -20,7 +20,7 @@ COPY --from=builder /app/dist ./dist
 EXPOSE 4141
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --spider -q http://localhost:4141/ || exit 1
+  CMD bun -e "fetch('http://localhost:4141/').then((res) => { if (!res.ok) process.exit(1) }).catch(() => process.exit(1))"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM oven/bun:1.3.7-alpine AS builder
 WORKDIR /app
 
 COPY ./package.json ./bun.lock ./
-RUN bun install --frozen-lockfile --registry https://registry.npmjs.org --network-concurrency 8
+RUN bun install --frozen-lockfile --registry https://registry.npmjs.org --network-concurrency 8 --no-verify
 
 COPY ./admin-ui/package.json ./admin-ui/bun.lock ./admin-ui/
-RUN bun install --frozen-lockfile --cwd admin-ui --registry https://registry.npmjs.org --network-concurrency 8
+RUN bun install --frozen-lockfile --cwd admin-ui --registry https://registry.npmjs.org --network-concurrency 8 --no-verify
 
 COPY . .
 RUN bun run build
@@ -13,9 +13,8 @@ RUN bun run build
 FROM oven/bun:1.3.7-alpine AS runner
 WORKDIR /app
 
-COPY ./package.json ./bun.lock ./
-RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache --registry https://registry.npmjs.org --network-concurrency 8
-
+COPY ./package.json ./
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 4141

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM oven/bun:1.2.19-alpine AS builder
+FROM oven/bun:1.3.7-alpine AS builder
 WORKDIR /app
 
 COPY ./package.json ./bun.lock ./
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --registry https://registry.npmjs.org --network-concurrency 8
 
 COPY ./admin-ui/package.json ./admin-ui/bun.lock ./admin-ui/
-RUN bun install --frozen-lockfile --cwd admin-ui
+RUN bun install --frozen-lockfile --cwd admin-ui --registry https://registry.npmjs.org --network-concurrency 8
 
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1.2.19-alpine AS runner
+FROM oven/bun:1.3.7-alpine AS runner
 WORKDIR /app
 
 COPY ./package.json ./bun.lock ./
-RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache
+RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache --registry https://registry.npmjs.org --network-concurrency 8
 
 COPY --from=builder /app/dist ./dist
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -87,9 +87,9 @@ import { parseSubagentMarkerFromFirstUser } from "./subagent-marker"
 import {
   estimateInputTokens,
   handleSelectionFailure,
-  isWarmupProbeRequest,
   maybeBlockOriginalModelName,
   mergeToolResultForClaude,
+  shouldUseSmallModelForWarmup,
 } from "./utils"
 
 const logger = createHandlerLogger("messages-handler")
@@ -161,8 +161,11 @@ export async function handleCompletion(c: Context) {
   const anthropicBeta = c.req.header("anthropic-beta")
   const isCompact = isCompactRequest(anthropicPayload)
 
-  // Fix warmup probe: force small model for Claude Code warmup requests (CLAUDE_CODE_SUBAGENT_MODEL also works).
-  if (anthropicBeta && isWarmupProbeRequest(anthropicPayload)) {
+  // Align warmup handling with the legacy heuristic used in caozhiyuan:
+  // anthropic-beta + no tools + non-compact requests route to the small model.
+  if (
+    shouldUseSmallModelForWarmup(anthropicPayload, anthropicBeta, isCompact)
+  ) {
     anthropicPayload.model = getSmallModel()
   }
 

--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -145,37 +145,13 @@ type SelectionFailureContext = {
   selection: SelectionFailure
 }
 
-export const isWarmupProbeRequest = (
+export const shouldUseSmallModelForWarmup = (
   payload: AnthropicMessagesPayload,
+  anthropicBetaHeader: string | undefined,
+  isCompact: boolean,
 ): boolean => {
-  const lastMsg = payload.messages.at(-1)
-  if (!lastMsg || lastMsg.role !== "user" || !Array.isArray(lastMsg.content)) {
-    return false
-  }
-
-  const lastBlock = lastMsg.content.at(-1)
-  if (!lastBlock || lastBlock.type !== "text") {
-    return false
-  }
-
-  const text = lastBlock.text.trim().toLowerCase()
-  const isEphemeral = lastBlock.cache_control?.type === "ephemeral"
-  if (!isEphemeral) return false
-
-  if (text === "warmup") return true
-
-  if (text === "hello") {
-    const preludeBlocks = lastMsg.content.slice(0, -1)
-    if (preludeBlocks.length === 0) return false
-
-    return preludeBlocks.every(
-      (block) =>
-        block.type === "text"
-        && block.text.trimStart().toLowerCase().startsWith("<system-reminder"),
-    )
-  }
-
-  return false
+  const noTools = !payload.tools || payload.tools.length === 0
+  return Boolean(anthropicBetaHeader) && noTools && !isCompact
 }
 
 export const handleSelectionFailure = (

--- a/tests/warmup-probe.test.ts
+++ b/tests/warmup-probe.test.ts
@@ -2,33 +2,60 @@ import { describe, expect, test } from "bun:test"
 
 import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
 
-import { isWarmupProbeRequest } from "~/routes/messages/utils"
+import { shouldUseSmallModelForWarmup } from "~/routes/messages/utils"
 
-describe("isWarmupProbeRequest", () => {
-  test("detects Claude Code hello warmup probe", () => {
+describe("shouldUseSmallModelForWarmup", () => {
+  test("routes anthropic beta requests without tools to the small model", () => {
     const payload: AnthropicMessagesPayload = {
       model: "copilot/gpt-5.2",
       messages: [
         {
           role: "user",
-          content: [
-            {
-              type: "text",
-              text: "<system-reminder>SessionStart:startup hook success: Success</system-reminder>",
-            },
-            {
-              type: "text",
-              text: "hello",
-              cache_control: {
-                type: "ephemeral",
-              },
-            },
-          ],
+          content: [{ type: "text", text: "hello" }],
         },
       ],
-      max_tokens: 1,
+      max_tokens: 16,
     }
 
-    expect(isWarmupProbeRequest(payload)).toBe(true)
+    expect(shouldUseSmallModelForWarmup(payload, "beta", false)).toBe(true)
+  })
+
+  test("does not route requests with tools to the small model", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "copilot/gpt-5.2",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+      max_tokens: 16,
+      tools: [
+        {
+          name: "echo",
+          input_schema: {
+            type: "object",
+            properties: {},
+          },
+        },
+      ],
+    }
+
+    expect(shouldUseSmallModelForWarmup(payload, "beta", false)).toBe(false)
+  })
+
+  test("does not route compact requests to the small model through warmup logic", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "copilot/gpt-5.2",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+      max_tokens: 16,
+    }
+
+    expect(shouldUseSmallModelForWarmup(payload, "beta", true)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- revert warmup small-model routing to the legacy caozhiyuan heuristic
- remove the hello/ephemeral warmup probe detection helper
- update warmup tests to match the restored behavior

## Testing
- bun test tests/warmup-probe.test.ts
- bun test tests/subagent-marker.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了路由决策：是否使用小模型现在基于 API beta 标识、是否为紧凑模式及是否携带工具，而不再依赖消息内容的启发式检测，从而更精确地在暖启动场景选择模型。

* **测试**
  * 更新并扩展了测试用例，覆盖带工具的请求、紧凑模式和 beta 标识下的路由结果。

* **杂项**
  * 更新了构建镜像与安装/健康检查流程以改善构建一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->