### PR TITLE
feat: stagger account initialization and add token refresh jitter

### DIFF
--- a/docs/superpowers/specs/2026-04-08-multi-account-timing-stagger-design.md
+++ b/docs/superpowers/specs/2026-04-08-multi-account-timing-stagger-design.md
@@ -93,14 +93,16 @@ const TOKEN_REFRESH_JITTER_MS = 30_000
 private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
   const baseDelay = Math.max((refreshInSeconds - 60) * 1000, 1000)
   const jitter = Math.floor(Math.random() * TOKEN_REFRESH_JITTER_MS)
-  return baseDelay + jitter
+  // Ensure the jittered delay doesn't exceed the token's validity window
+  const maxSafeDelay = Math.max(refreshInSeconds * 1000 - 1000, 1000)
+  return Math.min(baseDelay + jitter, maxSafeDelay)
 }
 ```
 
 **Characteristics**:
 - Adds 0-30 seconds of random jitter on top of the base delay
 - Base delay already reserves a 60-second buffer before expiry
-- With 30s jitter, worst case still refreshes 30s before expiry (safe margin)
+- Total delay is capped at `refreshInSeconds * 1000 - 1000` to guarantee refresh occurs at least 1 second before token expiry, even when `refresh_in` is unusually small
 - 20 accounts spread across a 30-second window ≈ 1.5s average spacing
 - Jitter is re-randomized on each refresh cycle (no persistent pattern)
 

--- a/docs/superpowers/specs/2026-04-08-multi-account-timing-stagger-design.md
+++ b/docs/superpowers/specs/2026-04-08-multi-account-timing-stagger-design.md
@@ -1,0 +1,146 @@
+# Multi-Account Timing Stagger Design
+
+**Date**: 2026-04-08  
+**Status**: Draft  
+**Scope**: Account initialization stagger + token refresh jitter
+
+## Background
+
+When copilot-api manages multiple GitHub Copilot accounts (~20) on a single machine with a single IP, the current implementation creates two timing-related risk patterns:
+
+1. **Initialization burst**: All accounts initialize sequentially in a tight loop, generating `3N` upstream API calls (token + quota + models) within seconds.
+2. **Token refresh synchronization**: All accounts receiving the same `refresh_in` value will refresh their tokens at nearly the same moment, creating periodic bursts.
+
+These patterns may trigger upstream rate limiting or anomaly detection.
+
+## Goals
+
+- Spread account initialization over time to avoid startup burst traffic
+- Add jitter to token refresh timing to prevent synchronized refresh storms
+- Minimal code changes, no changes to core request flow or account selection logic
+- Maintain all existing safety guarantees (pre-expiry refresh buffer, auth snapshot protection)
+
+## Non-Goals
+
+- IP diversification / proxy pool (separate future enhancement)
+- Request header fingerprint diversification
+- 429 retry with account switching
+- Affinity hotspot protection
+- Per-account rate limiting
+
+## Design
+
+### 1. Initialization Stagger
+
+**File**: `src/lib/accounts-manager.ts`  
+**Method**: `initialize()`
+
+**Current behavior** (line 176-183):
+```typescript
+for (const account of this.accounts.values()) {
+  try {
+    await this.initializeAccount(account)
+  } catch (error) {
+    // ... error handling
+  }
+}
+```
+
+**Proposed behavior**:
+```typescript
+const INIT_STAGGER_MIN_MS = 2000
+const INIT_STAGGER_MAX_MS = 5000
+
+let isFirst = true
+for (const account of this.accounts.values()) {
+  if (!isFirst) {
+    const delay = INIT_STAGGER_MIN_MS +
+      Math.floor(Math.random() * (INIT_STAGGER_MAX_MS - INIT_STAGGER_MIN_MS))
+    await new Promise(resolve => setTimeout(resolve, delay))
+  }
+  isFirst = false
+
+  try {
+    await this.initializeAccount(account)
+  } catch (error) {
+    // ... error handling unchanged
+  }
+}
+```
+
+**Characteristics**:
+- First account initializes immediately (fast startup for single-account usage)
+- Subsequent accounts wait 2-5 seconds each (randomized)
+- 20 accounts: total startup time ≈ 38-95 seconds
+- Constants defined at module level for easy adjustment
+
+### 2. Token Refresh Jitter
+
+**File**: `src/lib/accounts-manager.ts`  
+**Method**: `computeTokenRefreshDelayMs()`
+
+**Current behavior** (line 205-207):
+```typescript
+private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
+  return Math.max((refreshInSeconds - 60) * 1000, 1000)
+}
+```
+
+**Proposed behavior**:
+```typescript
+const TOKEN_REFRESH_JITTER_MS = 30_000
+
+private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
+  const baseDelay = Math.max((refreshInSeconds - 60) * 1000, 1000)
+  const jitter = Math.floor(Math.random() * TOKEN_REFRESH_JITTER_MS)
+  return baseDelay + jitter
+}
+```
+
+**Characteristics**:
+- Adds 0-30 seconds of random jitter on top of the base delay
+- Base delay already reserves a 60-second buffer before expiry
+- With 30s jitter, worst case still refreshes 30s before expiry (safe margin)
+- 20 accounts spread across a 30-second window ≈ 1.5s average spacing
+- Jitter is re-randomized on each refresh cycle (no persistent pattern)
+
+### Session Refresh — No Changes
+
+The existing session refresh already includes adequate jitter:
+```typescript
+const SESSION_REFRESH_BASE_MS = 60 * 60 * 1000     // 1 hour
+const SESSION_REFRESH_JITTER_MS = 20 * 60 * 1000    // 0-20 minutes
+```
+
+No modification needed.
+
+## New Constants Summary
+
+| Constant | Value | Location | Purpose |
+|----------|-------|----------|---------|
+| `INIT_STAGGER_MIN_MS` | `2000` | `accounts-manager.ts` | Minimum delay between account inits |
+| `INIT_STAGGER_MAX_MS` | `5000` | `accounts-manager.ts` | Maximum delay between account inits |
+| `TOKEN_REFRESH_JITTER_MS` | `30_000` | `accounts-manager.ts` | Random jitter window for token refresh |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/lib/accounts-manager.ts` | Add stagger delay in `initialize()` loop; add jitter in `computeTokenRefreshDelayMs()` |
+
+## Testing
+
+- Existing tests do not cover initialization timing or refresh scheduling — no breakage expected.
+- Optional: add unit test for `computeTokenRefreshDelayMs()` to verify jitter range (base + [0, 30s]).
+- Manual verification: observe startup logs to confirm staggered initialization timing.
+
+## Future Enhancements (Out of Scope)
+
+If needed later, these can be added incrementally:
+
+1. **Per-account rate limiting** — independent request rate caps per account
+2. **429 intelligent retry** — auto-switch account on rate limit, with backoff
+3. **Request header diversification** — per-account `editor-version` variance
+4. **Affinity hotspot protection** — flow caps on affinity-bound accounts
+5. **Account health scoring** — priority routing based on error rate / quota remaining
+6. **IP diversification** — proxy pool for per-account outbound IPs

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -75,6 +75,13 @@ const SESSION_REFRESH_BASE_MS = 60 * 60 * 1000
 /** Session refresh jitter window in milliseconds. */
 const SESSION_REFRESH_JITTER_MS = 20 * 60 * 1000
 
