### PR TITLE
feat: add configurable file log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,11 +357,14 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
     },
     "allowOriginalModelNamesForAliases": false,
     "useFunctionApplyPatch": true,
+    "forceAgent": false,
     "compactUseSmallModel": true,
     "messageStartInputTokensFallback": false,
     "modelRefreshIntervalHours": 24,
+    "sessionAffinityRetentionDays": 7,
     "useMessagesApi": true,
-    "useResponsesApiWebSearch": true
+    "useResponsesApiWebSearch": true,
+    "logLevel": "info"
   }
   ```
 - **auth.apiKeys:** API keys used for request authentication. Supports multiple keys for rotation. Requests can authenticate with either `x-api-key: <key>` or `Authorization: Bearer <key>`. If empty or omitted, authentication is disabled.
@@ -411,9 +414,13 @@ The `<target>` can be either the account ID (GitHub username) or a 1-based index
 - **compactUseSmallModel:** When `true`, detected "compact" requests (e.g., from Claude Code or opencode compact mode) will automatically use the configured `smallModel` to avoid consuming premium usage for short/background tasks. Defaults to `true`.
 - **messageStartInputTokensFallback:** When `true`, the Anthropic streaming translation layer estimates `message_start.input_tokens` when upstream stream events do not provide it. Defaults to `false`.
 - **modelRefreshIntervalHours:** Interval for refreshing account model lists in the background. Set to `0` to disable refresh. Defaults to `24`.
+- **sessionAffinityRetentionDays:** Number of days to retain session affinity bindings. Defaults to `7`.
 - **useMessagesApi:** When `true` (default), Claude-family models that support Copilot's native `/v1/messages` endpoint may use the Messages API path. Set to `false` to skip the Messages API candidate and fall back to `/responses` (if supported) or `/chat/completions`.
 - **useResponsesApiWebSearch:** When `true` (default), `/v1/responses` keeps tools with `type: "web_search"` and forwards them upstream. Set to `false` to strip them before the Copilot request is sent.
+- **logLevel:** Controls handler file-log verbosity under `logs/*.log`. Allowed values: `error`, `warn`, `info`, `debug`. Defaults to `info`. Set it to `debug` when you need payload- or stream-level diagnostics written into file logs.
 - **anthropicApiKey:** Optional Anthropic API key used for accurate Claude token counting (see [Accurate Claude Token Counting](#accurate-claude-token-counting) below). Can also be set via the `ANTHROPIC_API_KEY` environment variable. If not set, token counting falls back to GPT tokenizer estimation.
+
+`--verbose` no longer implicitly enables debug-level file logging. If you need detailed handler logs under `logs/*.log`, explicitly set `"logLevel": "debug"` in `config.json`.
 
 Edit this file to customize prompts or swap in your own fast model. If you edit it manually, restart the server (or call `GET /api/admin/config`) so the cached config is refreshed. Changes made through the Admin UI/API are validated, written to disk, and applied immediately; unknown keys are rejected.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -339,11 +339,14 @@ Admin API 规则独立于业务 API：
   },
   "allowOriginalModelNamesForAliases": false,
   "useFunctionApplyPatch": true,
+  "forceAgent": false,
   "compactUseSmallModel": true,
   "messageStartInputTokensFallback": false,
   "modelRefreshIntervalHours": 24,
+  "sessionAffinityRetentionDays": 7,
   "useMessagesApi": true,
-  "useResponsesApiWebSearch": true
+  "useResponsesApiWebSearch": true,
+  "logLevel": "info"
 }
 ```
 
@@ -366,9 +369,13 @@ Admin API 规则独立于业务 API：
 | `compactUseSmallModel` | compact 请求自动使用 smallModel |
 | `useMessagesApi` | 是否允许 `/v1/messages` 优先尝试 Copilot 原生 Messages API；关闭时将跳过该候选并从 `/responses`（如支持）或 `/chat/completions` 回退。 |
 | `useResponsesApiWebSearch` | 是否在 `/v1/responses` 中保留并转发 `type: "web_search"` 的工具；关闭时会在代理层剥离。 |
+| `logLevel` | 控制 `logs/*.log` 下 handler 文件日志的详细级别；可选 `error`、`warn`、`info`、`debug`，默认 `info`；如需把请求/响应 payload、stream event 等详细调试内容写入文件，请显式配置 `"logLevel": "debug"`。 |
 | `anthropicApiKey` | 可选 Anthropic API key；用于 Claude 模型 `count_tokens` 精确计数，也可通过环境变量 `ANTHROPIC_API_KEY` 提供 |
 | `messageStartInputTokensFallback` | Anthropic 流式首包 token 估算回退 |
 | `modelRefreshIntervalHours` | 模型刷新周期（小时，`0` 关闭） |
+| `sessionAffinityRetentionDays` | session affinity 绑定的保留天数，默认 `7` 天 |
+
+`--verbose` 不再隐式开启 debug 级别文件日志。
 
 ### providers 示例（Anthropic 上游代理）
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,8 @@ import fs from "node:fs"
 
 import { PATHS } from "./paths"
 
+export type LogLevel = "error" | "warn" | "info" | "debug"
+
 export interface AppConfig {
   auth?: {
     apiKeys?: Array<string>
@@ -30,6 +32,7 @@ export interface AppConfig {
   anthropicApiKey?: string
   useResponsesApiWebSearch?: boolean
   claudeTokenMultiplier?: number
+  logLevel?: LogLevel
 }
 
 export interface ModelConfig {
@@ -120,6 +123,7 @@ const defaultConfig: AppConfig = {
   sessionAffinityRetentionDays: 7,
   useMessagesApi: true,
   useResponsesApiWebSearch: true,
+  logLevel: "info",
 }
 
 let cachedConfig: AppConfig | null = null
@@ -146,6 +150,13 @@ function normalizeNonNegativeNumber(value: unknown): number | undefined {
   if (!Number.isFinite(value)) return undefined
   if (value < 0) return undefined
   return value
+}
+
+const LOG_LEVELS = new Set<LogLevel>(["error", "warn", "info", "debug"])
+
+function normalizeLogLevel(value: unknown): LogLevel | undefined {
+  if (typeof value !== "string") return undefined
+  return LOG_LEVELS.has(value as LogLevel) ? (value as LogLevel) : undefined
 }
 
 function ensureConfigFile(): void {
@@ -337,6 +348,27 @@ function mergeDefaultSessionAffinityRetention(config: AppConfig): {
   }
 }
 
+function mergeDefaultLogLevel(config: AppConfig): {
+  mergedConfig: AppConfig
+  changed: boolean
+} {
+  const normalized = normalizeLogLevel(
+    (config as Record<string, unknown>).logLevel,
+  )
+
+  if (normalized !== undefined) {
+    return { mergedConfig: config, changed: false }
+  }
+
+  return {
+    mergedConfig: {
+      ...config,
+      logLevel: defaultConfig.logLevel ?? "info",
+    },
+    changed: true,
+  }
+}
+
 type ConfigMergeResult = {
   mergedConfig: AppConfig
   changed: boolean
@@ -369,6 +401,7 @@ export function mergeConfigWithDefaults(): AppConfig {
     mergeDefaultAccountAffinity,
     mergeDefaultModelRefreshInterval,
     mergeDefaultSessionAffinityRetention,
+    mergeDefaultLogLevel,
   ])
 
   if (changed) {
@@ -580,6 +613,14 @@ export function getSmallModel(): string {
   }
 
   return getPreferredAliasForTarget(model) ?? model
+}
+
+export function getLogLevel(): LogLevel {
+  const config = getConfig()
+  const normalized = normalizeLogLevel(
+    (config as Record<string, unknown>).logLevel,
+  )
+  return normalized ?? defaultConfig.logLevel ?? "info"
 }
 
 export function isAccountAffinityEnabled(): boolean {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -352,9 +352,7 @@ function mergeDefaultLogLevel(config: AppConfig): {
   mergedConfig: AppConfig
   changed: boolean
 } {
-  const normalized = normalizeLogLevel(
-    (config as Record<string, unknown>).logLevel,
-  )
+  const normalized = normalizeLogLevel(config.logLevel)
 
   if (normalized !== undefined) {
     return { mergedConfig: config, changed: false }
@@ -617,9 +615,7 @@ export function getSmallModel(): string {
 
 export function getLogLevel(): LogLevel {
   const config = getConfig()
-  const normalized = normalizeLogLevel(
-    (config as Record<string, unknown>).logLevel,
-  )
+  const normalized = normalizeLogLevel(config.logLevel)
   return normalized ?? defaultConfig.logLevel ?? "info"
 }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -93,7 +93,11 @@ const sanitizeName = (name: string) => {
 }
 
 const getHandlerLogFilePath = (name: string, date: Date): string => {
-  const dateKey = date.toLocaleDateString("sv-SE")
+  const dateKey = [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-")
   return path.join(logDir, `${sanitizeName(name)}-${dateKey}.log`)
 }
 
@@ -319,9 +323,30 @@ export const debugJsonTail = (
 }
 
 // Consola level mapping: 0=error, 1=warn, 2=info/log/success, 3=verbose, 4=debug, 5=trace
-// We set level dynamically so consola short-circuits debug events before reaching the reporter
-// when logLevel != "debug", avoiding unnecessary reporter dispatch overhead.
-const getConsolaLevel = (): number => (resolveLogLevel() === "debug" ? 4 : 3)
+// Match the configured file log level so consola short-circuits irrelevant events before
+// they reach the reporter. "info" intentionally maps to 2 so info/log/success still pass.
+const getConsolaLevel = (): number => {
+  const logLevel = resolveLogLevel()
+
+  switch (logLevel) {
+    case "error": {
+      return 0
+    }
+    case "warn": {
+      return 1
+    }
+    case "info": {
+      return 2
+    }
+    case "debug": {
+      return 4
+    }
+    default: {
+      const exhaustiveCheck: never = logLevel
+      return exhaustiveCheck
+    }
+  }
+}
 
 export const createHandlerLogger = (name: string): ConsolaInstance => {
   const instance = consola.withTag(name)

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,16 +3,27 @@ import fs from "node:fs"
 import path from "node:path"
 import util from "node:util"
 
+import { getLogLevel, type LogLevel } from "./config"
 import { PATHS } from "./paths"
 import { requestContext } from "./request-context"
-import { state } from "./state"
 
 const LOG_RETENTION_DAYS = 7
 const LOG_RETENTION_MS = LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000
 const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000
-const LOG_DIR = path.join(PATHS.APP_DIR, "logs")
 const FLUSH_INTERVAL_MS = 1000
 const MAX_BUFFER_SIZE = 100
+
+const FILE_LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+}
+
+// Mutable so tests can override to a temp directory
+let logDir = path.join(PATHS.APP_DIR, "logs")
+// Test-only logLevel override; undefined means use getLogLevel() from config
+let testLogLevelOverride: LogLevel | undefined
 
 const logStreams = new Map<string, fs.WriteStream>()
 const logBuffers = new Map<string, Array<string>>()
@@ -21,21 +32,26 @@ let runtimeInitialized = false
 let flushInterval: ReturnType<typeof setInterval> | undefined
 let cleanupInterval: ReturnType<typeof setInterval> | undefined
 
+// Stored so tests can remove them during teardown
+let exitHandler: (() => void) | undefined
+let sigintHandler: (() => void) | undefined
+let sigtermHandler: (() => void) | undefined
+
 const ensureLogDirectory = () => {
-  if (!fs.existsSync(LOG_DIR)) {
-    fs.mkdirSync(LOG_DIR, { recursive: true })
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true })
   }
 }
 
 const cleanupOldLogs = () => {
-  if (!fs.existsSync(LOG_DIR)) {
+  if (!fs.existsSync(logDir)) {
     return
   }
 
   const now = Date.now()
 
-  for (const entry of fs.readdirSync(LOG_DIR)) {
-    const filePath = path.join(LOG_DIR, entry)
+  for (const entry of fs.readdirSync(logDir)) {
+    const filePath = path.join(logDir, entry)
 
     let stats: fs.Stats
     try {
@@ -74,6 +90,11 @@ const sanitizeName = (name: string) => {
     .replaceAll(/^-+|-+$/g, "")
 
   return normalized === "" ? "handler" : normalized
+}
+
+const getHandlerLogFilePath = (name: string, date: Date): string => {
+  const dateKey = date.toLocaleDateString("sv-SE")
+  return path.join(logDir, `${sanitizeName(name)}-${dateKey}.log`)
 }
 
 const maybeUnref = (timer: ReturnType<typeof setInterval>) => {
@@ -137,15 +158,19 @@ const initializeLoggerRuntime = () => {
   cleanupInterval = setInterval(cleanupOldLogs, CLEANUP_INTERVAL_MS)
   maybeUnref(cleanupInterval)
 
-  process.once("exit", cleanup)
-  process.once("SIGINT", () => {
+  exitHandler = cleanup
+  sigintHandler = () => {
     cleanup()
     process.exit(0)
-  })
-  process.once("SIGTERM", () => {
+  }
+  sigtermHandler = () => {
     cleanup()
     process.exit(0)
-  })
+  }
+
+  process.once("exit", exitHandler)
+  process.once("SIGINT", sigintHandler)
+  process.once("SIGTERM", sigtermHandler)
 }
 
 const getLogStream = (filePath: string): fs.WriteStream => {
@@ -178,13 +203,99 @@ const appendLine = (filePath: string, line: string) => {
   }
 }
 
+export const normalizeLogTypeToLevel = (type: string | undefined): LogLevel => {
+  switch (type) {
+    case "error": {
+      return "error"
+    }
+    case "warn": {
+      return "warn"
+    }
+    case "debug": {
+      return "debug"
+    }
+    default: {
+      return "info"
+    }
+  }
+}
+
+export const shouldWriteFileLog = (
+  type: string | undefined,
+  logLevel: LogLevel = resolveLogLevel(),
+): boolean => {
+  const typeLevel = normalizeLogTypeToLevel(type)
+  return FILE_LOG_LEVEL_PRIORITY[typeLevel] <= FILE_LOG_LEVEL_PRIORITY[logLevel]
+}
+
+const resolveLogLevel = (): LogLevel => testLogLevelOverride ?? getLogLevel()
+
+const isDebugFileLoggingEnabled = (): boolean => resolveLogLevel() === "debug"
+
+export const resetLoggerRuntimeForTests = (
+  overrideLogDir?: string,
+  logLevelOverride?: LogLevel,
+): void => {
+  if (flushInterval) {
+    clearInterval(flushInterval)
+    flushInterval = undefined
+  }
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval)
+    cleanupInterval = undefined
+  }
+
+  for (const stream of logStreams.values()) {
+    stream.destroy()
+  }
+  logStreams.clear()
+  logBuffers.clear()
+
+  if (exitHandler) {
+    process.off("exit", exitHandler)
+    exitHandler = undefined
+  }
+  if (sigintHandler) {
+    process.off("SIGINT", sigintHandler)
+    sigintHandler = undefined
+  }
+  if (sigtermHandler) {
+    process.off("SIGTERM", sigtermHandler)
+    sigtermHandler = undefined
+  }
+
+  runtimeInitialized = false
+  logDir = overrideLogDir ?? path.join(PATHS.APP_DIR, "logs")
+  testLogLevelOverride = logLevelOverride
+}
+
+export const getBufferedLogLinesForTests = (name: string): Array<string> => {
+  const prefix = `${sanitizeName(name)}-`
+
+  for (const [filePath, lines] of logBuffers.entries()) {
+    if (path.basename(filePath).startsWith(prefix)) {
+      return [...lines]
+    }
+  }
+
+  return []
+}
+
+/** @deprecated use resetLoggerRuntimeForTests / getBufferedLogLinesForTests */
+export const __loggerTestUtils = {
+  getBufferedHandlerLogLines: getBufferedLogLinesForTests,
+  resetBufferedLogs(): void {
+    logBuffers.clear()
+  },
+}
+
 type DebugLogger = Pick<ConsolaInstance, "debug">
 
 export const debugLazy = (
   logger: DebugLogger,
   factory: () => [unknown, ...Array<unknown>],
 ): void => {
-  if (!state.verbose) {
+  if (!isDebugFileLoggingEnabled()) {
     return
   }
 
@@ -207,25 +318,35 @@ export const debugJsonTail = (
   debugLazy(logger, () => [label, JSON.stringify(value).slice(-tailLength)])
 }
 
+// Consola level mapping: 0=error, 1=warn, 2=info/log/success, 3=verbose, 4=debug, 5=trace
+// We set level dynamically so consola short-circuits debug events before reaching the reporter
+// when logLevel != "debug", avoiding unnecessary reporter dispatch overhead.
+const getConsolaLevel = (): number => (resolveLogLevel() === "debug" ? 4 : 3)
+
 export const createHandlerLogger = (name: string): ConsolaInstance => {
-  const sanitizedName = sanitizeName(name)
   const instance = consola.withTag(name)
 
-  if (state.verbose) {
-    instance.level = 5
-  }
+  Object.defineProperty(instance, "level", {
+    get: getConsolaLevel,
+    configurable: true,
+  })
+
   instance.setReporters([])
 
   instance.addReporter({
     log(logObj) {
+      const fileLogLevel = resolveLogLevel()
+      if (!shouldWriteFileLog(logObj.type, fileLogLevel)) {
+        return
+      }
+
       initializeLoggerRuntime()
 
       const context = requestContext.getStore()
       const traceId = context?.traceId
       const date = logObj.date
-      const dateKey = date.toLocaleDateString("sv-SE")
       const timestamp = date.toLocaleString("sv-SE", { hour12: false })
-      const filePath = path.join(LOG_DIR, `${sanitizedName}-${dateKey}.log`)
+      const filePath = getHandlerLogFilePath(name, date)
       const message = formatArgs(logObj.args as Array<unknown>)
       const traceIdStr = traceId ? ` [${traceId}]` : ""
       const line = `[${timestamp}] [${logObj.type}] [${logObj.tag || name}]${traceIdStr}${

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -25,6 +25,7 @@ import {
   mergeConfigWithDefaults,
   PROVIDER_TYPE_ANTHROPIC,
   type AppConfig,
+  type LogLevel,
   type ModelConfig,
   type ProviderConfig,
 } from "~/lib/config"
@@ -173,6 +174,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "auth",
   "extraPrompts",
   "smallModel",
+  "logLevel",
   "accountAffinity",
   "apiKey",
   "anthropicApiKey",
@@ -199,6 +201,8 @@ const REASONING_EFFORTS = new Set<ReasoningEffort>([
   "high",
   "xhigh",
 ])
+
+const LOG_LEVELS = new Set<LogLevel>(["error", "warn", "info", "debug"])
 
 const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"])
 
@@ -234,6 +238,20 @@ function parseOptionalString(
   if (!trimmed) return { clear: true }
 
   return { value: trimmed }
+}
+
+function parseOptionalLogLevel(value: unknown): ParseFieldResult<LogLevel> {
+  const parsed = parseOptionalString(value, "logLevel")
+  if ("error" in parsed) return parsed
+  if ("clear" in parsed) return parsed
+
+  if (!LOG_LEVELS.has(parsed.value as LogLevel)) {
+    return {
+      error: `logLevel must be one of: ${[...LOG_LEVELS].join(", ")}`,
+    }
+  }
+
+  return { value: parsed.value as LogLevel }
 }
 
 function parseOptionalBoolean(
@@ -849,6 +867,18 @@ function applyAuthConfig(next: AppConfig, value: unknown): string | undefined {
   return undefined
 }
 
+function applyLogLevel(next: AppConfig, value: unknown): string | undefined {
+  const parsed = parseOptionalLogLevel(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    next.logLevel = undefined
+    return undefined
+  }
+
+  next.logLevel = parsed.value
+  return undefined
+}
+
 function applyOptionalBoolean(
   next: AppConfig,
   key:
@@ -969,6 +999,7 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
   auth: applyAuthConfig,
   extraPrompts: applyExtraPrompts,
   smallModel: (next, value) => applyOptionalString(next, "smallModel", value),
+  logLevel: applyLogLevel,
   accountAffinity: (next, value) =>
     applyOptionalBoolean(next, "accountAffinity", value),
   apiKey: (next, value) => applyOptionalString(next, "apiKey", value),

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import fs from "node:fs/promises"
 import path from "node:path"
 
-import { mergeConfigWithDefaults } from "~/lib/config"
+import { getLogLevel, mergeConfigWithDefaults } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
 
 type TestConfig = Record<string, unknown>
@@ -32,6 +32,125 @@ const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
     mergeConfigWithDefaults()
   }
 }
+
+test("GET /api/admin/config returns default logLevel", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config"),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as { logLevel?: string }
+    expect(body.logLevel).toBe("info")
+  })
+})
+
+test("POST /api/admin/config updates logLevel", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const postRes = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ logLevel: "debug" }),
+      }),
+    )
+
+    expect(postRes.status).toBe(200)
+
+    const postBody = (await postRes.json()) as { logLevel?: string }
+    expect(postBody.logLevel).toBe("debug")
+
+    const getRes = await server.fetch(
+      new Request("http://localhost/api/admin/config"),
+    )
+
+    expect(getRes.status).toBe(200)
+
+    const getBody = (await getRes.json()) as { logLevel?: string }
+    expect(getBody.logLevel).toBe("debug")
+    expect(getLogLevel()).toBe("debug")
+  })
+})
+
+test("POST /api/admin/config clears logLevel to default", async () => {
+  await withConfig({ logLevel: "debug" }, async () => {
+    const { server } = await import("../src/server")
+
+    const postRes = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ logLevel: null }),
+      }),
+    )
+
+    expect(postRes.status).toBe(200)
+
+    const postBody = (await postRes.json()) as { logLevel?: string }
+    expect(postBody.logLevel).toBe("info")
+
+    const getRes = await server.fetch(
+      new Request("http://localhost/api/admin/config"),
+    )
+
+    expect(getRes.status).toBe(200)
+
+    const getBody = (await getRes.json()) as { logLevel?: string }
+    expect(getBody.logLevel).toBe("info")
+    expect(getLogLevel()).toBe("info")
+  })
+})
+
+test("POST /api/admin/config rejects invalid logLevel strings", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ logLevel: "verbose" }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain("logLevel must be one of")
+  })
+})
+
+test("POST /api/admin/config rejects non-string logLevel", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ logLevel: false }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toBe("logLevel must be a string")
+  })
+})
 
 test("POST /api/admin/config updates useMessagesApi", async () => {
   await withConfig({}, async () => {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,14 +1,28 @@
 import { afterEach, expect, mock, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 
-import { debugJson, debugJsonTail } from "../src/lib/logger"
+import { type LogLevel } from "../src/lib/config"
+import {
+  createHandlerLogger,
+  debugJson,
+  debugJsonTail,
+  getBufferedLogLinesForTests,
+  normalizeLogTypeToLevel,
+  resetLoggerRuntimeForTests,
+  shouldWriteFileLog,
+} from "../src/lib/logger"
 import { state } from "../src/lib/state"
 
 afterEach(() => {
   state.verbose = false
+  resetLoggerRuntimeForTests()
 })
 
-test("debugJson skips serialization when verbose logging is disabled", () => {
-  state.verbose = false
+test("debugJson skips serialization when logLevel is not debug even if verbose is enabled", () => {
+  resetLoggerRuntimeForTests(undefined, "info")
+  state.verbose = true
 
   const logger = {
     debug: mock(() => {}),
@@ -21,8 +35,8 @@ test("debugJson skips serialization when verbose logging is disabled", () => {
   expect(logger.debug).not.toHaveBeenCalled()
 })
 
-test("debugJson logs the serialized payload when verbose logging is enabled", () => {
-  state.verbose = true
+test("debugJson logs the serialized payload when logLevel is debug", () => {
+  resetLoggerRuntimeForTests(undefined, "debug")
 
   const logger = {
     debug: mock(() => {}),
@@ -35,7 +49,7 @@ test("debugJson logs the serialized payload when verbose logging is enabled", ()
 })
 
 test("debugJsonTail preserves tail truncation behavior", () => {
-  state.verbose = true
+  resetLoggerRuntimeForTests(undefined, "debug")
 
   const logger = {
     debug: mock(() => {}),
@@ -43,7 +57,70 @@ test("debugJsonTail preserves tail truncation behavior", () => {
   const payload = { text: "abcdefghijklmnopqrstuvwxyz" }
   const expected = JSON.stringify(payload).slice(-10)
 
-  debugJsonTail(logger as never, "payload", { value: payload, tailLength: 10 })
+  debugJsonTail(logger as never, "payload", {
+    value: payload,
+    tailLength: 10,
+  })
 
   expect(logger.debug).toHaveBeenCalledWith("payload", expected)
+})
+
+test("shouldWriteFileLog respects the error/warn/info/debug matrix", () => {
+  const levels = ["error", "warn", "info", "debug"] as const
+  const expectedMatrix: Record<LogLevel, Record<LogLevel, boolean>> = {
+    error: { error: true, warn: false, info: false, debug: false },
+    warn: { error: true, warn: true, info: false, debug: false },
+    info: { error: true, warn: true, info: true, debug: false },
+    debug: { error: true, warn: true, info: true, debug: true },
+  }
+
+  for (const configuredLevel of levels) {
+    for (const logType of levels) {
+      expect(shouldWriteFileLog(logType, configuredLevel)).toBe(
+        expectedMatrix[configuredLevel][logType],
+      )
+    }
+  }
+})
+
+test("normalizeLogTypeToLevel maps info-like log types to info", () => {
+  expect(normalizeLogTypeToLevel("info")).toBe("info")
+  expect(normalizeLogTypeToLevel("log")).toBe("info")
+  expect(normalizeLogTypeToLevel("success")).toBe("info")
+  expect(normalizeLogTypeToLevel("unknown")).toBe("info")
+})
+
+test("createHandlerLogger blocks direct debug file logs when verbose is enabled but logLevel is info", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "logger-test-"))
+
+  try {
+    resetLoggerRuntimeForTests(tmpDir, "info")
+    state.verbose = true
+
+    const logger = createHandlerLogger("messages-handler-test")
+    logger.debug("blocked direct debug")
+
+    expect(getBufferedLogLinesForTests("messages-handler-test")).toEqual([])
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test("createHandlerLogger writes direct debug file logs when logLevel is debug", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "logger-test-"))
+
+  try {
+    resetLoggerRuntimeForTests(tmpDir, "debug")
+
+    const logger = createHandlerLogger("messages-handler-test")
+    logger.debug("allowed direct debug")
+
+    const lines = getBufferedLogLinesForTests("messages-handler-test")
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain("[debug]")
+    expect(lines[0]).toContain("allowed direct debug")
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary
- add `config.json.logLevel` support with default merging and `/api/admin/config` validation/update handling
- gate handler file logging by `logLevel` so debug payload and stream diagnostics only land in `logs/*.log` when explicitly enabled
- document the new config behavior in `README.md` and `README_CN.md`, including the boundary between `logLevel` and `--verbose`

## Test plan
- [x] `bun test \"tests/admin-config.test.ts\" \"tests/logger.test.ts\"`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增配置项：logLevel（error|warn|info|debug，默认 info）、sessionAffinityRetentionDays（默认 7）、forceAgent（默认 false）
  * 管理界面支持通过配置接口查看/修改 logLevel

* **文档**
  * 更新配置文档与示例（包含 JSON 语法修正），说明新增字段及默认值
  * 明确日志行为变更：--verbose 不再隐式启用文件级别的 debug 日志，需在 config.json 中设置 logLevel=debug
<!-- end of auto-generated comment: release notes by coderabbit.ai -->