### PR TITLE
feat: add premium usage statistics page

### DIFF
--- a/admin-ui/bun.lock
+++ b/admin-ui/bun.lock
@@ -23,6 +23,7 @@
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.4",
         "react-router-dom": "^7.11.0",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
       },
@@ -251,6 +252,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.54.0", "", { "os": "android", "cpu": "arm" }, "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng=="],
@@ -297,6 +300,10 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.18", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.18", "@tailwindcss/oxide-darwin-arm64": "4.1.18", "@tailwindcss/oxide-darwin-x64": "4.1.18", "@tailwindcss/oxide-freebsd-x64": "4.1.18", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18", "@tailwindcss/oxide-linux-arm64-musl": "4.1.18", "@tailwindcss/oxide-linux-x64-gnu": "4.1.18", "@tailwindcss/oxide-linux-x64-musl": "4.1.18", "@tailwindcss/oxide-wasm32-wasi": "4.1.18", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18", "@tailwindcss/oxide-win32-x64-msvc": "4.1.18" } }, "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A=="],
@@ -335,6 +342,24 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -344,6 +369,8 @@
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.51.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.51.0", "@typescript-eslint/type-utils": "8.51.0", "@typescript-eslint/utils": "8.51.0", "@typescript-eslint/visitor-keys": "8.51.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.2.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.51.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og=="],
 
