### PR TITLE
fix: ensure account list refreshes after adding account in Admin UI

### DIFF
--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1301,6 +1301,19 @@ export class AccountsManager {
   }
 
   /**
+   * Immediately reload the registry, bypassing the debounce delay.
+   * Useful when the caller has just modified the registry and needs
+   * the changes to be reflected before continuing.
+   */
+  async reloadRegistryNow(): Promise<void> {
+    if (this.reloadDebounceTimer) {
+      clearTimeout(this.reloadDebounceTimer)
+      this.reloadDebounceTimer = undefined
+    }
+    await this.reloadRegistry()
+  }
+
+  /**
    * Schedule a registry reload with debouncing.
    */
   private scheduleReload(): void {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -138,6 +138,7 @@ export class AccountsManager {
   private registryWatcherRestartTimer?: ReturnType<typeof setTimeout>
   private registryWatcherRestartDelayMs = WATCHER_RESTART_INITIAL_DELAY_MS
   private isReloading = false
+  private currentReloadPromise?: Promise<void>
 
   /** Initialize accounts manager (load registry, migrate legacy token). */
   async initialize(vsCodeVersion?: string): Promise<void> {
@@ -1302,13 +1303,17 @@ export class AccountsManager {
 
   /**
    * Immediately reload the registry, bypassing the debounce delay.
-   * Useful when the caller has just modified the registry and needs
-   * the changes to be reflected before continuing.
+   * If a reload is already running, waits for it to complete and then
+   * runs another reload to ensure the latest changes are captured.
    */
   async reloadRegistryNow(): Promise<void> {
     if (this.reloadDebounceTimer) {
       clearTimeout(this.reloadDebounceTimer)
       this.reloadDebounceTimer = undefined
+    }
+    // Wait for any in-progress reload before starting a fresh one
+    if (this.currentReloadPromise) {
+      await this.currentReloadPromise
     }
     await this.reloadRegistry()
   }
@@ -1340,44 +1345,49 @@ export class AccountsManager {
     }
     this.isReloading = true
 
-    try {
-      const newMetas = await listAccountsFromRegistry()
-      const newIds = new Set(newMetas.map((m) => m.id))
-      const currentIds = new Set(this.accountOrder)
+    this.currentReloadPromise = (async () => {
+      try {
+        const newMetas = await listAccountsFromRegistry()
+        const newIds = new Set(newMetas.map((m) => m.id))
+        const currentIds = new Set(this.accountOrder)
 
-      // Track changes for logging
-      const added: Array<string> = []
-      const removed: Array<string> = []
-      const updated: Array<string> = []
+        // Track changes for logging
+        const added: Array<string> = []
+        const removed: Array<string> = []
+        const updated: Array<string> = []
 
-      this.removeDeletedAccounts(currentIds, newIds, removed)
+        this.removeDeletedAccounts(currentIds, newIds, removed)
 
-      // Add new accounts (newIds - currentIds)
-      for (const meta of newMetas) {
-        if (!currentIds.has(meta.id)) {
-          await this.addNewAccount(meta, added)
+        // Add new accounts (newIds - currentIds)
+        for (const meta of newMetas) {
+          if (!currentIds.has(meta.id)) {
+            await this.addNewAccount(meta, added)
+          }
         }
+
+        // Update existing accounts when meta/token changed
+        await this.reinitializeUpdatedAccounts(newMetas, currentIds, updated)
+
+        // Update accountOrder to reflect new order
+        this.accountOrder = newMetas
+          .map((m) => m.id)
+          .filter((id) => this.accounts.has(id))
+
+        // Reset load-balance cursor on account list/order changes.
+        this.loadBalanceCursor = 0
+
+        this.logRegistryReloadChanges(added, removed, updated)
+      } catch (error) {
+        consola.error("Failed to reload registry:", error)
+        this.shutdown()
+        process.exit(1)
+      } finally {
+        this.isReloading = false
+        this.currentReloadPromise = undefined
       }
+    })()
 
-      // Update existing accounts when meta/token changed
-      await this.reinitializeUpdatedAccounts(newMetas, currentIds, updated)
-
-      // Update accountOrder to reflect new order
-      this.accountOrder = newMetas
-        .map((m) => m.id)
-        .filter((id) => this.accounts.has(id))
-
-      // Reset load-balance cursor on account list/order changes.
-      this.loadBalanceCursor = 0
-
-      this.logRegistryReloadChanges(added, removed, updated)
-    } catch (error) {
-      consola.error("Failed to reload registry:", error)
-      this.shutdown()
-      process.exit(1)
-    } finally {
-      this.isReloading = false
-    }
+    await this.currentReloadPromise
   }
 
   private removeDeletedAccounts(

--- a/src/routes/admin-api/auth-sessions.ts
+++ b/src/routes/admin-api/auth-sessions.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto"
 
 import type { AccountType } from "~/lib/types/account"
 
+import { accountsManager } from "~/lib/accounts-manager"
 import {
   addAccountToRegistry,
   listAccountsFromRegistry,
@@ -220,6 +221,11 @@ export class AuthSessionManager {
         })
       }
       if (!this.getLiveSession(sessionId)) return
+
+      // Wait for accountsManager to pick up the new/updated account
+      // before marking the session as completed, so the frontend
+      // refresh will see the account immediately.
+      await accountsManager.reloadRegistryNow()
 
       this.completeSession(sessionId, accountId)
     } catch (error) {


### PR DESCRIPTION
## Summary

- Fix race condition where the Admin UI account list didn't refresh after adding a new account (closes #53)
- Add `AccountsManager.reloadRegistryNow()` method to bypass the 500ms debounce delay on registry reload
- Call it from `auth-sessions` after modifying the registry, before marking the auth session as "completed"

## Root Cause

The `/admin/api/accounts` endpoint relies on `accountsManager.getAccountStatus()` for account data. When a new account was added:

1. `auth-sessions` wrote to `registry.json` and immediately marked the session as "completed"
2. `accountsManager` detected the file change via `fs.watch`, but had a **500ms debounce** + account initialization delay
3. Frontend refreshed immediately after seeing "completed", but the new account wasn't in `accountsManager`'s memory yet

## Fix

Now `auth-sessions` awaits `accountsManager.reloadRegistryNow()` before marking the session as completed. This ensures the account is fully loaded when the frontend refreshes.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 218 tests pass, 0 failures
- [ ] Manual: Start dev server, add account via Admin UI, verify account appears immediately after clicking "Done"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了账户认证流程中的数据同步机制，确保在认证完成前账户注册表已正确更新，提高了账户数据的一致性。

* **性能优化**
  * 优化了账户注册表的重载逻辑，支持在必要时立即刷新而无需等待延迟。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->