+/** Minimum delay between account initializations in milliseconds. */
+const INIT_STAGGER_MIN_MS = 2000
+/** Maximum delay between account initializations in milliseconds. */
+const INIT_STAGGER_MAX_MS = 5000
+/** Random jitter window added to token refresh delay in milliseconds. */
+const TOKEN_REFRESH_JITTER_MS = 30_000
+
 export interface AccountRequestCandidate {
   modelId: string
   endpoint: string
@@ -172,8 +179,22 @@ export class AccountsManager {
       this.accountOrder.push(meta.id)
     }
 
-    // Initialize Copilot tokens for all accounts
+    // Initialize Copilot tokens for all accounts (staggered to avoid burst traffic)
+    let isFirstAccount = true
     for (const account of this.accounts.values()) {
+      if (!isFirstAccount) {
+        const staggerDelay =
+          INIT_STAGGER_MIN_MS
+          + Math.floor(
+            Math.random() * (INIT_STAGGER_MAX_MS - INIT_STAGGER_MIN_MS),
+          )
+        consola.debug(
+          `Staggering initialization of account ${account.id} by ${staggerDelay}ms`,
+        )
+        await new Promise((resolve) => setTimeout(resolve, staggerDelay))
+      }
+      isFirstAccount = false
+
       try {
         await this.initializeAccount(account)
       } catch (error) {
@@ -203,7 +224,9 @@ export class AccountsManager {
   }
 
   private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
-    return Math.max((refreshInSeconds - 60) * 1000, 1000)
+    const baseDelay = Math.max((refreshInSeconds - 60) * 1000, 1000)
+    const jitter = Math.floor(Math.random() * TOKEN_REFRESH_JITTER_MS)
+    return baseDelay + jitter
   }
 
   private computeSessionRefreshDelayMs(): number {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -226,7 +226,9 @@ export class AccountsManager {
   private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
     const baseDelay = Math.max((refreshInSeconds - 60) * 1000, 1000)
     const jitter = Math.floor(Math.random() * TOKEN_REFRESH_JITTER_MS)
-    return baseDelay + jitter
+    // Ensure the jittered delay doesn't exceed the token's validity window
+    const maxSafeDelay = Math.max(refreshInSeconds * 1000 - 1000, 1000)
+    return Math.min(baseDelay + jitter, maxSafeDelay)
   }
 
   private computeSessionRefreshDelayMs(): number {


### PR DESCRIPTION
## Summary
- Add 2-5s random delay between multi-account initializations to avoid burst upstream API traffic at startup
- Add 0-30s random jitter to token refresh timing to prevent synchronized refresh storms
- Session refresh already has adequate jitter, no changes needed

## Test plan
- [x] All 218 existing tests pass (0 failures)
- [x] Lint and typecheck pass
- [ ] Manual verification: observe startup logs to confirm staggered initialization timing with multiple accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 多账户初始化改为时间错开：第一个账户立即初始化，后续账户在 2–5 秒范围内随机延迟后依次初始化，减少并发峰值。
  * 令牌刷新时加入 0–30 秒的随机抖动以分散刷新请求，并在极端情况下确保仍在令牌过期前完成刷新。
  * 会话刷新行为保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->