@@ -411,7 +438,31 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -422,6 +473,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
+
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -448,6 +501,8 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -491,9 +546,13 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -601,6 +660,10 @@
 
     "react-i18next": ["react-i18next@16.5.4", "", { "dependencies": { "@babel/runtime": "^7.28.4", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 25.6.2", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g=="],
 
+    "react-is": ["react-is@19.2.5", "", {}, "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -612,6 +675,14 @@
     "react-router-dom": ["react-router-dom@7.11.0", "", { "dependencies": { "react-router": "7.11.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -641,6 +712,8 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
@@ -666,6 +739,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@7.3.0", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg=="],
 
@@ -700,6 +775,8 @@
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg=="],
 

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",
     "react-router-dom": "^7.11.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { NotFoundPage } from "@/pages/not-found-page"
 import { RequestDetailPage } from "@/pages/request-detail-page"
 import { RequestsPage } from "@/pages/requests-page"
 import { SettingsPage } from "@/pages/settings-page"
+import { StatisticsPage } from "@/pages/statistics-page"
 
 export default function App(): React.JSX.Element {
   return (
@@ -15,6 +16,7 @@ export default function App(): React.JSX.Element {
         <Route path="/" element={<Navigate to="/accounts" replace />} />
         <Route path="/accounts" element={<AccountsPage />} />
         <Route path="/requests" element={<RequestsPage />} />
+        <Route path="/statistics" element={<StatisticsPage />} />
         <Route path="/models" element={<ModelsPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/request/:requestId" element={<RequestDetailPage />} />

--- a/admin-ui/src/components/app-shell.tsx
+++ b/admin-ui/src/components/app-shell.tsx
@@ -42,6 +42,7 @@ function NavItem({
 const NAV_ITEMS = [
   { to: "/accounts", labelKey: "nav.accounts" },
   { to: "/requests", labelKey: "nav.requests" },
+  { to: "/statistics", labelKey: "nav.statistics" },
   { to: "/models", labelKey: "nav.models" },
   { to: "/settings", labelKey: "nav.settings" },
 ] as const

--- a/admin-ui/src/components/charts/account-usage-chart.tsx
+++ b/admin-ui/src/components/charts/account-usage-chart.tsx
@@ -28,7 +28,7 @@ const CHART_COLORS = [
 
 function formatXLabel(dateStr: string, isHourly: boolean): string {
   if (isHourly) {
-    const match = /T(\d{2})/.exec(dateStr)
+    const match = /(\d{2}):00/.exec(dateStr) ?? /T(\d{2})/.exec(dateStr)
     return match ? `${match[1]}:00` : dateStr
   }
   const match = /(\d{2})-(\d{2})$/.exec(dateStr)

--- a/admin-ui/src/components/charts/account-usage-chart.tsx
+++ b/admin-ui/src/components/charts/account-usage-chart.tsx
@@ -39,7 +39,7 @@ export function AccountUsageChart({
   data,
   isHourly = false,
 }: {
-  data: DailyAccountStatsItem[]
+  data: Array<DailyAccountStatsItem>
   isHourly?: boolean
 }): React.JSX.Element {
   const { t } = useTranslation()
@@ -61,12 +61,18 @@ export function AccountUsageChart({
 
     const ids = [...accountSet]
 
+    // Zero-fill: ensure every date row has a value for every account
     const rows = [...dateMap.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, values]) => ({
-        label: formatXLabel(date, isHourly),
-        ...values,
-      }))
+      .map(([date, values]) => {
+        const row: Record<string, number | string> = {
+          label: formatXLabel(date, isHourly),
+        }
+        for (const id of ids) {
+          row[id] = values[id] ?? 0
+        }
+        return row
+      })
 
     return { pivoted: rows, accountIds: ids }
   }, [data, isHourly])

--- a/admin-ui/src/components/charts/account-usage-chart.tsx
+++ b/admin-ui/src/components/charts/account-usage-chart.tsx
@@ -1,0 +1,125 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Area,
+  AreaChart,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import type { DailyAccountStatsItem } from "@/lib/admin-api"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+const CHART_COLORS = [
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
+]
+
+function formatXLabel(dateStr: string, isHourly: boolean): string {
+  if (isHourly) {
+    const match = /T(\d{2})/.exec(dateStr)
+    return match ? `${match[1]}:00` : dateStr
+  }
+  const match = /(\d{2})-(\d{2})$/.exec(dateStr)
+  return match ? `${match[1]}-${match[2]}` : dateStr
+}
+
+export function AccountUsageChart({
+  data,
+  isHourly = false,
+}: {
+  data: DailyAccountStatsItem[]
+  isHourly?: boolean
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const { pivoted, accountIds } = useMemo(() => {
+    const dateMap = new Map<string, Record<string, number>>()
+    const accountSet = new Set<string>()
+
+    for (const item of data) {
+      accountSet.add(item.account_id)
+
+      let row = dateMap.get(item.date)
+      if (!row) {
+        row = {}
+        dateMap.set(item.date, row)
+      }
+      row[item.account_id] = item.cost_units_sum
+    }
+
+    const ids = [...accountSet]
+
+    const rows = [...dateMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, values]) => ({
+        label: formatXLabel(date, isHourly),
+        ...values,
+      }))
+
+    return { pivoted: rows, accountIds: ids }
+  }, [data, isHourly])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("statistics.accountUsage")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {pivoted.length === 0 ? (
+          <div className="text-muted-foreground flex h-64 items-center justify-center text-sm">
+            {t("statistics.noData")}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <AreaChart data={pivoted} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={50}
+              />
+              <Tooltip
+                contentStyle={{
+                  borderRadius: "0.375rem",
+                  fontSize: "0.75rem",
+                }}
+              />
+              <Legend wrapperStyle={{ fontSize: "0.75rem" }} />
+              {accountIds.map((id, idx) => (
+                <Area
+                  key={id}
+                  type="monotone"
+                  dataKey={id}
+                  name={id}
+                  stackId="1"
+                  fill={CHART_COLORS[idx % CHART_COLORS.length]}
+                  fillOpacity={0.3}
+                  stroke={CHART_COLORS[idx % CHART_COLORS.length]}
+                  strokeWidth={1.5}
+                />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/admin-ui/src/components/charts/premium-usage-chart.tsx
+++ b/admin-ui/src/components/charts/premium-usage-chart.tsx
@@ -1,0 +1,161 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Area,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import type { DailyStatsItem } from "@/lib/admin-api"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+function formatXLabel(dateStr: string, isHourly: boolean): string {
+  if (isHourly) {
+    // dateStr is like "2026-04-13T14:00:00" or similar -- extract HH:00
+    const match = /T(\d{2})/.exec(dateStr)
+    return match ? `${match[1]}:00` : dateStr
+  }
+  // dateStr is like "2026-04-13" -- extract MM-DD
+  const match = /(\d{2})-(\d{2})$/.exec(dateStr)
+  return match ? `${match[1]}-${match[2]}` : dateStr
+}
+
+function CustomTooltipContent({
+  active,
+  payload,
+  label,
+  t,
+}: {
+  active: boolean
+  payload: ReadonlyArray<{ payload?: unknown }>
+  label?: string | number
+  t: (key: string) => string
+}): React.JSX.Element | null {
+  if (!active || payload.length === 0) return null
+
+  const item = payload[0]?.payload as DailyStatsItem | undefined
+  if (!item) return null
+
+  return (
+    <div className="bg-popover text-popover-foreground rounded-md border px-3 py-2 text-xs shadow-md">
+      <div className="mb-1 font-medium">{String(label ?? "")}</div>
+      <div className="space-y-0.5">
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("statistics.costUnits")}</span>
+          <span className="tabular-nums font-medium">{item.cost_units_sum}</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("statistics.requestCount")}</span>
+          <span className="tabular-nums font-medium">{item.request_count}</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("statistics.tokensTotal")}</span>
+          <span className="tabular-nums font-medium">{item.tokens_total}</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("statistics.errorCount")}</span>
+          <span className="tabular-nums font-medium">{item.error_count}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PremiumUsageChart({
+  data,
+  isHourly = false,
+}: {
+  data: DailyStatsItem[]
+  isHourly?: boolean
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const chartData = useMemo(
+    () =>
+      data.map((d) => ({
+        ...d,
+        label: formatXLabel(d.date, isHourly),
+      })),
+    [data, isHourly],
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("statistics.premiumUsage")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 ? (
+          <div className="text-muted-foreground flex h-64 items-center justify-center text-sm">
+            {t("statistics.noData")}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <ComposedChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                yAxisId="cost"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={50}
+              />
+              <YAxis
+                yAxisId="count"
+                orientation="right"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={50}
+              />
+              <Tooltip
+                content={({ active, payload, label }) => (
+                  <CustomTooltipContent
+                    active={active}
+                    payload={payload}
+                    label={label}
+                    t={t}
+                  />
+                )}
+              />
+              <Area
+                yAxisId="cost"
+                type="monotone"
+                dataKey="cost_units_sum"
+                name={t("statistics.costUnits")}
+                fill="var(--color-chart-1)"
+                fillOpacity={0.2}
+                stroke="var(--color-chart-1)"
+                strokeWidth={2}
+              />
+              <Line
+                yAxisId="count"
+                type="monotone"
+                dataKey="request_count"
+                name={t("statistics.requestCount")}
+                stroke="var(--color-chart-2)"
+                strokeWidth={2}
+                strokeDasharray="5 3"
+                dot={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/admin-ui/src/components/charts/premium-usage-chart.tsx
+++ b/admin-ui/src/components/charts/premium-usage-chart.tsx
@@ -87,7 +87,7 @@ export function PremiumUsageChart({
   data,
   isHourly = false,
 }: {
-  data: DailyStatsItem[]
+  data: Array<DailyStatsItem>
   isHourly?: boolean
 }): React.JSX.Element {
   const { t } = useTranslation()

--- a/admin-ui/src/components/charts/premium-usage-chart.tsx
+++ b/admin-ui/src/components/charts/premium-usage-chart.tsx
@@ -20,29 +20,26 @@ import {
 
 function formatXLabel(dateStr: string, isHourly: boolean): string {
   if (isHourly) {
-    // dateStr is like "2026-04-13T14:00:00" or similar -- extract HH:00
-    const match = /T(\d{2})/.exec(dateStr)
+    const match = /(\d{2}):00/.exec(dateStr) ?? /T(\d{2})/.exec(dateStr)
     return match ? `${match[1]}:00` : dateStr
   }
-  // dateStr is like "2026-04-13" -- extract MM-DD
   const match = /(\d{2})-(\d{2})$/.exec(dateStr)
   return match ? `${match[1]}-${match[2]}` : dateStr
 }
 
-function CustomTooltipContent({
-  active,
-  payload,
-  label,
-  t,
-}: {
-  active: boolean
-  payload: ReadonlyArray<{ payload?: unknown }>
-  label?: string | number
-  t: (key: string) => string
-}): React.JSX.Element | null {
-  if (!active || payload.length === 0) return null
+function renderTooltip(
+  t: (key: string) => string,
+  // Recharts v3 Tooltip content props are loosely typed
+  props: Record<string, unknown>,
+): React.JSX.Element | null {
+  const active = props.active as boolean | undefined
+  const payload = props.payload as
+    | ReadonlyArray<{ payload?: DailyStatsItem }>
+    | undefined
+  const label = props.label as string | number | undefined
 
-  const item = payload[0]?.payload as DailyStatsItem | undefined
+  if (!active || !payload?.length) return null
+  const item = payload[0]?.payload
   if (!item) return null
 
   return (
@@ -50,20 +47,36 @@ function CustomTooltipContent({
       <div className="mb-1 font-medium">{String(label ?? "")}</div>
       <div className="space-y-0.5">
         <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">{t("statistics.costUnits")}</span>
-          <span className="tabular-nums font-medium">{item.cost_units_sum}</span>
+          <span className="text-muted-foreground">
+            {t("statistics.costUnits")}
+          </span>
+          <span className="tabular-nums font-medium">
+            {item.cost_units_sum}
+          </span>
         </div>
         <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">{t("statistics.requestCount")}</span>
-          <span className="tabular-nums font-medium">{item.request_count}</span>
+          <span className="text-muted-foreground">
+            {t("statistics.requestCount")}
+          </span>
+          <span className="tabular-nums font-medium">
+            {item.request_count}
+          </span>
         </div>
         <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">{t("statistics.tokensTotal")}</span>
-          <span className="tabular-nums font-medium">{item.tokens_total}</span>
+          <span className="text-muted-foreground">
+            {t("statistics.tokensTotal")}
+          </span>
+          <span className="tabular-nums font-medium">
+            {item.tokens_total}
+          </span>
         </div>
         <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">{t("statistics.errorCount")}</span>
-          <span className="tabular-nums font-medium">{item.error_count}</span>
+          <span className="text-muted-foreground">
+            {t("statistics.errorCount")}
+          </span>
+          <span className="tabular-nums font-medium">
+            {item.error_count}
+          </span>
         </div>
       </div>
     </div>
@@ -123,14 +136,9 @@ export function PremiumUsageChart({
                 width={50}
               />
               <Tooltip
-                content={({ active, payload, label }) => (
-                  <CustomTooltipContent
-                    active={active}
-                    payload={payload}
-                    label={label}
-                    t={t}
-                  />
-                )}
+                content={(props: Record<string, unknown>) =>
+                  renderTooltip(t, props)
+                }
               />
               <Area
                 yAxisId="cost"

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -186,6 +186,24 @@ export type AdminModelsDetailsResponse = {
   items: Array<AdminModelDetailsItem>
 }
 
+export type DailyStatsItem = {
+  date: string
+  request_count: number
+  cost_units_sum: number
+  tokens_total: number
+  error_count: number
+}
+
+export type DailyAccountStatsItem = DailyStatsItem & {
+  account_id: string
+}
+
+export type PremiumStatsResponse = {
+  daily: DailyStatsItem[]
+  by_account: DailyAccountStatsItem[]
+  range: { from: string; to: string; granularity: "day" | "hour" }
+}
+
 export class AdminApiError extends Error {
   readonly status: number
   readonly responseText: string
@@ -330,6 +348,22 @@ export async function getAdminModels(): Promise<AdminModelsResponse> {
 
 export async function getAdminModelDetails(): Promise<AdminModelsDetailsResponse> {
   return fetchAdminJson<AdminModelsDetailsResponse>("/api/admin/models/details")
+}
+
+export async function getAdminPremiumStats(params: {
+  from?: string
+  to?: string
+  accountId?: string
+  granularity?: "day" | "hour"
+}): Promise<PremiumStatsResponse> {
+  const q = new URLSearchParams()
+  if (params.from) q.set("from", params.from)
+  if (params.to) q.set("to", params.to)
+  if (params.accountId) q.set("account_id", params.accountId)
+  if (params.granularity) q.set("granularity", params.granularity)
+  return fetchAdminJson<PremiumStatsResponse>(
+    `/api/admin/stats/premium-daily?${q.toString()}`,
+  )
 }
 
 // --- Account Management Types ---

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -199,8 +199,8 @@ export type DailyAccountStatsItem = DailyStatsItem & {
 }
 
 export type PremiumStatsResponse = {
-  daily: DailyStatsItem[]
-  by_account: DailyAccountStatsItem[]
+  daily: Array<DailyStatsItem>
+  by_account: Array<DailyAccountStatsItem>
   range: { from: string; to: string; granularity: "day" | "hour" }
 }
 

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -10,6 +10,7 @@
   "nav": {
     "accounts": "Accounts",
     "requests": "Requests",
+    "statistics": "Statistics",
     "models": "Models",
     "settings": "Settings",
     "openNavigation": "Open navigation"
@@ -552,5 +553,28 @@
   "notFound": {
     "title": "Not found",
     "description": "The page you are looking for does not exist."
+  },
+  "statistics": {
+    "title": "Statistics",
+    "premiumUsage": "Premium Usage Trend",
+    "accountUsage": "Per-Account Premium Usage",
+    "costUnits": "Cost Units",
+    "requestCount": "Request Count",
+    "tokensTotal": "Total Tokens",
+    "errorCount": "Errors",
+    "timeRange": {
+      "24h": "24h",
+      "7d": "7 Days",
+      "month": "This Month",
+      "custom": "Custom"
+    },
+    "autoRefresh": {
+      "off": "Auto-refresh: Off",
+      "30s": "Every 30s",
+      "60s": "Every 60s",
+      "5m": "Every 5m"
+    },
+    "noData": "No premium request data for this period",
+    "loadFailed": "Failed to load statistics"
   }
 }

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -10,6 +10,7 @@
   "nav": {
     "accounts": "账号",
     "requests": "请求",
+    "statistics": "统计",
     "models": "模型",
     "settings": "设置",
     "openNavigation": "打开导航"
@@ -552,5 +553,28 @@
   "notFound": {
     "title": "未找到页面",
     "description": "你访问的页面不存在。"
+  },
+  "statistics": {
+    "title": "统计",
+    "premiumUsage": "高级请求用量趋势",
+    "accountUsage": "各账号高级请求消耗",
+    "costUnits": "成本单位",
+    "requestCount": "请求次数",
+    "tokensTotal": "总 Token 数",
+    "errorCount": "错误数",
+    "timeRange": {
+      "24h": "24 小时",
+      "7d": "7 天",
+      "month": "本月",
+      "custom": "自定义"
+    },
+    "autoRefresh": {
+      "off": "自动刷新：关",
+      "30s": "每 30 秒",
+      "60s": "每 60 秒",
+      "5m": "每 5 分钟"
+    },
+    "noData": "该时间段无高级请求数据",
+    "loadFailed": "加载统计数据失败"
   }
 }

--- a/admin-ui/src/pages/statistics-page.tsx
+++ b/admin-ui/src/pages/statistics-page.tsx
@@ -68,8 +68,8 @@ export function StatisticsPage(): React.JSX.Element {
   const [autoRefreshMs, setAutoRefreshMs] = useState(0)
 
   const [loading, setLoading] = useState(false)
-  const [daily, setDaily] = useState<DailyStatsItem[]>([])
-  const [byAccount, setByAccount] = useState<DailyAccountStatsItem[]>([])
+  const [daily, setDaily] = useState<Array<DailyStatsItem>>([])
+  const [byAccount, setByAccount] = useState<Array<DailyAccountStatsItem>>([])
   const [isHourly, setIsHourly] = useState(false)
 
   const loadInFlightRef = useRef(false)

--- a/admin-ui/src/pages/statistics-page.tsx
+++ b/admin-ui/src/pages/statistics-page.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+
+import {
+  AdminApiError,
+  type DailyAccountStatsItem,
+  type DailyStatsItem,
+  getAdminPremiumStats,
+} from "@/lib/admin-api"
+import { i18n } from "@/lib/i18n"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { PremiumUsageChart } from "@/components/charts/premium-usage-chart"
+import { AccountUsageChart } from "@/components/charts/account-usage-chart"
+
+type TimePreset = "24h" | "7d" | "month" | "custom"
+
+function toDateString(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, "0")
+  const d = String(date.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
+}
+
+function presetToRange(preset: TimePreset, customFrom: string, customTo: string): {
+  from: string
+  to: string
+  granularity: "day" | "hour"
+} {
+  const now = new Date()
+  const today = toDateString(now)
+
+  if (preset === "24h") {
+    const yesterday = new Date(now.getTime() - 86_400_000)
+    return { from: toDateString(yesterday), to: today, granularity: "hour" }
+  }
+
+  if (preset === "7d") {
+    const weekAgo = new Date(now.getTime() - 7 * 86_400_000)
+    return { from: toDateString(weekAgo), to: today, granularity: "day" }
+  }
+
+  if (preset === "month") {
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    return { from: toDateString(startOfMonth), to: today, granularity: "day" }
+  }
+
+  // custom
+  return {
+    from: customFrom || today,
+    to: customTo || today,
+    granularity: "day",
+  }
+}
+
+export function StatisticsPage(): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const [preset, setPreset] = useState<TimePreset>("7d")
+  const [customFrom, setCustomFrom] = useState("")
+  const [customTo, setCustomTo] = useState("")
+  const [autoRefreshMs, setAutoRefreshMs] = useState(0)
+
+  const [loading, setLoading] = useState(false)
+  const [daily, setDaily] = useState<DailyStatsItem[]>([])
+  const [byAccount, setByAccount] = useState<DailyAccountStatsItem[]>([])
+  const [isHourly, setIsHourly] = useState(false)
+
+  const loadInFlightRef = useRef(false)
+  const autoRefreshRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (loadInFlightRef.current) return
+    loadInFlightRef.current = true
+    setLoading(true)
+
+    try {
+      const range = presetToRange(preset, customFrom, customTo)
+      const res = await getAdminPremiumStats({
+        from: range.from,
+        to: range.to,
+        granularity: range.granularity,
+      })
+      setDaily(res.daily)
+      setByAccount(res.by_account)
+      setIsHourly(range.granularity === "hour")
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      toast.error(i18n.t("statistics.loadFailed"), { description: msg })
+    } finally {
+      loadInFlightRef.current = false
+      setLoading(false)
+    }
+  }, [preset, customFrom, customTo])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Auto-refresh with recursive setTimeout
+  useEffect(() => {
+    let disposed = false
+
+    if (autoRefreshRef.current) {
+      clearTimeout(autoRefreshRef.current)
+      autoRefreshRef.current = null
+    }
+
+    if (autoRefreshMs > 0) {
+      const scheduleNext = () => {
+        if (disposed) return
+        autoRefreshRef.current = setTimeout(async () => {
+          if (loadInFlightRef.current) {
+            scheduleNext()
+            return
+          }
+          try {
+            await refresh()
+          } finally {
+            scheduleNext()
+          }
+        }, autoRefreshMs)
+      }
+
+      scheduleNext()
+    }
+
+    return () => {
+      disposed = true
+      if (autoRefreshRef.current) {
+        clearTimeout(autoRefreshRef.current)
+        autoRefreshRef.current = null
+      }
+    }
+  }, [autoRefreshMs, refresh])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-xl font-semibold">{t("statistics.title")}</h1>
+
+        <div className="flex items-center gap-2">
+          <Select value={preset} onValueChange={(v) => setPreset(v as TimePreset)}>
+            <SelectTrigger size="sm" className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="24h">{t("statistics.timeRange.24h")}</SelectItem>
+              <SelectItem value="7d">{t("statistics.timeRange.7d")}</SelectItem>
+              <SelectItem value="month">{t("statistics.timeRange.month")}</SelectItem>
+              <SelectItem value="custom">{t("statistics.timeRange.custom")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {preset === "custom" && (
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              value={customFrom}
+              onChange={(e) => setCustomFrom(e.target.value)}
+              className="border-input bg-background text-foreground h-8 rounded-md border px-2 text-sm"
+            />
+            <span className="text-muted-foreground text-sm">-</span>
+            <input
+              type="date"
+              value={customTo}
+              onChange={(e) => setCustomTo(e.target.value)}
+              className="border-input bg-background text-foreground h-8 rounded-md border px-2 text-sm"
+            />
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          {autoRefreshMs > 0 && (
+            <span className="relative flex h-2 w-2">
+              <span className="bg-primary absolute inline-flex h-full w-full rounded-full opacity-75 motion-safe:animate-ping" />
+              <span className="bg-primary relative inline-flex h-2 w-2 rounded-full" />
+            </span>
+          )}
+          <Select value={String(autoRefreshMs)} onValueChange={(v) => setAutoRefreshMs(Number(v))}>
+            <SelectTrigger size="sm" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="0">{t("statistics.autoRefresh.off")}</SelectItem>
+              <SelectItem value="30000">{t("statistics.autoRefresh.30s")}</SelectItem>
+              <SelectItem value="60000">{t("statistics.autoRefresh.60s")}</SelectItem>
+              <SelectItem value="300000">{t("statistics.autoRefresh.5m")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {loading && daily.length === 0 ? (
+        <div className="space-y-6">
+          <div className="bg-muted h-[380px] animate-pulse rounded-xl" />
+          <div className="bg-muted h-[380px] animate-pulse rounded-xl" />
+        </div>
+      ) : (
+        <>
+          <PremiumUsageChart data={daily} isHourly={isHourly} />
+          <AccountUsageChart data={byAccount} isHourly={isHourly} />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -148,6 +148,60 @@ function migrateV1(db: Database): void {
   `)
 }
 
+function migrateV9(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS daily_premium_stats (
+      date            TEXT    NOT NULL,
+      account_id      TEXT    NOT NULL,
+      request_count   INTEGER NOT NULL DEFAULT 0,
+      cost_units_sum  REAL    NOT NULL DEFAULT 0,
+      tokens_total    INTEGER NOT NULL DEFAULT 0,
+      error_count     INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms   INTEGER NOT NULL,
+      PRIMARY KEY (date, account_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_daily_premium_stats_date
+      ON daily_premium_stats(date);
+  `)
+
+  // Backfill from existing request_log (guard: table may not exist in edge cases)
+  const hasRequestLog = db
+    .query(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'request_log' LIMIT 1;",
+    )
+    .get()
+
+  if (hasRequestLog) {
+    const nowMs = Date.now()
+    db.run(
+      `INSERT INTO daily_premium_stats
+         (date, account_id, request_count, cost_units_sum, tokens_total, error_count, updated_at_ms)
+       SELECT
+         date(started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
+         account_id,
+         COUNT(*)                                              AS request_count,
+         SUM(cost_units)                                       AS cost_units_sum,
+         COALESCE(SUM(tokens_total), 0)                        AS tokens_total,
+         SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END) AS error_count,
+         ?                                                     AS updated_at_ms
+       FROM request_log
+       WHERE cost_units > 0
+         AND account_id IS NOT NULL
+       GROUP BY 1, 2
+       ON CONFLICT(date, account_id) DO UPDATE SET
+         request_count   = excluded.request_count,
+         cost_units_sum  = excluded.cost_units_sum,
+         tokens_total    = excluded.tokens_total,
+         error_count     = excluded.error_count,
+         updated_at_ms   = excluded.updated_at_ms;`,
+      [nowMs],
+    )
+  }
+
+  db.run("PRAGMA user_version = 9;")
+}
+
 function migrateV8(db: Database): void {
   db.run(`
     CREATE TABLE IF NOT EXISTS session_affinity (
@@ -174,7 +228,7 @@ function migrateAdminDb(db: Database): void {
   } | null
   const current = row?.user_version ?? 0
 
-  if (current >= 8) {
+  if (current >= 9) {
     return
   }
 
@@ -271,4 +325,5 @@ function migrateAdminDb(db: Database): void {
   }
 
   migrateV8(db)
+  migrateV9(db)
 }

--- a/src/lib/request-history.test.ts
+++ b/src/lib/request-history.test.ts
@@ -263,7 +263,7 @@ describe("RequestHistoryStore", () => {
     expect(columns).toContain("selection_reason")
     expect(columns).toContain("upstream_error_message_raw")
 
-    expect(db.query("PRAGMA user_version;").get()).toEqual({ user_version: 8 })
+    expect(db.query("PRAGMA user_version;").get()).toEqual({ user_version: 9 })
   })
 
   test("query orders by id DESC and supports cursor paging", () => {

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -464,9 +464,9 @@ export class RequestHistoryStore {
 
       // Write-time aggregation for premium stats
       if (
-        record.costUnits != null &&
-        record.costUnits > 0 &&
-        record.accountId
+        record.costUnits !== undefined
+        && record.costUnits > 0
+        && record.accountId
       ) {
         try {
           getStatsStoreInstance()?.upsertDailyStats({
@@ -474,7 +474,7 @@ export class RequestHistoryStore {
             accountId: record.accountId,
             costUnits: record.costUnits,
             tokensTotal: record.tokensTotal ?? 0,
-            hasError: record.errorName != null,
+            hasError: record.errorName !== undefined,
           })
         } catch {
           // Stats aggregation is best-effort; never break request logging

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -18,6 +18,7 @@ import type { AccountSelectionReason } from "./accounts-manager"
 import type { AffinityKeySource } from "./utils"
 
 import { getAdminDb, getAdminDbPath, getAdminDbUserVersion } from "./admin-db"
+import { StatsStore } from "./stats-store"
 
 const DEFAULT_RETENTION_DAYS = 14
 const DEFAULT_MAX_ROWS = 200_000
@@ -460,6 +461,25 @@ export class RequestHistoryStore {
       ] as const
 
       this.insertStmt.run(...args)
+
+      // Write-time aggregation for premium stats
+      if (
+        record.costUnits != null &&
+        record.costUnits > 0 &&
+        record.accountId
+      ) {
+        try {
+          getStatsStoreInstance()?.upsertDailyStats({
+            startedAtMs: record.startedAtMs,
+            accountId: record.accountId,
+            costUnits: record.costUnits,
+            tokensTotal: record.tokensTotal ?? 0,
+            hasError: record.errorName != null,
+          })
+        } catch {
+          // Stats aggregation is best-effort; never break request logging
+        }
+      }
     } catch (error) {
       warnInsertFailure(error)
     }
@@ -750,6 +770,18 @@ const disabledStore: RequestHistoryStoreApi = {
 let sharedStore: RequestHistoryStoreApi | null = null
 let maintenanceStarted = false
 
+let sharedStatsStore: StatsStore | null = null
+
+function getStatsStoreInstance(): StatsStore | null {
+  if (sharedStatsStore) return sharedStatsStore
+  try {
+    sharedStatsStore = new StatsStore(getAdminDb())
+    return sharedStatsStore
+  } catch {
+    return null
+  }
+}
+
 export function getRequestHistoryStore(): RequestHistoryStoreApi {
   if (sharedStore) {
     return sharedStore
@@ -768,11 +800,17 @@ export function getRequestHistoryStore(): RequestHistoryStoreApi {
 
       // Run once at startup.
       sharedStore.cleanupRetention()
+      getStatsStoreInstance()?.cleanupStatsRetention()
 
       // Then daily.
       setInterval(
         () => {
           sharedStore?.cleanupRetention()
+          try {
+            getStatsStoreInstance()?.cleanupStatsRetention()
+          } catch {
+            // Stats cleanup is best-effort
+          }
         },
         24 * 60 * 60 * 1000,
       )
@@ -807,4 +845,8 @@ export function extractResponsesUsageFromResult(
   result: ResponsesResult,
 ): NormalizedUsage {
   return normalizeResponsesUsage(result.usage)
+}
+
+export function getStatsStore(): StatsStore | null {
+  return getStatsStoreInstance()
 }

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -1,0 +1,165 @@
+import type { Database } from "bun:sqlite"
+
+import { consola } from "consola"
+
+export interface DailyStats {
+  date: string
+  request_count: number
+  cost_units_sum: number
+  tokens_total: number
+  error_count: number
+}
+
+export interface DailyAccountStats extends DailyStats {
+  account_id: string
+}
+
+export interface PremiumStatsResponse {
+  daily: DailyStats[]
+  by_account: DailyAccountStats[]
+  range: { from: string; to: string; granularity: "day" | "hour" }
+}
+
+export const DEFAULT_STATS_RETENTION_DAYS = 180
+
+export function toLocalDateString(ms: number): string {
+  const d = new Date(ms)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+export class StatsStore {
+  private readonly db: Database
+  private readonly upsertStmt: ReturnType<Database["query"]>
+
+  constructor(db: Database) {
+    this.db = db
+    this.upsertStmt = db.query(`
+      INSERT INTO daily_premium_stats
+        (date, account_id, request_count, cost_units_sum, tokens_total, error_count, updated_at_ms)
+      VALUES (?, ?, 1, ?, ?, ?, ?)
+      ON CONFLICT(date, account_id) DO UPDATE SET
+        request_count   = request_count  + 1,
+        cost_units_sum  = cost_units_sum + excluded.cost_units_sum,
+        tokens_total    = tokens_total   + excluded.tokens_total,
+        error_count     = error_count    + excluded.error_count,
+        updated_at_ms   = excluded.updated_at_ms
+    `)
+  }
+
+  upsertDailyStats(record: {
+    startedAtMs: number
+    accountId: string
+    costUnits: number
+    tokensTotal: number
+    hasError: boolean
+  }): void {
+    const date = toLocalDateString(record.startedAtMs)
+    this.upsertStmt.run(
+      date,
+      record.accountId,
+      record.costUnits,
+      record.tokensTotal ?? 0,
+      record.hasError ? 1 : 0,
+      Date.now(),
+    )
+  }
+
+  getDailyPremiumStats(params: {
+    from: string
+    to: string
+    accountId?: string
+  }): { daily: DailyStats[]; byAccount: DailyAccountStats[] } {
+    const accountFilter = params.accountId ? " AND account_id = ?" : ""
+    const args: (string | number)[] = [params.from, params.to]
+    if (params.accountId) args.push(params.accountId)
+
+    const daily = this.db
+      .query(
+        `SELECT date,
+                SUM(request_count)  AS request_count,
+                SUM(cost_units_sum) AS cost_units_sum,
+                SUM(tokens_total)   AS tokens_total,
+                SUM(error_count)    AS error_count
+         FROM daily_premium_stats
+         WHERE date >= ? AND date <= ?${accountFilter}
+         GROUP BY date
+         ORDER BY date`,
+      )
+      .all(...args) as DailyStats[]
+
+    const byAccount = this.db
+      .query(
+        `SELECT date, account_id, request_count, cost_units_sum, tokens_total, error_count
+         FROM daily_premium_stats
+         WHERE date >= ? AND date <= ?${accountFilter}
+         ORDER BY date, account_id`,
+      )
+      .all(...args) as DailyAccountStats[]
+
+    return { daily, byAccount }
+  }
+
+  getHourlyPremiumStats(params: {
+    fromMs: number
+    toMs: number
+    accountId?: string
+  }): { daily: DailyStats[]; byAccount: DailyAccountStats[] } {
+    const accountFilter = params.accountId ? " AND account_id = ?" : ""
+    const dailyArgs: (string | number)[] = [params.fromMs, params.toMs]
+    if (params.accountId) dailyArgs.push(params.accountId)
+
+    const daily = this.db
+      .query(
+        `SELECT strftime('%Y-%m-%d %H:00', started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
+                COUNT(*)                                                   AS request_count,
+                SUM(cost_units)                                            AS cost_units_sum,
+                COALESCE(SUM(tokens_total), 0)                             AS tokens_total,
+                SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END)    AS error_count
+         FROM request_log
+         WHERE cost_units > 0
+           AND started_at_ms >= ? AND started_at_ms <= ?${accountFilter}
+         GROUP BY 1
+         ORDER BY 1`,
+      )
+      .all(...dailyArgs) as DailyStats[]
+
+    const byAccountFilter = params.accountId
+      ? " AND account_id = ?"
+      : " AND account_id IS NOT NULL"
+    const byAccountArgs: (string | number)[] = [params.fromMs, params.toMs]
+    if (params.accountId) byAccountArgs.push(params.accountId)
+
+    const byAccount = this.db
+      .query(
+        `SELECT strftime('%Y-%m-%d %H:00', started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
+                account_id,
+                COUNT(*)                                                   AS request_count,
+                SUM(cost_units)                                            AS cost_units_sum,
+                COALESCE(SUM(tokens_total), 0)                             AS tokens_total,
+                SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END)    AS error_count
+         FROM request_log
+         WHERE cost_units > 0${byAccountFilter}
+           AND started_at_ms >= ? AND started_at_ms <= ?
+         GROUP BY 1, 2
+         ORDER BY 1, 2`,
+      )
+      .all(...byAccountArgs) as DailyAccountStats[]
+
+    return { daily, byAccount }
+  }
+
+  cleanupStatsRetention(
+    retentionDays: number = DEFAULT_STATS_RETENTION_DAYS,
+  ): void {
+    try {
+      const cutoffDate = toLocalDateString(
+        Date.now() - retentionDays * 24 * 60 * 60 * 1000,
+      )
+      this.db
+        .query("DELETE FROM daily_premium_stats WHERE date < ?;")
+        .run(cutoffDate)
+    } catch (error) {
+      consola.debug("Failed to cleanup daily_premium_stats retention", error)
+    }
+  }
+}

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -15,8 +15,8 @@ export interface DailyAccountStats extends DailyStats {
 }
 
 export interface PremiumStatsResponse {
-  daily: DailyStats[]
-  by_account: DailyAccountStats[]
+  daily: Array<DailyStats>
+  by_account: Array<DailyAccountStats>
   range: { from: string; to: string; granularity: "day" | "hour" }
 }
 
@@ -58,7 +58,7 @@ export class StatsStore {
       date,
       record.accountId,
       record.costUnits,
-      record.tokensTotal ?? 0,
+      record.tokensTotal,
       record.hasError ? 1 : 0,
       Date.now(),
     )
@@ -68,9 +68,9 @@ export class StatsStore {
     from: string
     to: string
     accountId?: string
-  }): { daily: DailyStats[]; byAccount: DailyAccountStats[] } {
+  }): { daily: Array<DailyStats>; byAccount: Array<DailyAccountStats> } {
     const accountFilter = params.accountId ? " AND account_id = ?" : ""
-    const args: (string | number)[] = [params.from, params.to]
+    const args: Array<string | number> = [params.from, params.to]
     if (params.accountId) args.push(params.accountId)
 
     const daily = this.db
@@ -85,7 +85,7 @@ export class StatsStore {
          GROUP BY date
          ORDER BY date`,
       )
-      .all(...args) as DailyStats[]
+      .all(...args) as Array<DailyStats>
 
     const byAccount = this.db
       .query(
@@ -94,7 +94,7 @@ export class StatsStore {
          WHERE date >= ? AND date <= ?${accountFilter}
          ORDER BY date, account_id`,
       )
-      .all(...args) as DailyAccountStats[]
+      .all(...args) as Array<DailyAccountStats>
 
     return { daily, byAccount }
   }
@@ -103,9 +103,9 @@ export class StatsStore {
     fromMs: number
     toMs: number
     accountId?: string
-  }): { daily: DailyStats[]; byAccount: DailyAccountStats[] } {
+  }): { daily: Array<DailyStats>; byAccount: Array<DailyAccountStats> } {
     const accountFilter = params.accountId ? " AND account_id = ?" : ""
-    const dailyArgs: (string | number)[] = [params.fromMs, params.toMs]
+    const dailyArgs: Array<string | number> = [params.fromMs, params.toMs]
     if (params.accountId) dailyArgs.push(params.accountId)
 
     const daily = this.db
@@ -121,12 +121,11 @@ export class StatsStore {
          GROUP BY 1
          ORDER BY 1`,
       )
-      .all(...dailyArgs) as DailyStats[]
+      .all(...dailyArgs) as Array<DailyStats>
 
-    const byAccountFilter = params.accountId
-      ? " AND account_id = ?"
-      : " AND account_id IS NOT NULL"
-    const byAccountArgs: (string | number)[] = [params.fromMs, params.toMs]
+    const byAccountFilter =
+      params.accountId ? " AND account_id = ?" : " AND account_id IS NOT NULL"
+    const byAccountArgs: Array<string | number> = [params.fromMs, params.toMs]
     if (params.accountId) byAccountArgs.push(params.accountId)
 
     const byAccount = this.db
@@ -138,12 +137,12 @@ export class StatsStore {
                 COALESCE(SUM(tokens_total), 0)                             AS tokens_total,
                 SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END)    AS error_count
          FROM request_log
-         WHERE cost_units > 0${byAccountFilter}
-           AND started_at_ms >= ? AND started_at_ms <= ?
+         WHERE cost_units > 0
+           AND started_at_ms >= ? AND started_at_ms <= ?${byAccountFilter}
          GROUP BY 1, 2
          ORDER BY 1, 2`,
       )
-      .all(...byAccountArgs) as DailyAccountStats[]
+      .all(...byAccountArgs) as Array<DailyAccountStats>
 
     return { daily, byAccount }
   }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -36,6 +36,7 @@ import {
   type AccountStatsRow,
 } from "~/lib/request-history"
 import { applySharedSessionAffinityRetention } from "~/lib/session-affinity-store"
+import { toLocalDateString } from "~/lib/stats-store"
 import { isAccountType } from "~/lib/types/account"
 
 import { authSessionManager } from "./auth-sessions"
@@ -1664,20 +1665,22 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
   const granularity = p.get("granularity") === "hour" ? "hour" : "day"
 
   const now = new Date()
-  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`
+  const todayStr = toLocalDateString(now.getTime())
 
   const resolvedFrom =
-    from
-    || (() => {
-      const d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
-      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
-    })()
+    from || toLocalDateString(now.getTime() - 7 * 24 * 60 * 60 * 1000)
   const resolvedTo = to || todayStr
+
+  // Parse YYYY-MM-DD as local time (not UTC)
+  function parseLocalDate(dateStr: string): Date {
+    const [y, m, d] = dateStr.split("-").map(Number)
+    return new Date(y, m - 1, d)
+  }
 
   // Validate granularity=hour range <= 48h
   if (granularity === "hour") {
-    const fromDate = new Date(resolvedFrom)
-    const toDate = new Date(resolvedTo)
+    const fromDate = parseLocalDate(resolvedFrom)
+    const toDate = parseLocalDate(resolvedTo)
     const diffMs = toDate.getTime() - fromDate.getTime() + 24 * 60 * 60 * 1000
     if (diffMs > 48 * 60 * 60 * 1000) {
       return jsonError(c, 400, {
@@ -1698,8 +1701,8 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
   }
 
   if (granularity === "hour") {
-    const fromMs = new Date(resolvedFrom).getTime()
-    const toMs = new Date(resolvedTo + "T23:59:59.999").getTime()
+    const fromMs = parseLocalDate(resolvedFrom).getTime()
+    const toMs = parseLocalDate(resolvedTo).getTime() + 86_399_999
     const result = statsStore.getHourlyPremiumStats({
       fromMs,
       toMs,

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -32,6 +32,7 @@ import {
 import { PATHS } from "~/lib/paths"
 import {
   getRequestHistoryStore,
+  getStatsStore,
   type AccountStatsRow,
 } from "~/lib/request-history"
 import { applySharedSessionAffinityRetention } from "~/lib/session-affinity-store"
@@ -1651,4 +1652,74 @@ adminApiRoutes.post("/accounts/:id/reauth", async (c) => {
       type: "internal_error",
     })
   }
+})
+
+adminApiRoutes.get("/stats/premium-daily", (c) => {
+  const url = new URL(c.req.url, "http://local")
+  const p = url.searchParams
+
+  const from = p.get("from") || undefined
+  const to = p.get("to") || undefined
+  const accountId = p.get("account_id") || undefined
+  const granularity = p.get("granularity") === "hour" ? "hour" : "day"
+
+  const now = new Date()
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`
+
+  const resolvedFrom =
+    from ||
+    (() => {
+      const d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+    })()
+  const resolvedTo = to || todayStr
+
+  // Validate granularity=hour range <= 48h
+  if (granularity === "hour") {
+    const fromDate = new Date(resolvedFrom)
+    const toDate = new Date(resolvedTo)
+    const diffMs = toDate.getTime() - fromDate.getTime() + 24 * 60 * 60 * 1000
+    if (diffMs > 48 * 60 * 60 * 1000) {
+      return jsonError(c, 400, {
+        message:
+          "Hourly granularity is only supported for ranges up to 48 hours.",
+        type: "bad_request",
+      })
+    }
+  }
+
+  const statsStore = getStatsStore()
+  if (!statsStore) {
+    return c.json({
+      daily: [],
+      by_account: [],
+      range: { from: resolvedFrom, to: resolvedTo, granularity },
+    })
+  }
+
+  if (granularity === "hour") {
+    const fromMs = new Date(resolvedFrom).getTime()
+    const toMs = new Date(resolvedTo + "T23:59:59.999").getTime()
+    const result = statsStore.getHourlyPremiumStats({
+      fromMs,
+      toMs,
+      accountId,
+    })
+    return c.json({
+      daily: result.daily,
+      by_account: result.byAccount,
+      range: { from: resolvedFrom, to: resolvedTo, granularity },
+    })
+  }
+
+  const result = statsStore.getDailyPremiumStats({
+    from: resolvedFrom,
+    to: resolvedTo,
+    accountId,
+  })
+  return c.json({
+    daily: result.daily,
+    by_account: result.byAccount,
+    range: { from: resolvedFrom, to: resolvedTo, granularity },
+  })
 })

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1667,8 +1667,8 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
   const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`
 
   const resolvedFrom =
-    from ||
-    (() => {
+    from
+    || (() => {
       const d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
       return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
     })()

--- a/tests/session-affinity-store.test.ts
+++ b/tests/session-affinity-store.test.ts
@@ -4,11 +4,11 @@ import { expect, test } from "bun:test"
 import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
 import { SessionAffinityStore } from "../src/lib/session-affinity-store"
 
-test("initAdminDb migrates admin DB to user_version 8", () => {
+test("initAdminDb migrates admin DB to user_version 9", () => {
   const db = new Database(":memory:")
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(8)
+  expect(getAdminDbUserVersion(db)).toBe(9)
 })
 
 test("initAdminDb upgrades an existing v7 DB to v8 and creates session_affinity", () => {
@@ -32,7 +32,7 @@ test("initAdminDb upgrades an existing v7 DB to v8 and creates session_affinity"
     )
     .get() as { name?: string } | null
 
-  expect(getAdminDbUserVersion(db)).toBe(8)
+  expect(getAdminDbUserVersion(db)).toBe(9)
   expect(after?.name).toBe("session_affinity")
 })
 

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -1,0 +1,384 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+
+import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
+import {
+  StatsStore,
+  toLocalDateString,
+} from "../src/lib/stats-store"
+
+test("initAdminDb migrates admin DB to user_version 9", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  expect(getAdminDbUserVersion(db)).toBe(9)
+})
+
+test("daily_premium_stats table has the expected columns", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  const columns = db
+    .query("PRAGMA table_info(daily_premium_stats);")
+    .all() as Array<{ name: string }>
+
+  expect(columns.map((c) => c.name)).toEqual([
+    "date",
+    "account_id",
+    "request_count",
+    "cost_units_sum",
+    "tokens_total",
+    "error_count",
+    "updated_at_ms",
+  ])
+})
+
+test("v9 migration backfills from existing request_log data", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  // Reset to v8 and drop the stats table so we can test the backfill
+  db.run("PRAGMA user_version = 8;")
+  db.run("DROP TABLE IF EXISTS daily_premium_stats;")
+
+  // Insert test data into request_log
+  const baseMs = new Date("2026-04-10T12:00:00").getTime()
+  db.run(
+    `INSERT INTO request_log
+       (request_id, started_at_ms, method, path, account_id, cost_units, tokens_total, error_name)
+     VALUES
+       ('req-1', ?, 'POST', '/v1/messages', 'acct-a', 10.0, 1000, NULL),
+       ('req-2', ?, 'POST', '/v1/messages', 'acct-a', 5.0,  500,  'RateLimit'),
+       ('req-3', ?, 'POST', '/v1/messages', 'acct-b', 8.0,  800,  NULL)`,
+    [baseMs, baseMs + 1000, baseMs + 2000],
+  )
+
+  // Re-run migration (should trigger v9 since user_version is 8)
+  initAdminDb(db)
+
+  expect(getAdminDbUserVersion(db)).toBe(9)
+
+  const rows = db
+    .query(
+      "SELECT date, account_id, request_count, cost_units_sum, tokens_total, error_count FROM daily_premium_stats ORDER BY account_id",
+    )
+    .all() as Array<{
+    date: string
+    account_id: string
+    request_count: number
+    cost_units_sum: number
+    tokens_total: number
+    error_count: number
+  }>
+
+  expect(rows.length).toBe(2)
+
+  const acctA = rows.find((r) => r.account_id === "acct-a")!
+  expect(acctA.request_count).toBe(2)
+  expect(acctA.cost_units_sum).toBe(15.0)
+  expect(acctA.tokens_total).toBe(1500)
+  expect(acctA.error_count).toBe(1)
+
+  const acctB = rows.find((r) => r.account_id === "acct-b")!
+  expect(acctB.request_count).toBe(1)
+  expect(acctB.cost_units_sum).toBe(8.0)
+  expect(acctB.tokens_total).toBe(800)
+  expect(acctB.error_count).toBe(0)
+})
+
+test("upsertDailyStats creates new rows", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const startedAtMs = new Date("2026-04-10T14:30:00").getTime()
+  store.upsertDailyStats({
+    startedAtMs,
+    accountId: "acct-a",
+    costUnits: 10.0,
+    tokensTotal: 1000,
+    hasError: false,
+  })
+
+  const rows = db
+    .query("SELECT * FROM daily_premium_stats")
+    .all() as Array<{
+    date: string
+    account_id: string
+    request_count: number
+    cost_units_sum: number
+    tokens_total: number
+    error_count: number
+  }>
+
+  expect(rows.length).toBe(1)
+  expect(rows[0].date).toBe(toLocalDateString(startedAtMs))
+  expect(rows[0].account_id).toBe("acct-a")
+  expect(rows[0].request_count).toBe(1)
+  expect(rows[0].cost_units_sum).toBe(10.0)
+  expect(rows[0].tokens_total).toBe(1000)
+  expect(rows[0].error_count).toBe(0)
+})
+
+test("upsertDailyStats accumulates on same date+account", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const startedAtMs = new Date("2026-04-10T10:00:00").getTime()
+
+  store.upsertDailyStats({
+    startedAtMs,
+    accountId: "acct-a",
+    costUnits: 10.0,
+    tokensTotal: 1000,
+    hasError: false,
+  })
+
+  store.upsertDailyStats({
+    startedAtMs: startedAtMs + 3600_000, // 1 hour later, same day
+    accountId: "acct-a",
+    costUnits: 5.0,
+    tokensTotal: 500,
+    hasError: true,
+  })
+
+  const rows = db
+    .query("SELECT * FROM daily_premium_stats")
+    .all() as Array<{
+    request_count: number
+    cost_units_sum: number
+    tokens_total: number
+    error_count: number
+  }>
+
+  expect(rows.length).toBe(1)
+  expect(rows[0].request_count).toBe(2)
+  expect(rows[0].cost_units_sum).toBe(15.0)
+  expect(rows[0].tokens_total).toBe(1500)
+  expect(rows[0].error_count).toBe(1)
+})
+
+test("upsertDailyStats creates separate rows for different accounts", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const startedAtMs = new Date("2026-04-10T10:00:00").getTime()
+
+  store.upsertDailyStats({
+    startedAtMs,
+    accountId: "acct-a",
+    costUnits: 10.0,
+    tokensTotal: 1000,
+    hasError: false,
+  })
+
+  store.upsertDailyStats({
+    startedAtMs,
+    accountId: "acct-b",
+    costUnits: 8.0,
+    tokensTotal: 800,
+    hasError: false,
+  })
+
+  const rows = db
+    .query(
+      "SELECT account_id FROM daily_premium_stats ORDER BY account_id",
+    )
+    .all() as Array<{ account_id: string }>
+
+  expect(rows.length).toBe(2)
+  expect(rows[0].account_id).toBe("acct-a")
+  expect(rows[1].account_id).toBe("acct-b")
+})
+
+test("getDailyPremiumStats returns aggregated daily totals", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const day1 = new Date("2026-04-10T10:00:00").getTime()
+  const day2 = new Date("2026-04-11T10:00:00").getTime()
+
+  store.upsertDailyStats({
+    startedAtMs: day1,
+    accountId: "acct-a",
+    costUnits: 10.0,
+    tokensTotal: 1000,
+    hasError: false,
+  })
+  store.upsertDailyStats({
+    startedAtMs: day1,
+    accountId: "acct-b",
+    costUnits: 5.0,
+    tokensTotal: 500,
+    hasError: true,
+  })
+  store.upsertDailyStats({
+    startedAtMs: day2,
+    accountId: "acct-a",
+    costUnits: 8.0,
+    tokensTotal: 800,
+    hasError: false,
+  })
+
+  const result = store.getDailyPremiumStats({
+    from: "2026-04-10",
+    to: "2026-04-11",
+  })
+
+  expect(result.daily.length).toBe(2)
+  expect(result.daily[0].date).toBe("2026-04-10")
+  expect(result.daily[0].request_count).toBe(2)
+  expect(result.daily[0].cost_units_sum).toBe(15.0)
+  expect(result.daily[0].tokens_total).toBe(1500)
+  expect(result.daily[0].error_count).toBe(1)
+
+  expect(result.daily[1].date).toBe("2026-04-11")
+  expect(result.daily[1].request_count).toBe(1)
+
+  expect(result.byAccount.length).toBe(3)
+})
+
+test("getDailyPremiumStats filters by account_id", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const day1 = new Date("2026-04-10T10:00:00").getTime()
+
+  store.upsertDailyStats({
+    startedAtMs: day1,
+    accountId: "acct-a",
+    costUnits: 10.0,
+    tokensTotal: 1000,
+    hasError: false,
+  })
+  store.upsertDailyStats({
+    startedAtMs: day1,
+    accountId: "acct-b",
+    costUnits: 5.0,
+    tokensTotal: 500,
+    hasError: false,
+  })
+
+  const result = store.getDailyPremiumStats({
+    from: "2026-04-10",
+    to: "2026-04-10",
+    accountId: "acct-a",
+  })
+
+  expect(result.daily.length).toBe(1)
+  expect(result.daily[0].request_count).toBe(1)
+  expect(result.daily[0].cost_units_sum).toBe(10.0)
+
+  expect(result.byAccount.length).toBe(1)
+  expect(result.byAccount[0].account_id).toBe("acct-a")
+})
+
+test("getDailyPremiumStats returns empty arrays for no data", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const result = store.getDailyPremiumStats({
+    from: "2026-04-10",
+    to: "2026-04-10",
+  })
+
+  expect(result.daily).toEqual([])
+  expect(result.byAccount).toEqual([])
+})
+
+test("getHourlyPremiumStats aggregates by hour from request_log", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // Insert directly into request_log for hourly queries
+  const hour1 = new Date("2026-04-10T10:15:00").getTime()
+  const hour1b = new Date("2026-04-10T10:45:00").getTime()
+  const hour2 = new Date("2026-04-10T11:30:00").getTime()
+
+  db.run(
+    `INSERT INTO request_log
+       (request_id, started_at_ms, method, path, account_id, cost_units, tokens_total, error_name)
+     VALUES
+       ('h-1', ?, 'POST', '/v1/messages', 'acct-a', 10.0, 1000, NULL),
+       ('h-2', ?, 'POST', '/v1/messages', 'acct-a', 5.0,  500,  'Error'),
+       ('h-3', ?, 'POST', '/v1/messages', 'acct-b', 8.0,  800,  NULL)`,
+    [hour1, hour1b, hour2],
+  )
+
+  const result = store.getHourlyPremiumStats({
+    fromMs: hour1,
+    toMs: hour2 + 1000,
+  })
+
+  expect(result.daily.length).toBe(2)
+  // First hour should have 2 requests aggregated
+  expect(result.daily[0].request_count).toBe(2)
+  expect(result.daily[0].cost_units_sum).toBe(15.0)
+  // Second hour should have 1 request
+  expect(result.daily[1].request_count).toBe(1)
+
+  expect(result.byAccount.length).toBe(2)
+})
+
+test("cleanupStatsRetention removes old stats", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // Insert a row with an old date
+  const oldDate = new Date("2025-01-01T10:00:00").getTime()
+  const recentDate = new Date("2026-04-10T10:00:00").getTime()
+
+  store.upsertDailyStats({
+    startedAtMs: oldDate,
+    accountId: "acct-a",
+    costUnits: 10.0,
+    tokensTotal: 1000,
+    hasError: false,
+  })
+  store.upsertDailyStats({
+    startedAtMs: recentDate,
+    accountId: "acct-a",
+    costUnits: 5.0,
+    tokensTotal: 500,
+    hasError: false,
+  })
+
+  const beforeCount = (
+    db.query("SELECT COUNT(*) as cnt FROM daily_premium_stats").get() as {
+      cnt: number
+    }
+  ).cnt
+  expect(beforeCount).toBe(2)
+
+  // Cleanup with 30 days retention (old row should be removed)
+  store.cleanupStatsRetention(30)
+
+  const afterCount = (
+    db.query("SELECT COUNT(*) as cnt FROM daily_premium_stats").get() as {
+      cnt: number
+    }
+  ).cnt
+  expect(afterCount).toBe(1)
+
+  // Verify the remaining row is the recent one
+  const remaining = db
+    .query("SELECT date FROM daily_premium_stats")
+    .get() as { date: string }
+  expect(remaining.date).toBe(toLocalDateString(recentDate))
+})
+
+test("toLocalDateString formats correctly", () => {
+  // Use a known date in local time
+  const ms = new Date(2026, 3, 10).getTime() // April 10, 2026 (month is 0-indexed)
+  expect(toLocalDateString(ms)).toBe("2026-04-10")
+
+  const ms2 = new Date(2026, 0, 1).getTime() // January 1, 2026
+  expect(toLocalDateString(ms2)).toBe("2026-01-01")
+})

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -2,10 +2,7 @@ import { Database } from "bun:sqlite"
 import { expect, test } from "bun:test"
 
 import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
-import {
-  StatsStore,
-  toLocalDateString,
-} from "../src/lib/stats-store"
+import { StatsStore, toLocalDateString } from "../src/lib/stats-store"
 
 test("initAdminDb migrates admin DB to user_version 9", () => {
   const db = new Database(":memory:")
@@ -73,17 +70,19 @@ test("v9 migration backfills from existing request_log data", () => {
 
   expect(rows.length).toBe(2)
 
-  const acctA = rows.find((r) => r.account_id === "acct-a")!
-  expect(acctA.request_count).toBe(2)
-  expect(acctA.cost_units_sum).toBe(15.0)
-  expect(acctA.tokens_total).toBe(1500)
-  expect(acctA.error_count).toBe(1)
+  const acctA = rows.find((r) => r.account_id === "acct-a")
+  expect(acctA).toBeDefined()
+  expect(acctA?.request_count).toBe(2)
+  expect(acctA?.cost_units_sum).toBe(15.0)
+  expect(acctA?.tokens_total).toBe(1500)
+  expect(acctA?.error_count).toBe(1)
 
-  const acctB = rows.find((r) => r.account_id === "acct-b")!
-  expect(acctB.request_count).toBe(1)
-  expect(acctB.cost_units_sum).toBe(8.0)
-  expect(acctB.tokens_total).toBe(800)
-  expect(acctB.error_count).toBe(0)
+  const acctB = rows.find((r) => r.account_id === "acct-b")
+  expect(acctB).toBeDefined()
+  expect(acctB?.request_count).toBe(1)
+  expect(acctB?.cost_units_sum).toBe(8.0)
+  expect(acctB?.tokens_total).toBe(800)
+  expect(acctB?.error_count).toBe(0)
 })
 
 test("upsertDailyStats creates new rows", () => {
@@ -100,9 +99,7 @@ test("upsertDailyStats creates new rows", () => {
     hasError: false,
   })
 
-  const rows = db
-    .query("SELECT * FROM daily_premium_stats")
-    .all() as Array<{
+  const rows = db.query("SELECT * FROM daily_premium_stats").all() as Array<{
     date: string
     account_id: string
     request_count: number
@@ -143,9 +140,7 @@ test("upsertDailyStats accumulates on same date+account", () => {
     hasError: true,
   })
 
-  const rows = db
-    .query("SELECT * FROM daily_premium_stats")
-    .all() as Array<{
+  const rows = db.query("SELECT * FROM daily_premium_stats").all() as Array<{
     request_count: number
     cost_units_sum: number
     tokens_total: number
@@ -183,9 +178,7 @@ test("upsertDailyStats creates separate rows for different accounts", () => {
   })
 
   const rows = db
-    .query(
-      "SELECT account_id FROM daily_premium_stats ORDER BY account_id",
-    )
+    .query("SELECT account_id FROM daily_premium_stats ORDER BY account_id")
     .all() as Array<{ account_id: string }>
 
   expect(rows.length).toBe(2)
@@ -368,9 +361,9 @@ test("cleanupStatsRetention removes old stats", () => {
   expect(afterCount).toBe(1)
 
   // Verify the remaining row is the recent one
-  const remaining = db
-    .query("SELECT date FROM daily_premium_stats")
-    .get() as { date: string }
+  const remaining = db.query("SELECT date FROM daily_premium_stats").get() as {
+    date: string
+  }
   expect(remaining.date).toBe(toLocalDateString(recentDate))
 })
 


### PR DESCRIPTION
## Summary

- Add a Statistics page to the admin dashboard with two Recharts-powered charts:
  - **Premium Usage Trend** — dual Y-axis (cost units area + request count dashed line)
  - **Per-Account Premium Usage** — stacked area chart per upstream account
- New `daily_premium_stats` SQLite table with write-time upsert aggregation (DB migration v9)
- 180-day stats retention (independent of request_log 14-day policy)
- Historical backfill from existing `request_log` during migration
- `GET /api/admin/stats/premium-daily` endpoint with day/hour granularity, date range, and account filter
- Time range presets (24h/7d/this month/custom) with auto-refresh (30s/60s/5m/off)
- Full i18n support (en-US + zh-CN)
- Loading skeleton, empty state, and error toast handling

## Test plan

- [x] 392 unit/integration tests pass (`bun test`)
- [x] 12 new tests in `tests/stats-store.test.ts` covering upsert, queries, backfill, cleanup
- [x] Lint passes with 0 errors (`bun run lint`)
- [x] TypeScript compiles cleanly (backend + admin-ui)
- [x] Admin-UI production build succeeds
- [x] Chrome manual verification: navigation, time controls, empty states, i18n (en/zh), light/dark theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了统计页面，展示高级使用情况、成本单位、请求计数和令牌总数的历史趋势
  * 支持多种时间范围选择（24小时/7天/月份/自定义）和自动刷新功能
  * 提供按账户分类的使用分析视图

* **测试**
  * 新增统计功能的测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->