### PR TITLE
fix: migrate model sources to accounts manager

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,7 +3,10 @@ import type { Model } from "~/services/copilot/get-models"
 import { accountsManager } from "~/lib/accounts-manager"
 
 export const getAvailableModels = (): Array<Model> =>
-  accountsManager.getFirstAccountModels()?.data ?? []
+  (accountsManager.getFirstAccountModels()?.data ?? []).filter(
+    (model) =>
+      model.model_picker_enabled || model.capabilities.type === "embeddings",
+  )
 
 export const findEndpointModel = (sdkModelId: string): Model | undefined => {
   const models = getAvailableModels()

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,9 +1,12 @@
 import type { Model } from "~/services/copilot/get-models"
 
-import { state } from "~/lib/state"
+import { accountsManager } from "~/lib/accounts-manager"
+
+export const getAvailableModels = (): Array<Model> =>
+  accountsManager.getFirstAccountModels()?.data ?? []
 
 export const findEndpointModel = (sdkModelId: string): Model | undefined => {
-  const models = state.models?.data ?? []
+  const models = getAvailableModels()
   const exactMatch = models.find((m) => m.id === sdkModelId)
   if (exactMatch) {
     return exactMatch
@@ -15,12 +18,7 @@ export const findEndpointModel = (sdkModelId: string): Model | undefined => {
   }
 
   const modelName = `claude-${normalized.family}-${normalized.version}`
-  const model = models.find((m) => m.id === modelName)
-  if (model) {
-    return model
-  }
-
-  return undefined
+  return models.find((m) => m.id === modelName)
 }
 
 /**

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto"
 
-import type { ModelsResponse } from "~/services/copilot/get-models"
-
 import type { AccountContext, AccountType } from "./types/account"
 
 export interface State {
@@ -9,7 +7,6 @@ export interface State {
   copilotToken?: string
 
   accountType: AccountType
-  models?: ModelsResponse
   vsCodeVersion?: string
 
   macMachineId?: string

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,6 @@ import { networkInterfaces } from "node:os"
 
 import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
 
-import { getModels } from "~/services/copilot/get-models"
 import { getVSCodeVersion } from "~/services/get-vscode-version"
 
 import { getVSCodeDeviceId } from "./deviceid"
@@ -19,17 +18,6 @@ export const sleep = (ms: number) =>
 
 export const isNullish = (value: unknown): value is null | undefined =>
   value === null || value === undefined
-
-export async function cacheModels(): Promise<void> {
-  const models = await getModels()
-  state.models = {
-    ...models,
-    data: models.data.filter(
-      (model) =>
-        model.model_picker_enabled || model.capabilities.type === "embeddings",
-    ),
-  }
-}
 
 export const cacheVSCodeVersion = async () => {
   const response = await getVSCodeVersion()

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -1,6 +1,6 @@
 import type { Model } from "~/services/copilot/get-models"
 
-import { state } from "~/lib/state"
+import { getAvailableModels } from "~/lib/models"
 import {
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
@@ -40,7 +40,7 @@ export function translateToOpenAI(
   payload: AnthropicMessagesPayload,
 ): ChatCompletionsPayload {
   const modelId = payload.model
-  const model = state.models?.data.find((m) => m.id === modelId)
+  const model = getAvailableModels().find((m) => m.id === modelId)
   const thinkingBudget = getThinkingBudget(payload, model)
   return {
     model: modelId,

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -2,31 +2,24 @@ import { Hono } from "hono"
 
 import { getAliasTargetSet, getModelAliases } from "~/lib/config"
 import { forwardError } from "~/lib/error"
-import { state } from "~/lib/state"
-import { cacheModels } from "~/lib/utils"
+import { getAvailableModels } from "~/lib/models"
 
 export const modelRoutes = new Hono()
 
 modelRoutes.get("/", async (c) => {
   try {
-    if (!state.models) {
-      // This should be handled by startup logic, but as a fallback.
-      await cacheModels()
-    }
-
     const blockedTargets = getAliasTargetSet()
-    const models =
-      state.models?.data
-        .filter((model) => !blockedTargets.has(model.id.toLowerCase()))
-        .map((model) => ({
-          id: model.id,
-          object: "model",
-          type: "model",
-          created: 0, // No date available from source
-          created_at: new Date(0).toISOString(), // No date available from source
-          owned_by: model.vendor,
-          display_name: model.name,
-        })) ?? []
+    const models = getAvailableModels()
+      .filter((model) => !blockedTargets.has(model.id.toLowerCase()))
+      .map((model) => ({
+        id: model.id,
+        object: "model",
+        type: "model",
+        created: 0, // No date available from source
+        created_at: new Date(0).toISOString(), // No date available from source
+        owned_by: model.vendor,
+        display_name: model.name,
+      }))
 
     const aliasItems = Object.keys(getModelAliases())
     const aliasModels = aliasItems.map((alias) => ({

--- a/src/routes/provider/messages/count-tokens-handler.ts
+++ b/src/routes/provider/messages/count-tokens-handler.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono"
 import type { Model } from "~/services/copilot/get-models"
 
 import { createHandlerLogger } from "~/lib/logger"
-import { state } from "~/lib/state"
+import { getAvailableModels } from "~/lib/models"
 import { getTokenCount } from "~/lib/tokenizer"
 import { type AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
 import { translateToOpenAI } from "~/routes/messages/non-stream-translation"
@@ -36,7 +36,9 @@ export async function handleProviderCountTokens(c: Context): Promise<Response> {
     const openAIPayload = translateToOpenAI(anthropicPayload)
     const modelId = anthropicPayload.model.trim()
 
-    let selectedModel = state.models?.data.find((model) => model.id === modelId)
+    let selectedModel = getAvailableModels().find(
+      (model) => model.id === modelId,
+    )
 
     if (!selectedModel && modelId) {
       selectedModel = createFallbackModel(modelId)

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -10,7 +10,6 @@ const originalState = {
   copilotToken: state.copilotToken,
   lastRequestTimestamp: state.lastRequestTimestamp,
   manualApprove: state.manualApprove,
-  models: state.models,
   rateLimitSeconds: state.rateLimitSeconds,
   rateLimitWait: state.rateLimitWait,
   verbose: state.verbose,
@@ -37,29 +36,6 @@ const fetchMock = mock(() =>
   ),
 )
 
-const createModels = () => ({
-  object: "list" as const,
-  data: [
-    {
-      capabilities: {
-        family: "gpt",
-        limits: {},
-        object: "model_capabilities" as const,
-        supports: {},
-        tokenizer: "o200k_base",
-        type: "chat" as const,
-      },
-      id: "gpt-5.4",
-      model_picker_enabled: true,
-      name: "gpt-5.4",
-      object: "model" as const,
-      preview: false,
-      vendor: "openai",
-      version: "1",
-    },
-  ],
-})
-
 const createApp = () => {
   const app = new Hono()
   app.route("/v1/chat/completions", completionRoutes)
@@ -75,7 +51,6 @@ beforeEach(() => {
   state.rateLimitWait = false
   state.rateLimitSeconds = undefined
   state.lastRequestTimestamp = undefined
-  state.models = createModels()
 
   fetchMock.mockClear()
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
@@ -91,7 +66,6 @@ afterEach(() => {
   state.rateLimitWait = originalState.rateLimitWait
   state.rateLimitSeconds = originalState.rateLimitSeconds
   state.lastRequestTimestamp = originalState.lastRequestTimestamp
-  state.models = originalState.models
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
 })
 

--- a/tests/model-alias-switch.test.ts
+++ b/tests/model-alias-switch.test.ts
@@ -6,10 +6,10 @@ import path from "node:path"
 
 import type { Model } from "~/services/copilot/get-models"
 
+import { accountsManager } from "~/lib/accounts-manager"
 import { getSmallModel, mergeConfigWithDefaults } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
 import { getRequestHistoryStore } from "~/lib/request-history"
-import { state } from "~/lib/state"
 import { maybeBlockOriginalModelName } from "~/routes/messages/utils"
 import { modelRoutes } from "~/routes/models/route"
 
@@ -70,17 +70,20 @@ const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
 }
 
 const withMockedModels = async (run: () => Promise<void>) => {
-  const originalModels = state.models
-  state.models = {
-    data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
-    object: "list",
-  } as ModelsResponse
+  const originalGetFirstAccountModels =
+    accountsManager.getFirstAccountModels.bind(accountsManager)
+
+  accountsManager.getFirstAccountModels = () =>
+    ({
+      data: [buildModel("gpt-5-mini"), buildModel("gpt-4")],
+      object: "list",
+    }) as ModelsResponse
 
   try {
     await run()
   } finally {
     // eslint-disable-next-line require-atomic-updates
-    state.models = originalModels
+    accountsManager.getFirstAccountModels = originalGetFirstAccountModels
   }
 }
 

--- a/tests/model-source-account-manager.test.ts
+++ b/tests/model-source-account-manager.test.ts
@@ -6,7 +6,7 @@ import type { ChatCompletionsPayload } from "~/services/copilot/create-chat-comp
 import type { Model } from "~/services/copilot/get-models"
 
 import { accountsManager } from "~/lib/accounts-manager"
-import { findEndpointModel } from "~/lib/models"
+import { findEndpointModel, getAvailableModels } from "~/lib/models"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
 import { translateToOpenAI } from "~/routes/messages/non-stream-translation"
@@ -80,6 +80,40 @@ describe("account-managed model sources", () => {
         expect(body.data.map((model) => model.id)).toContain(
           "copilot-test-route-model",
         )
+      },
+    )
+  })
+
+  test("getAvailableModels excludes hidden chat models while keeping embeddings", async () => {
+    const visibleChat = buildModel("visible-chat")
+    const hiddenChat = buildModel("hidden-chat", {
+      model_picker_enabled: false,
+    })
+    const hiddenEmbeddings = buildModel("hidden-embeddings", {
+      model_picker_enabled: false,
+      capabilities: {
+        family: "test",
+        limits: {},
+        object: "capabilities",
+        supports: {},
+        tokenizer: "o200k_base",
+        type: "embeddings",
+      },
+    })
+
+    await withMockedModels([visibleChat, hiddenChat, hiddenEmbeddings], () => {
+      expect(getAvailableModels().map((model) => model.id)).toEqual([
+        "visible-chat",
+        "hidden-embeddings",
+      ])
+    })
+  })
+
+  test("findEndpointModel ignores hidden chat models in compatibility lookups", async () => {
+    await withMockedModels(
+      [buildModel("hidden-chat", { model_picker_enabled: false })],
+      () => {
+        expect(findEndpointModel("hidden-chat")).toBeUndefined()
       },
     )
   })

--- a/tests/model-source-account-manager.test.ts
+++ b/tests/model-source-account-manager.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+
+import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+import type { ChatCompletionsPayload } from "~/services/copilot/create-chat-completions"
+import type { Model } from "~/services/copilot/get-models"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { findEndpointModel } from "~/lib/models"
+import { state } from "~/lib/state"
+import { getTokenCount } from "~/lib/tokenizer"
+import { translateToOpenAI } from "~/routes/messages/non-stream-translation"
+import { modelRoutes } from "~/routes/models/route"
+import { handleProviderCountTokens } from "~/routes/provider/messages/count-tokens-handler"
+
+type ModelsResponse = { data: Array<Model>; object: string }
+
+const buildModel = (id: string, overrides?: Partial<Model>): Model => ({
+  id,
+  name: id,
+  vendor: "upstream",
+  object: "model",
+  preview: false,
+  version: "test",
+  model_picker_enabled: true,
+  capabilities: {
+    family: "test",
+    limits: {
+      max_output_tokens: 8192,
+    },
+    object: "capabilities",
+    supports: {
+      max_thinking_budget: 4096,
+      min_thinking_budget: 1024,
+    },
+    tokenizer: "o200k_base",
+    type: "chat",
+  },
+  ...overrides,
+})
+
+const originalGetFirstAccountModels =
+  accountsManager.getFirstAccountModels.bind(accountsManager)
+const legacyState = state as unknown as Record<string, unknown>
+
+const clearLegacyModels = () => {
+  Reflect.deleteProperty(legacyState, "models")
+}
+
+const withMockedModels = async (
+  models: Array<Model>,
+  run: () => Promise<void> | void,
+) => {
+  accountsManager.getFirstAccountModels = () =>
+    ({
+      data: models,
+      object: "list",
+    }) as ModelsResponse
+  clearLegacyModels()
+  await run()
+}
+
+afterEach(() => {
+  accountsManager.getFirstAccountModels = originalGetFirstAccountModels
+  clearLegacyModels()
+})
+
+describe("account-managed model sources", () => {
+  test("GET /v1/models returns account-managed models when legacy state cache is absent", async () => {
+    await withMockedModels(
+      [buildModel("copilot-test-route-model")],
+      async () => {
+        const res = await modelRoutes.fetch(new Request("http://local/"))
+
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as {
+          data: Array<{ id: string }>
+        }
+
+        expect(body.data.map((model) => model.id)).toContain(
+          "copilot-test-route-model",
+        )
+      },
+    )
+  })
+
+  test("findEndpointModel resolves normalized Claude ids from account-managed models", async () => {
+    await withMockedModels([buildModel("claude-sonnet-4.5")], () => {
+      expect(findEndpointModel("claude-sonnet-4-5-20250514")?.id).toBe(
+        "claude-sonnet-4.5",
+      )
+    })
+  })
+
+  test("translateToOpenAI derives thinking budget from account-managed models", async () => {
+    const model = buildModel("claude-sonnet-4.5")
+
+    await withMockedModels([model], () => {
+      const payload: AnthropicMessagesPayload = {
+        model: model.id,
+        messages: [{ role: "user", content: "hello" }],
+        max_tokens: 512,
+        thinking: {
+          type: "enabled",
+          budget_tokens: 2048,
+        },
+      }
+
+      const openAIPayload = translateToOpenAI(payload)
+
+      expect(openAIPayload.thinking_budget).toBe(2048)
+    })
+  })
+
+  test("provider count_tokens uses tokenizer from account-managed models", async () => {
+    const providerModel = buildModel("provider-test-model", {
+      capabilities: {
+        family: "test",
+        limits: {},
+        object: "capabilities",
+        supports: {},
+        tokenizer: "cl100k_base",
+        type: "chat",
+      },
+    })
+    const content = "你好🙂你好🙂你好🙂"
+    const openAIPayload: ChatCompletionsPayload = {
+      model: providerModel.id,
+      messages: [{ role: "user", content }],
+    }
+    const expected = await getTokenCount(openAIPayload, providerModel)
+
+    await withMockedModels([providerModel], async () => {
+      const app = new Hono()
+      app.post(
+        "/providers/:provider/messages/count_tokens",
+        handleProviderCountTokens,
+      )
+
+      const res = await app.request("/providers/test/messages/count_tokens", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: providerModel.id,
+          messages: [{ role: "user", content }],
+          max_tokens: 1,
+        } satisfies AnthropicMessagesPayload),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        input_tokens: expected.input + expected.output,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- migrate model lookups from legacy `state.models` to `accountsManager.getFirstAccountModels()`
- remove the unused `cacheModels()` / `state.models` compatibility path
- add regression coverage for `/v1/models`, `findEndpointModel`, `translateToOpenAI`, and provider `count_tokens`

## Test plan
- [x] bun test
- [x] bun run typecheck
- [x] bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 模型列表获取逻辑已调整，确保展示来自账户的可用模型并排除对用户不可见的聊天模型，提升模型选择一致性。
  * 相关路由与翻译流程改为基于新来源选择模型，改善兼容性与行为稳定性。

* **测试**
  * 扩展并更新测试以覆盖账户托管模型的端到端场景，确保令牌计数、思考预算和模型别名解析行为正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->