### PR TITLE
fix: parse subagent markers with trailing runtime text

### DIFF
--- a/src/routes/messages/subagent-marker.ts
+++ b/src/routes/messages/subagent-marker.ts
@@ -1,6 +1,7 @@
 import type { AnthropicMessagesPayload } from "./anthropic-types"
 
 const subagentMarkerPrefix = "__SUBAGENT_MARKER__"
+const REMINDER_RE = /<system-reminder>([\s\S]*?)<\/system-reminder>/g
 
 export interface SubagentMarker {
   session_id: string
@@ -35,44 +36,72 @@ export const parseSubagentMarkerFromFirstUser = (
 const parseSubagentMarkerFromSystemReminder = (
   text: string,
 ): SubagentMarker | null => {
-  const startTag = "<system-reminder>"
-  const endTag = "</system-reminder>"
-  let searchFrom = 0
+  for (const [, content] of text.matchAll(REMINDER_RE)) {
+    const markerIndex = content.indexOf(subagentMarkerPrefix)
+    if (markerIndex === -1) continue
 
-  while (true) {
-    const reminderStart = text.indexOf(startTag, searchFrom)
-    if (reminderStart === -1) {
-      break
-    }
-
-    const contentStart = reminderStart + startTag.length
-    const reminderEnd = text.indexOf(endTag, contentStart)
-    if (reminderEnd === -1) {
-      break
-    }
-
-    const reminderContent = text.slice(contentStart, reminderEnd)
-    const markerIndex = reminderContent.indexOf(subagentMarkerPrefix)
-    if (markerIndex === -1) {
-      searchFrom = reminderEnd + endTag.length
-      continue
-    }
-
-    const markerJson = reminderContent
+    const afterPrefix = content
       .slice(markerIndex + subagentMarkerPrefix.length)
-      .trim()
+      .trimStart()
+    if (!afterPrefix.startsWith("{")) continue
+
+    const json = extractBalancedJson(afterPrefix)
+    if (!json) continue
 
     try {
-      const parsed = JSON.parse(markerJson) as SubagentMarker
+      const parsed = JSON.parse(json) as SubagentMarker
       if (!parsed.session_id || !parsed.agent_id || !parsed.agent_type) {
-        searchFrom = reminderEnd + endTag.length
+        continue
+      }
+      return parsed
+    } catch {
+      continue
+    }
+  }
+
+  return null
+}
+
+/** Extract the first balanced `{...}` object from text that starts with `{`. */
+const extractBalancedJson = (text: string): string | null => {
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+
+    if (inString) {
+      if (escaped) {
+        escaped = false
         continue
       }
 
-      return parsed
-    } catch {
-      searchFrom = reminderEnd + endTag.length
+      if (char === "\\") {
+        escaped = true
+        continue
+      }
+
+      if (char === '"') {
+        inString = false
+      }
+
       continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+
+    if (char === "{") {
+      depth += 1
+      continue
+    }
+
+    if (char === "}") {
+      depth -= 1
+      if (depth === 0) return text.slice(0, index + 1)
     }
   }
 

--- a/tests/subagent-marker.test.ts
+++ b/tests/subagent-marker.test.ts
@@ -39,6 +39,49 @@ SubagentStart hook additional context: __SUBAGENT_MARKER__{"session_id":"s-1","a
     })
   })
 
+  test("parses marker when runtime appends a started line after json", () => {
+    const payload = basePayload([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `<system-reminder>
+SubagentStart hook additional context: __SUBAGENT_MARKER__{"session_id":"s-1","agent_id":"a-1","agent_type":"claude-subagent"}
+Agent Explore started (agent-1)
+</system-reminder>`,
+          },
+        ],
+      },
+    ])
+
+    expect(parseSubagentMarkerFromFirstUser(payload)).toEqual({
+      session_id: "s-1",
+      agent_id: "a-1",
+      agent_type: "claude-subagent",
+    })
+  })
+
+  test("parses marker when runtime appends multiple lines after json", () => {
+    const payload = basePayload([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: '<system-reminder>\nSubagentStart hook additional context: __SUBAGENT_MARKER__{"session_id":"s-2","agent_id":"a-2","agent_type":"claude \\"subagent\\""}\nAgent Explore started (agent-2)\nAdditional runtime note\n</system-reminder>',
+          },
+        ],
+      },
+    ])
+
+    expect(parseSubagentMarkerFromFirstUser(payload)).toEqual({
+      session_id: "s-2",
+      agent_id: "a-2",
+      agent_type: 'claude "subagent"',
+    })
+  })
+
   test("returns null when marker json is invalid", () => {
     const payload = basePayload([
       {
@@ -47,6 +90,25 @@ SubagentStart hook additional context: __SUBAGENT_MARKER__{"session_id":"s-1","a
           {
             type: "text",
             text: "<system-reminder>__SUBAGENT_MARKER__{invalid-json}</system-reminder>",
+          },
+        ],
+      },
+    ])
+
+    expect(parseSubagentMarkerFromFirstUser(payload)).toBeNull()
+  })
+
+  test("returns null when marker json object is incomplete", () => {
+    const payload = basePayload([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `<system-reminder>
+SubagentStart hook additional context: __SUBAGENT_MARKER__{"session_id":"s-1","agent_id":"a-1","agent_type":"claude-subagent"
+Agent Explore started (agent-1)
+</system-reminder>`,
           },
         ],
       },


### PR DESCRIPTION
## Summary
- extract the first balanced JSON object after `__SUBAGENT_MARKER__`
- ignore trailing Claude Code runtime text inside the same `<system-reminder>` block
- add regression coverage for single-line, multi-line, and incomplete JSON cases

## Test plan
- [x] bun test "tests/subagent-marker.test.ts"
- [x] bun test "tests/messages-handler.test.ts"
- [x] bun test "tests/messages-request-log-subagent.test.ts"
- [x] bun run lint
- [x] bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了子代理标记解析的稳定性，更好地处理边界情况和无效输入。
  * 增强了系统提醒块的提取逻辑，支持处理标记后的额外文本。

* **测试**
  * 添加测试覆盖以验证不完整JSON的处理。
  * 扩展测试场景以验证标记解析的鲁棒性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->