### PR TITLE
fix: use upstream request ID for account affinity routing

### DIFF
--- a/admin-ui/src/hooks/use-active-section.ts
+++ b/admin-ui/src/hooks/use-active-section.ts
@@ -24,7 +24,7 @@ type UseActiveSectionReturn = {
 export function useActiveSection({
   sectionIds,
   rootMargin = "-20% 0px -60% 0px",
-  threshold = 0.5,
+  threshold = 0,
 }: UseActiveSectionOptions): UseActiveSectionReturn {
   const [activeSection, setActiveSection] = useState(sectionIds[0] ?? "")
   const sectionRefs = useRef(new Map<string, HTMLElement>())

--- a/src/lib/account-affinity.ts
+++ b/src/lib/account-affinity.ts
@@ -1,9 +1,7 @@
 import type { AccountRuntime } from "~/lib/types/account"
 
 export interface AffinityContext {
-  promptCacheKey?: string
-  sessionId?: string
-  safetyIdentifier?: string
+  requestId?: string
 }
 
 interface AffinityCacheEntry {
@@ -80,21 +78,13 @@ export class AccountAffinityCache {
 }
 
 /**
- * Extract the best available affinity key from the request context.
- * Priority: promptCacheKey > sessionId > safetyIdentifier.
+ * Extract the affinity key from the request context.
+ * Uses the upstream request ID which is deterministic for the same user message.
  */
 export function extractAffinityKey(
   context: AffinityContext,
 ): string | undefined {
-  for (const candidate of [
-    context.promptCacheKey,
-    context.sessionId,
-    context.safetyIdentifier,
-  ]) {
-    const normalized = candidate?.trim()
-    if (normalized) return normalized
-  }
-  return undefined
+  return context.requestId?.trim() || undefined
 }
 
 /**

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -78,7 +78,10 @@ export async function handleCompletion(c: Context) {
 
   logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
 
-  const upstreamRequestId = generateRequestIdFromPayload(payload)
+  const upstreamRequestId = generateRequestIdFromPayload(
+    payload,
+    normalizedPromptCacheKey,
+  )
 
   const selection = await accountsManager.selectAccountForRequest(
     [

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -78,6 +78,8 @@ export async function handleCompletion(c: Context) {
 
   logger.debug("Request payload:", JSON.stringify(payload).slice(-400))
 
+  const upstreamRequestId = generateRequestIdFromPayload(payload)
+
   const selection = await accountsManager.selectAccountForRequest(
     [
       {
@@ -86,8 +88,7 @@ export async function handleCompletion(c: Context) {
       },
     ],
     {
-      promptCacheKey: normalizedPromptCacheKey,
-      safetyIdentifier: normalizedSafetyIdentifier,
+      requestId: upstreamRequestId,
     },
   )
 
@@ -125,7 +126,6 @@ export async function handleCompletion(c: Context) {
   )
 
   const accountCtx = toAccountContext(account)
-  const upstreamRequestId = generateRequestIdFromPayload(payloadWithMaxTokens)
   const upstreamSessionId = getUUID(upstreamRequestId)
   request.upstreamRequestId = upstreamRequestId
   request.upstreamSessionId = upstreamSessionId

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -243,9 +243,7 @@ export async function handleCompletion(c: Context) {
   )
 
   const selection = await accountsManager.selectAccountForRequest(candidates, {
-    promptCacheKey: normalizedPromptCacheKey,
-    sessionId,
-    safetyIdentifier: normalizedSafetyIdentifier,
+    requestId: upstreamRequestId,
   })
   if (!selection.ok) {
     return handleSelectionFailure({

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -89,9 +89,10 @@ export const handleResponses = async (c: Context) => {
     })
   }
 
-  const upstreamRequestId = generateRequestIdFromPayload({
-    messages: payload.input,
-  })
+  const upstreamRequestId = generateRequestIdFromPayload(
+    { messages: payload.input },
+    normalizedPromptCacheKey,
+  )
 
   const selection = await accountsManager.selectAccountForRequest(
     [

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -89,6 +89,10 @@ export const handleResponses = async (c: Context) => {
     })
   }
 
+  const upstreamRequestId = generateRequestIdFromPayload({
+    messages: payload.input,
+  })
+
   const selection = await accountsManager.selectAccountForRequest(
     [
       {
@@ -97,8 +101,7 @@ export const handleResponses = async (c: Context) => {
       },
     ],
     {
-      promptCacheKey: normalizedPromptCacheKey,
-      safetyIdentifier: normalizedSafetyIdentifier,
+      requestId: upstreamRequestId,
     },
   )
 
@@ -136,9 +139,6 @@ export const handleResponses = async (c: Context) => {
   if (state.manualApprove) await awaitApproval()
 
   const accountCtx = toAccountContext(account)
-  const upstreamRequestId = generateRequestIdFromPayload({
-    messages: upstreamPayload.input,
-  })
   const upstreamSessionId = getUUID(upstreamRequestId)
   request.upstreamRequestId = upstreamRequestId
   request.upstreamSessionId = upstreamSessionId

--- a/tests/account-affinity-cache.test.ts
+++ b/tests/account-affinity-cache.test.ts
@@ -121,34 +121,23 @@ test("size reflects current entry count", () => {
 // extractAffinityKey
 // ---------------------------------------------------------------------------
 
-test("extractAffinityKey returns promptCacheKey first", () => {
+test("extractAffinityKey returns requestId", () => {
   expect(
     extractAffinityKey({
-      promptCacheKey: "pck",
-      sessionId: "sid",
-      safetyIdentifier: "safe",
+      requestId: "req-123",
     }),
-  ).toBe("pck")
+  ).toBe("req-123")
 })
 
-test("extractAffinityKey falls back to sessionId", () => {
+test("extractAffinityKey returns undefined when requestId is empty", () => {
   expect(
     extractAffinityKey({
-      sessionId: "sid",
-      safetyIdentifier: "safe",
+      requestId: "  ",
     }),
-  ).toBe("sid")
+  ).toBeUndefined()
 })
 
-test("extractAffinityKey falls back to safetyIdentifier", () => {
-  expect(
-    extractAffinityKey({
-      safetyIdentifier: "safe",
-    }),
-  ).toBe("safe")
-})
-
-test("extractAffinityKey returns undefined when nothing available", () => {
+test("extractAffinityKey returns undefined when requestId is missing", () => {
   expect(extractAffinityKey({})).toBeUndefined()
 })
 

--- a/tests/accounts-manager-free-lb.test.ts
+++ b/tests/accounts-manager-free-lb.test.ts
@@ -387,7 +387,7 @@ test("affinity: confirmAffinity routes subsequent requests to the same account",
   // First request: sequential → account "a". Confirm affinity.
   const first = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-1" },
+    { requestId: "session-1" },
   )
   expect(first.ok).toBe(true)
   if (!first.ok) return
@@ -397,7 +397,7 @@ test("affinity: confirmAffinity routes subsequent requests to the same account",
   // Second request with same key: affinity cache hit → same account.
   const second = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-1" },
+    { requestId: "session-1" },
   )
   expect(second.ok).toBe(true)
   if (!second.ok) return
@@ -427,7 +427,7 @@ test("affinity: without confirmAffinity, cache is not populated", async () => {
   // First request — do NOT call confirmAffinity.
   const first = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-2" },
+    { requestId: "session-2" },
   )
   expect(first.ok).toBe(true)
   if (!first.ok) return
@@ -437,7 +437,7 @@ test("affinity: without confirmAffinity, cache is not populated", async () => {
   // Second request: cache miss → round-robin advances cursor → "b".
   const second = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-2" },
+    { requestId: "session-2" },
   )
   expect(second.ok).toBe(true)
   if (!second.ok) return
@@ -474,7 +474,7 @@ test("affinity: different models with same key can route to different accounts",
 
   const selA = await manager.selectAccountForRequest(
     [{ modelId: "model-a", endpoint: "/chat/completions" }],
-    { promptCacheKey: "shared-key" },
+    { requestId: "shared-key" },
   )
   expect(selA.ok).toBe(true)
   if (!selA.ok) return
@@ -482,7 +482,7 @@ test("affinity: different models with same key can route to different accounts",
 
   const selB = await manager.selectAccountForRequest(
     [{ modelId: "model-b", endpoint: "/chat/completions" }],
-    { promptCacheKey: "shared-key" },
+    { requestId: "shared-key" },
   )
   expect(selB.ok).toBe(true)
   if (!selB.ok) return
@@ -516,7 +516,7 @@ test("affinity: skips failed preferred account and falls back to sequential", as
   // Establish affinity to account "a".
   const first = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-3" },
+    { requestId: "session-3" },
   )
   expect(first.ok).toBe(true)
   if (!first.ok) return
@@ -530,7 +530,7 @@ test("affinity: skips failed preferred account and falls back to sequential", as
   // Next request: affinity points to "a" but it's failed → fallback to "b".
   const second = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-3" },
+    { requestId: "session-3" },
   )
   expect(second.ok).toBe(true)
   if (!second.ok) return
@@ -587,7 +587,7 @@ test("affinity: disabled → no confirmAffinity callback even with context", asy
 
   const selection = await manager.selectAccountForRequest(
     [{ modelId: "free-model", endpoint: "/chat/completions" }],
-    { promptCacheKey: "session-x" },
+    { requestId: "session-x" },
   )
   expect(selection.ok).toBe(true)
   if (!selection.ok) return


### PR DESCRIPTION
## Summary
- Replace `promptCacheKey`/`sessionId`/`safetyIdentifier`-based account affinity with **upstream request ID**
- Ensures user and agent requests within the same conversation turn are always routed to the same upstream account
- Prevents `"input item ID does not belong to this connection"` errors from GitHub Copilot API

## Problem
When multiple upstream accounts are configured, the affinity system relied on `promptCacheKey` / `safetyIdentifier` extracted from the `user` field in the request payload. If the client didn't include session metadata in the `user` field, affinity was effectively disabled, causing same-turn `user` and `agent` requests to be routed to different accounts. GitHub Copilot API validates that agent requests belong to the same "connection" as the initial user request, resulting in errors.

## Solution
Use the deterministic **upstream request ID** (SHA-256 hash of `sessionId + machineId + lastUserContent`) as the affinity cache key. This ID is:
- **Stable within a conversation turn**: same user message → same request ID
- **Independent of client metadata**: no need for the client to embed session info in the `user` field
- **Already computed**: just moved the generation before account selection

## Changes
- `src/lib/account-affinity.ts`: Simplified `AffinityContext` to `{ requestId?: string }`
- `src/routes/chat-completions/handler.ts`: Generate request ID before account selection
- `src/routes/responses/handler.ts`: Same
- `src/routes/messages/handler.ts`: Pass `requestId` as affinity context
- Updated related tests

## Test plan
- [x] TypeScript typecheck passes
- [x] All 171 tests pass (including affinity-specific tests)
- [ ] Manual verification with multi-account setup to confirm no more `"input item ID does not belong to this connection"` errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构 (Refactor)**
  * 统一采用单一请求标识以简化请求路由和账户选择行为，改善路由一致性。
  * 调整交集观察器阈值以更早检测可见性，提升界面响应体验。

* **测试 (Tests)**
  * 更新相关测试用例以匹配新的请求标识和路由行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->