### PR TITLE
feat: surface subagent request status in admin UI

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -2,6 +2,60 @@ import { readAdminToken } from "@/lib/admin-token"
 
 export const ADMIN_TOKEN_REQUIRED_EVENT = "admin-ui:admin-token-required"
 
+// Wire types from backend (SQLite 0/1/null)
+type AdminRequestItemWire = {
+  request_id: string
+  started_at_ms?: number
+  http_status: number
+  duration_ms?: number
+  ttfb_ms?: number
+
+  path: string
+  upstream_endpoint?: string
+  upstream_model?: string
+  client_model?: string
+  account_id?: string
+
+  cost_units?: number
+  premium_unlimited_after?: boolean
+  premium_remaining_after?: number
+  premium_remaining_before?: number
+  premium_remaining_diff?: number
+
+  tokens_input?: number
+  tokens_output?: number
+  tokens_total?: number
+  tokens_cached_input?: number
+
+  client_ip?: string
+  user_agent?: string
+
+  user_id?: string
+  safety_identifier?: string
+  prompt_cache_key?: string
+  initiator?: string
+  is_subagent?: number | null
+  upstream_request_id?: string
+
+  affinity_hit?: number | null
+  affinity_cache_key?: string | null
+
+  error?: unknown
+}
+
+// UI-facing type with normalized boolean semantics
+export type AdminRequestItem = Omit<AdminRequestItemWire, "is_subagent"> & {
+  is_subagent?: boolean | null
+}
+
+export function normalizeAdminRequestItem(wire: AdminRequestItemWire): AdminRequestItem {
+  const { is_subagent, ...rest } = wire
+  return {
+    ...rest,
+    is_subagent: is_subagent === 1 ? true : is_subagent === 0 ? false : null,
+  }
+}
+
 export type AdminMeta = {
   userVersion?: number
   dbPath?: string
@@ -29,51 +83,6 @@ export type AdminAccountItem = {
 
 export type AdminAccountsResponse = {
   items: AdminAccountItem[]
-}
-
-export type AdminRequestItem = {
-  request_id: string
-  started_at_ms?: number
-  http_status: number
-  duration_ms?: number
-  ttfb_ms?: number
-
-  path: string
-  upstream_endpoint?: string
-  upstream_model?: string
-  client_model?: string
-  account_id?: string
-
-  // Cost/quota
-  cost_units?: number
-  premium_unlimited_after?: boolean
-  premium_remaining_after?: number
-  premium_remaining_before?: number
-  premium_remaining_diff?: number
-
-  // Token usage
-  tokens_input?: number
-  tokens_output?: number
-  tokens_total?: number
-  tokens_cached_input?: number
-
-  // Client info
-  client_ip?: string
-  user_agent?: string
-
-  // Session correlation
-  user_id?: string
-  safety_identifier?: string
-  prompt_cache_key?: string
-  initiator?: string
-  upstream_request_id?: string
-
-  // Affinity
-  affinity_hit?: number | null
-  affinity_cache_key?: string | null
-
-  // Optional error info (depends on store)
-  error?: unknown
 }
 
 export type AdminRequestsResponse = {
@@ -274,15 +283,26 @@ export async function queryAdminRequests(params: {
   q.set("limit", String(params.limit ?? 50))
   if (params.cursor_id != null) q.set("cursor_id", String(params.cursor_id))
 
-  return fetchAdminJson<AdminRequestsResponse>(`/api/admin/requests?${q.toString()}`)
+  const response = await fetchAdminJson<{ items: AdminRequestItemWire[]; next_cursor_id?: number | null; has_more: boolean }>(
+    `/api/admin/requests?${q.toString()}`
+  )
+
+  return {
+    ...response,
+    items: response.items.map(normalizeAdminRequestItem),
+  }
 }
 
 export async function getAdminRequestDetail(
   requestId: string
 ): Promise<AdminRequestDetailResponse> {
-  return fetchAdminJson<AdminRequestDetailResponse>(
+  const response = await fetchAdminJson<{ item: AdminRequestItemWire | null }>(
     `/api/admin/requests/${encodeURIComponent(requestId)}`
   )
+
+  return {
+    item: response.item ? normalizeAdminRequestItem(response.item) : null,
+  }
 }
 
 export async function getAdminConfig(): Promise<AdminConfigResponse> {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -65,6 +65,7 @@
     "endpoint": "Endpoint",
     "model": "Model",
     "xInitiator": "Initiator",
+    "subagentRequest": "Subagent Request",
     "cost": "Cost",
     "quota": "Quota",
     "durationAbbrev": "Duration",
@@ -185,6 +186,7 @@
     },
     "columnTooltip": {
       "initiator": "Value of the x-initiator header sent by the client (e.g. IDE extension name).",
+      "subagentRequest": "Whether this request was identified as a subagent request.",
       "cost": "Copilot cost units consumed by this request.",
       "quota": "Premium interactions quota remaining after this request.",
       "duration": "Total response time in milliseconds.",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -65,6 +65,7 @@
     "endpoint": "端点",
     "model": "模型",
     "xInitiator": "发起方",
+    "subagentRequest": "子代理请求",
     "cost": "成本",
     "quota": "额度",
     "durationAbbrev": "耗时",
@@ -185,6 +186,7 @@
     },
     "columnTooltip": {
       "initiator": "客户端发送的 x-initiator 请求头值（如 IDE 扩展名称）。",
+      "subagentRequest": "该请求是否被识别为子代理请求。",
       "cost": "此请求消耗的 Copilot 成本单位。",
       "quota": "此请求完成后剩余的 Premium 交互额度。",
       "duration": "总响应时间（毫秒）。",

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -182,6 +182,7 @@ const requestsTableColVisibility = [
   "hidden lg:table-cell",
   "hidden xl:table-cell",
   "hidden xl:table-cell",
+  "hidden xl:table-cell",
   "hidden 2xl:table-cell",
   "hidden lg:table-cell",
   null,
@@ -712,15 +713,21 @@ export function RequestsPage(): React.JSX.Element {
                     <ColHead label={t("common.xInitiator")} tooltip={t("requestsPage.columnTooltip.initiator")} />
                   </TableHead>
                   <TableHead className={cn(requestsTableColVisibility[6])}>
-                    <ColHead label={t("common.tokens")} tooltip={t("requestsPage.columnTooltip.tokens")} />
+                    <ColHead
+                      label={t("common.subagentRequest")}
+                      tooltip={t("requestsPage.columnTooltip.subagentRequest")}
+                    />
                   </TableHead>
                   <TableHead className={cn(requestsTableColVisibility[7])}>
-                    <ColHead label={t("common.cost")} tooltip={t("requestsPage.columnTooltip.cost")} />
+                    <ColHead label={t("common.tokens")} tooltip={t("requestsPage.columnTooltip.tokens")} />
                   </TableHead>
                   <TableHead className={cn(requestsTableColVisibility[8])}>
-                    <ColHead label={t("common.quota")} tooltip={t("requestsPage.columnTooltip.quota")} />
+                    <ColHead label={t("common.cost")} tooltip={t("requestsPage.columnTooltip.cost")} />
                   </TableHead>
                   <TableHead className={cn(requestsTableColVisibility[9])}>
+                    <ColHead label={t("common.quota")} tooltip={t("requestsPage.columnTooltip.quota")} />
+                  </TableHead>
+                  <TableHead className={cn(requestsTableColVisibility[10])}>
                     <ColHead label={t("common.durationAbbrev")} tooltip={t("requestsPage.columnTooltip.duration")} />
                   </TableHead>
                   <TableHead>{t("common.status")}</TableHead>
@@ -824,16 +831,25 @@ export function RequestsPage(): React.JSX.Element {
                         <TableCell className={cn(requestsTableColVisibility[5], "font-mono text-xs")}>
                           {r.initiator || ""}
                         </TableCell>
-                        <TableCell className={cn(requestsTableColVisibility[6], "font-mono text-xs")}>
-                          {r.tokens_total != null ? fmtNum(r.tokens_total) : ""}
+                        <TableCell className={cn(requestsTableColVisibility[6], "text-xs")}>
+                          {r.is_subagent === null ? (
+                            "—"
+                          ) : (
+                            <Badge variant={r.is_subagent ? "secondary" : "outline"}>
+                              {t(r.is_subagent ? "common.yes" : "common.no")}
+                            </Badge>
+                          )}
                         </TableCell>
                         <TableCell className={cn(requestsTableColVisibility[7], "font-mono text-xs")}>
-                          {r.cost_units ?? ""}
+                          {r.tokens_total != null ? fmtNum(r.tokens_total) : ""}
                         </TableCell>
                         <TableCell className={cn(requestsTableColVisibility[8], "font-mono text-xs")}>
-                          {quota}
+                          {r.cost_units ?? ""}
                         </TableCell>
                         <TableCell className={cn(requestsTableColVisibility[9], "font-mono text-xs")}>
+                          {quota}
+                        </TableCell>
+                        <TableCell className={cn(requestsTableColVisibility[10], "font-mono text-xs")}>
                           {r.duration_ms != null ? fmtNum(r.duration_ms) : ""}
                         </TableCell>
                         <TableCell>{statusBadge}</TableCell>

--- a/admin-ui/tests/admin-ui-subagent-request.test.ts
+++ b/admin-ui/tests/admin-ui-subagent-request.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+
+import { normalizeAdminRequestItem } from "../src/lib/admin-api"
+
+test("normalizeAdminRequestItem converts wire is_subagent values into UI semantics", () => {
+  expect(normalizeAdminRequestItem({ request_id: "r1", http_status: 200, path: "/v1/messages", is_subagent: 1 }).is_subagent).toBe(true)
+  expect(normalizeAdminRequestItem({ request_id: "r2", http_status: 200, path: "/v1/messages", is_subagent: 0 }).is_subagent).toBe(false)
+  expect(normalizeAdminRequestItem({ request_id: "r3", http_status: 200, path: "/v1/messages", is_subagent: null }).is_subagent).toBeNull()
+  expect(normalizeAdminRequestItem({ request_id: "r4", http_status: 200, path: "/v1/messages" }).is_subagent).toBeNull()
+})

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -213,10 +213,15 @@ function migrateAdminDb(db: Database): void {
 
   if (current < 6) {
     // v6: explicit subagent request tracking column
-    db.run(`
-      ALTER TABLE request_log ADD COLUMN is_subagent INTEGER;
+    const hasIsSubagent = db
+      .query("PRAGMA table_info(request_log);")
+      .all()
+      .some((row) => (row as { name?: string }).name === "is_subagent")
 
-      PRAGMA user_version = 6;
-    `)
+    if (!hasIsSubagent) {
+      db.run("ALTER TABLE request_log ADD COLUMN is_subagent INTEGER;")
+    }
+
+    db.run("PRAGMA user_version = 6;")
   }
 }

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -147,7 +147,7 @@ function migrateAdminDb(db: Database): void {
   } | null
   const current = row?.user_version ?? 0
 
-  if (current >= 5) {
+  if (current >= 6) {
     return
   }
 
@@ -208,6 +208,15 @@ function migrateAdminDb(db: Database): void {
       ALTER TABLE request_log ADD COLUMN affinity_cache_key TEXT;
 
       PRAGMA user_version = 5;
+    `)
+  }
+
+  if (current < 6) {
+    // v6: explicit subagent request tracking column
+    db.run(`
+      ALTER TABLE request_log ADD COLUMN is_subagent INTEGER;
+
+      PRAGMA user_version = 6;
     `)
   }
 }

--- a/src/lib/request-history.test.ts
+++ b/src/lib/request-history.test.ts
@@ -230,7 +230,22 @@ describe("RequestHistoryStore", () => {
     expect(row?.stream).toBe(0)
     expect(row?.is_subagent).toBe(1)
     expect(row?.premium_unlimited_before).toBe(0)
-    expect(store.meta().userVersion).toBe(6)
+    expect(store.meta().userVersion).toBeGreaterThanOrEqual(6)
+  })
+
+  test("initAdminDb is idempotent when is_subagent already exists but user_version is stale", () => {
+    const db = new Database(":memory:")
+    initAdminDb(db)
+    db.run("PRAGMA user_version = 5;")
+
+    expect(() => initAdminDb(db)).not.toThrow()
+    expect(
+      db
+        .query("PRAGMA table_info(request_log);")
+        .all()
+        .some((row) => (row as { name?: string }).name === "is_subagent"),
+    ).toBe(true)
+    expect(db.query("PRAGMA user_version;").get()).toEqual({ user_version: 6 })
   })
 
   test("query orders by id DESC and supports cursor paging", () => {

--- a/src/lib/request-history.test.ts
+++ b/src/lib/request-history.test.ts
@@ -209,6 +209,7 @@ describe("RequestHistoryStore", () => {
       clientIp: "203.0.113.9",
       clientIpSource: "x-forwarded-for",
       userAgent: "ua",
+      isSubagent: true,
       tokensInput: 10,
       tokensOutput: 20,
       tokensTotal: 30,
@@ -227,7 +228,9 @@ describe("RequestHistoryStore", () => {
     expect(row?.path).toBe("/v1/messages")
     expect(row?.account_id).toBe("acct-1")
     expect(row?.stream).toBe(0)
+    expect(row?.is_subagent).toBe(1)
     expect(row?.premium_unlimited_before).toBe(0)
+    expect(store.meta().userVersion).toBe(6)
   })
 
   test("query orders by id DESC and supports cursor paging", () => {

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -190,6 +190,7 @@ export type RequestLogInsert = {
   safetyIdentifier?: string
   promptCacheKey?: string
   initiator?: "agent" | "user"
+  isSubagent?: boolean
   upstreamRequestId?: string
 
   tokensInput?: number
@@ -241,6 +242,7 @@ export type RequestLogRow = {
   safety_identifier: string | null
   prompt_cache_key: string | null
   initiator: string | null
+  is_subagent: number | null
   upstream_request_id: string | null
 
   tokens_input: number | null
@@ -336,6 +338,7 @@ export class RequestHistoryStore {
         safety_identifier,
         prompt_cache_key,
         initiator,
+        is_subagent,
         upstream_request_id,
         tokens_input,
         tokens_output,
@@ -359,7 +362,7 @@ export class RequestHistoryStore {
         ?,?,?,?,?,?,?,?,
         ?,?,?,?,?,?,?,?,
         ?,?,?,?,?,?,?,?,
-        ?,?,?,?,?,?,?
+        ?,?,?,?,?,?,?,?
       );
     `)
 
@@ -411,6 +414,7 @@ export class RequestHistoryStore {
         toDbNull(record.safetyIdentifier),
         toDbNull(record.promptCacheKey),
         toDbNull(record.initiator),
+        toDbBool(record.isSubagent),
         toDbNull(record.upstreamRequestId),
 
         toDbNull(record.tokensInput),

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -123,6 +123,7 @@ type InstrumentationContext = {
   safetyIdentifier?: string
   promptCacheKey?: string
   initiator?: "agent" | "user"
+  isSubagent?: boolean
   upstreamRequestId?: string
 
   /** Call after upstream success to persist affinity mapping. */
@@ -218,6 +219,7 @@ export async function handleCompletion(c: Context) {
     safetyIdentifier: normalizedSafetyIdentifier,
     promptCacheKey: normalizedPromptCacheKey,
     initiator: initiatorOverride,
+    isSubagent: Boolean(subagentMarker),
   })
   if (blockedResponse) return blockedResponse
 
@@ -267,6 +269,7 @@ export async function handleCompletion(c: Context) {
       safetyIdentifier: normalizedSafetyIdentifier,
       promptCacheKey: normalizedPromptCacheKey,
       initiator: fallbackInitiator,
+      isSubagent: Boolean(subagentMarker),
       selection,
     })
   }
@@ -290,6 +293,7 @@ export async function handleCompletion(c: Context) {
     userId,
     safetyIdentifier: normalizedSafetyIdentifier,
     promptCacheKey: normalizedPromptCacheKey,
+    isSubagent: Boolean(subagentMarker),
     clientModel,
     account,
     reservation,
@@ -594,6 +598,7 @@ function insertRequestLog(
     safetyIdentifier: instr.safetyIdentifier,
     promptCacheKey: instr.promptCacheKey,
     initiator: instr.initiator,
+    isSubagent: instr.isSubagent,
     upstreamRequestId: instr.upstreamRequestId,
     affinityHit: instr.affinityHit,
     affinityCacheKey: instr.affinityCacheKey,

--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -70,6 +70,7 @@ type SelectionFailureContext = {
   safetyIdentifier?: string
   promptCacheKey?: string
   initiator?: "agent" | "user"
+  isSubagent?: boolean
   selection: SelectionFailure
 }
 
@@ -125,6 +126,7 @@ export const handleSelectionFailure = (
     safetyIdentifier,
     promptCacheKey,
     initiator,
+    isSubagent,
     selection,
   } = context
   const finishedAtMs = Date.now()
@@ -145,6 +147,7 @@ export const handleSelectionFailure = (
     safetyIdentifier,
     promptCacheKey,
     initiator,
+    isSubagent,
     httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
     selectionFailureReason: selection.reason,
   })

--- a/tests/messages-request-log-subagent.test.ts
+++ b/tests/messages-request-log-subagent.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import type { AccountRuntime } from "~/lib/types/account"
+import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+import type { Model } from "~/services/copilot/get-models"
+
+const testHome = await fs.mkdtemp(
+  path.join(os.tmpdir(), "copilot-api-subagent-request-log-"),
+)
+process.env.COPILOT_API_HOME = testHome
+
+const [{ accountsManager }, { getAdminDb }, { state }, { messageRoutes }] =
+  await Promise.all([
+    import("~/lib/accounts-manager"),
+    import("~/lib/admin-db"),
+    import("~/lib/state"),
+    import("~/routes/messages/route"),
+  ])
+
+type RequestLogSnapshot = {
+  initiator: string | null
+  is_subagent: number | null
+}
+
+const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+const originalFetch = fetchHolder.fetch
+const originalSelect =
+  accountsManager.selectAccountForRequest.bind(accountsManager)
+const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
+const originalMarkFailed =
+  accountsManager.markAccountFailed.bind(accountsManager)
+
+function buildAccount(): AccountRuntime {
+  return {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghu_test",
+    copilotToken: "copilot_test",
+    vsCodeVersion: "1.0.0",
+    premiumRemaining: 10,
+    unlimited: false,
+  }
+}
+
+function buildModel(id: string): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+
+function buildSelection(endpoint: string, modelId: string) {
+  return {
+    ok: true as const,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId),
+    endpoint,
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    affinityHit: false,
+  }
+}
+
+function buildAnthropicResponse(model: string, text: string) {
+  return {
+    id: "msg_1",
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text }],
+    model,
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 1,
+      output_tokens: 1,
+    },
+  }
+}
+
+function createPayload(
+  overrides: Partial<AnthropicMessagesPayload> = {},
+): AnthropicMessagesPayload {
+  return {
+    model: "original-model",
+    max_tokens: 128,
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  }
+}
+
+function getLatestRequestLog(): RequestLogSnapshot | null {
+  return getAdminDb()
+    .query(
+      "SELECT initiator, is_subagent FROM request_log ORDER BY id DESC LIMIT 1;",
+    )
+    .get() as RequestLogSnapshot | null
+}
+
+beforeEach(() => {
+  state.manualApprove = false
+  state.verbose = false
+
+  getAdminDb().run("DELETE FROM request_log;")
+
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/v1/messages", "messages-model"))
+  accountsManager.finalizeQuota = () => Promise.resolve()
+  accountsManager.markAccountFailed = () => {}
+})
+
+afterEach(() => {
+  fetchHolder.fetch = originalFetch
+  accountsManager.selectAccountForRequest = originalSelect
+  accountsManager.finalizeQuota = originalFinalize
+  accountsManager.markAccountFailed = originalMarkFailed
+})
+
+describe("messages request log subagent persistence", () => {
+  test("writes is_subagent = 1 for __SUBAGENT_MARKER__ requests", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify(buildAnthropicResponse("messages-model", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            messages: [
+              {
+                role: "user",
+                content: [
+                  {
+                    type: "text",
+                    text: '<system-reminder>__SUBAGENT_MARKER__{"session_id":"sub-session","agent_id":"agent-1","agent_type":"Explore"}</system-reminder>',
+                  },
+                  {
+                    type: "text",
+                    text: "hello",
+                  },
+                ],
+              },
+            ],
+          }),
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(getLatestRequestLog()?.is_subagent).toBe(1)
+  })
+
+  test("keeps tool_result continuations out of is_subagent without marker", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify(buildAnthropicResponse("messages-model", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            messages: [
+              {
+                role: "user",
+                content: [
+                  {
+                    type: "tool_result",
+                    tool_use_id: "tool_1",
+                    content: "ok",
+                  },
+                ],
+              },
+            ],
+          }),
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(getLatestRequestLog()).toEqual({
+      initiator: "agent",
+      is_subagent: 0,
+    })
+  })
+})

--- a/tests/messages-request-log-subagent.test.ts
+++ b/tests/messages-request-log-subagent.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -136,6 +144,11 @@ afterEach(() => {
   accountsManager.selectAccountForRequest = originalSelect
   accountsManager.finalizeQuota = originalFinalize
   accountsManager.markAccountFailed = originalMarkFailed
+})
+
+afterAll(async () => {
+  getAdminDb().close()
+  await fs.rm(testHome, { recursive: true, force: true })
 })
 
 describe("messages request log subagent persistence", () => {


### PR DESCRIPTION
## Summary
- persist explicit `is_subagent` request-history data for `/v1/messages`, including early failure paths
- normalize the admin API field to boolean semantics and show a `Subagent Request` column in the requests table
- add regression coverage for request-log persistence and admin UI normalization

## Test plan
- [x] bun run lint
- [x] bun run lint:admin
- [x] bun run typecheck
- [x] bun test "/Volumes/Nick-OMV-Storage/Workspace/copilot-api/src/lib/request-history.test.ts" "/Volumes/Nick-OMV-Storage/Workspace/copilot-api/tests/messages-request-log-subagent.test.ts" "/Volumes/Nick-OMV-Storage/Workspace/copilot-api/admin-ui/tests/admin-ui-subagent-request.test.ts"
- [x] bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 管理员 UI 的请求表新增“子代理请求”列，展示请求是否为子代理并在表格中以标记显示。
  * 系统开始在请求历史中记录并保存子代理标识，以便在详情和列表中正确展示。

* **本地化**
  * 增加中英文文案与列提示，说明子代理请求含义。

* **测试**
  * 添加端到端和单元测试，覆盖子代理识别、规范化与持久化行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->