### PR TITLE
feat: actual premium consumption statistics from quota snapshots

### DIFF
--- a/admin-ui/src/components/charts/account-usage-chart.tsx
+++ b/admin-ui/src/components/charts/account-usage-chart.tsx
@@ -94,7 +94,7 @@ export function AccountUsageChart({
         row = {}
         dateMap.set(item.date, row)
       }
-      row[item.account_id] = item.cost_units_sum
+      row[item.account_id] = item.premium_consumed
     }
 
     const ids = [...accountSet]

--- a/admin-ui/src/components/charts/premium-usage-chart.tsx
+++ b/admin-ui/src/components/charts/premium-usage-chart.tsx
@@ -51,7 +51,7 @@ function renderTooltip(
             {t("statistics.costUnits")}
           </span>
           <span className="tabular-nums font-medium">
-            {item.cost_units_sum}
+            {item.premium_consumed}
           </span>
         </div>
         <div className="flex justify-between gap-4">
@@ -143,7 +143,7 @@ export function PremiumUsageChart({
               <Area
                 yAxisId="cost"
                 type="monotone"
-                dataKey="cost_units_sum"
+                dataKey="premium_consumed"
                 name={t("statistics.costUnits")}
                 fill="var(--color-chart-1)"
                 fillOpacity={0.2}

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -189,7 +189,7 @@ export type AdminModelsDetailsResponse = {
 export type DailyStatsItem = {
   date: string
   request_count: number
-  cost_units_sum: number
+  premium_consumed: number
   tokens_total: number
   error_count: number
 }

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -62,6 +62,7 @@ import {
   addAccountToRegistry,
 } from "./accounts-registry"
 import { PATHS } from "./paths"
+import { getStatsStore } from "./request-history"
 import { getSharedSessionAffinityStore } from "./session-affinity-store"
 import { SessionOwnershipCache } from "./session-ownership"
 
@@ -731,10 +732,25 @@ export class AccountsManager {
       try {
         const usage = await getCopilotUsage(ctx)
         const premium = usage.quota_snapshots.premium_interactions
-        applyQuotaRefreshSuccessIfCurrent(account, snapshot, {
+        const applied = applyQuotaRefreshSuccessIfCurrent(account, snapshot, {
           premium,
           copilotApiUrl: usage.endpoints.api,
         })
+
+        if (applied) {
+          try {
+            getStatsStore()?.insertQuotaSnapshot({
+              accountId: account.id,
+              snapshotAtMs: Date.now(),
+              remaining: premium.remaining,
+              entitlement: premium.entitlement,
+              unlimited: premium.unlimited,
+              source: "refresh",
+            })
+          } catch {
+            // Best-effort: don't fail the quota refresh if snapshot insert fails
+          }
+        }
       } catch (error) {
         if (error instanceof HTTPError && error.response.status === 401) {
           applyUnauthorizedIfCurrent(account, snapshot, "Unauthorized (401)")

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -222,13 +222,60 @@ function migrateV8(db: Database): void {
   `)
 }
 
+function migrateV10(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS quota_snapshots (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      account_id      TEXT    NOT NULL,
+      snapshot_at_ms  INTEGER NOT NULL,
+      remaining       INTEGER NOT NULL,
+      entitlement     INTEGER NOT NULL,
+      unlimited       INTEGER NOT NULL DEFAULT 0,
+      source          TEXT    NOT NULL DEFAULT 'refresh'
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_quota_snapshots_account_time
+      ON quota_snapshots(account_id, snapshot_at_ms);
+
+    CREATE INDEX IF NOT EXISTS idx_quota_snapshots_time
+      ON quota_snapshots(snapshot_at_ms);
+  `)
+
+  const hasRequestLog = db
+    .query(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'request_log' LIMIT 1;",
+    )
+    .get()
+
+  if (hasRequestLog) {
+    db.run(`
+      INSERT INTO quota_snapshots
+        (account_id, snapshot_at_ms, remaining, entitlement, unlimited, source)
+      SELECT
+        account_id,
+        finished_at_ms,
+        CAST(premium_remaining_after AS INTEGER),
+        0,
+        COALESCE(premium_unlimited_after, 0),
+        'backfill'
+      FROM request_log
+      WHERE premium_remaining_after IS NOT NULL
+        AND account_id IS NOT NULL
+        AND finished_at_ms IS NOT NULL
+      ORDER BY finished_at_ms;
+    `)
+  }
+
+  db.run("PRAGMA user_version = 10;")
+}
+
 function migrateAdminDb(db: Database): void {
   const row = db.query("PRAGMA user_version;").get() as {
     user_version?: number
   } | null
   const current = row?.user_version ?? 0
 
-  if (current >= 9) {
+  if (current >= 10) {
     return
   }
 
@@ -326,4 +373,5 @@ function migrateAdminDb(db: Database): void {
 
   migrateV8(db)
   migrateV9(db)
+  migrateV10(db)
 }

--- a/src/lib/request-history.test.ts
+++ b/src/lib/request-history.test.ts
@@ -263,7 +263,7 @@ describe("RequestHistoryStore", () => {
     expect(columns).toContain("selection_reason")
     expect(columns).toContain("upstream_error_message_raw")
 
-    expect(db.query("PRAGMA user_version;").get()).toEqual({ user_version: 9 })
+    expect(db.query("PRAGMA user_version;").get()).toEqual({ user_version: 10 })
   })
 
   test("query orders by id DESC and supports cursor paging", () => {

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -5,7 +5,7 @@ import { consola } from "consola"
 export interface DailyStats {
   date: string
   request_count: number
-  cost_units_sum: number
+  premium_consumed: number
   tokens_total: number
   error_count: number
 }
@@ -96,8 +96,8 @@ export class StatsStore {
   }): Array<{ date: string; account_id: string; premium_consumed: number }> {
     const dateExpr =
       params.granularity === "hour" ?
-        "strftime('%Y-%m-%d %H:00', snapshot_at_ms / 1000, 'unixepoch')"
-      : "date(snapshot_at_ms / 1000, 'unixepoch')"
+        "strftime('%Y-%m-%d %H:00', snapshot_at_ms / 1000, 'unixepoch', 'localtime')"
+      : "date(snapshot_at_ms / 1000, 'unixepoch', 'localtime')"
 
     const accountFilter = params.accountId ? " AND account_id = ?" : ""
     const args: Array<string | number> = []
@@ -173,11 +173,10 @@ export class StatsStore {
     const args: Array<string | number> = [params.from, params.to]
     if (params.accountId) args.push(params.accountId)
 
-    const daily = this.db
+    const dailyMetrics = this.db
       .query(
         `SELECT date,
                 SUM(request_count)  AS request_count,
-                SUM(cost_units_sum) AS cost_units_sum,
                 SUM(tokens_total)   AS tokens_total,
                 SUM(error_count)    AS error_count
          FROM daily_premium_stats
@@ -185,18 +184,43 @@ export class StatsStore {
          GROUP BY date
          ORDER BY date`,
       )
-      .all(...args) as Array<DailyStats>
+      .all(...args) as Array<{
+      date: string
+      request_count: number
+      tokens_total: number
+      error_count: number
+    }>
 
-    const byAccount = this.db
+    const byAccountMetrics = this.db
       .query(
-        `SELECT date, account_id, request_count, cost_units_sum, tokens_total, error_count
+        `SELECT date, account_id, request_count, tokens_total, error_count
          FROM daily_premium_stats
          WHERE date >= ? AND date <= ?${accountFilter}
          ORDER BY date, account_id`,
       )
-      .all(...args) as Array<DailyAccountStats>
+      .all(...args) as Array<{
+      date: string
+      account_id: string
+      request_count: number
+      tokens_total: number
+      error_count: number
+    }>
 
-    return { daily, byAccount }
+    const fromMs = this.localDateToMs(params.from)
+    const toMs = this.localDateToMs(params.to) + 86_399_999
+
+    const consumption = this.getConsumptionFromSnapshots({
+      fromMs,
+      toMs,
+      granularity: "day",
+      accountId: params.accountId,
+    })
+
+    return this.mergeMetricsAndConsumption(
+      dailyMetrics,
+      byAccountMetrics,
+      consumption,
+    )
   }
 
   getHourlyPremiumStats(params: {
@@ -208,11 +232,10 @@ export class StatsStore {
     const dailyArgs: Array<string | number> = [params.fromMs, params.toMs]
     if (params.accountId) dailyArgs.push(params.accountId)
 
-    const daily = this.db
+    const dailyMetrics = this.db
       .query(
         `SELECT strftime('%Y-%m-%d %H:00', started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
                 COUNT(*)                                                   AS request_count,
-                SUM(cost_units)                                            AS cost_units_sum,
                 COALESCE(SUM(tokens_total), 0)                             AS tokens_total,
                 SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END)    AS error_count
          FROM request_log
@@ -221,19 +244,23 @@ export class StatsStore {
          GROUP BY 1
          ORDER BY 1`,
       )
-      .all(...dailyArgs) as Array<DailyStats>
+      .all(...dailyArgs) as Array<{
+      date: string
+      request_count: number
+      tokens_total: number
+      error_count: number
+    }>
 
     const byAccountFilter =
       params.accountId ? " AND account_id = ?" : " AND account_id IS NOT NULL"
     const byAccountArgs: Array<string | number> = [params.fromMs, params.toMs]
     if (params.accountId) byAccountArgs.push(params.accountId)
 
-    const byAccount = this.db
+    const byAccountMetrics = this.db
       .query(
         `SELECT strftime('%Y-%m-%d %H:00', started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
                 account_id,
                 COUNT(*)                                                   AS request_count,
-                SUM(cost_units)                                            AS cost_units_sum,
                 COALESCE(SUM(tokens_total), 0)                             AS tokens_total,
                 SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END)    AS error_count
          FROM request_log
@@ -242,9 +269,26 @@ export class StatsStore {
          GROUP BY 1, 2
          ORDER BY 1, 2`,
       )
-      .all(...byAccountArgs) as Array<DailyAccountStats>
+      .all(...byAccountArgs) as Array<{
+      date: string
+      account_id: string
+      request_count: number
+      tokens_total: number
+      error_count: number
+    }>
 
-    return { daily, byAccount }
+    const consumption = this.getConsumptionFromSnapshots({
+      fromMs: params.fromMs,
+      toMs: params.toMs,
+      granularity: "hour",
+      accountId: params.accountId,
+    })
+
+    return this.mergeMetricsAndConsumption(
+      dailyMetrics,
+      byAccountMetrics,
+      consumption,
+    )
   }
 
   cleanupStatsRetention(
@@ -257,8 +301,91 @@ export class StatsStore {
       this.db
         .query("DELETE FROM daily_premium_stats WHERE date < ?;")
         .run(cutoffDate)
+
+      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000
+      this.db
+        .query("DELETE FROM quota_snapshots WHERE snapshot_at_ms < ?;")
+        .run(cutoffMs)
     } catch (error) {
-      consola.debug("Failed to cleanup daily_premium_stats retention", error)
+      consola.debug("Failed to cleanup stats retention", error)
     }
+  }
+
+  private localDateToMs(dateStr: string): number {
+    const [y, m, d] = dateStr.split("-").map(Number)
+    return new Date(y, m - 1, d).getTime()
+  }
+
+  private mergeMetricsAndConsumption(
+    dailyMetrics: Array<{
+      date: string
+      request_count: number
+      tokens_total: number
+      error_count: number
+    }>,
+    byAccountMetrics: Array<{
+      date: string
+      account_id: string
+      request_count: number
+      tokens_total: number
+      error_count: number
+    }>,
+    consumption: Array<{
+      date: string
+      account_id: string
+      premium_consumed: number
+    }>,
+  ): { daily: Array<DailyStats>; byAccount: Array<DailyAccountStats> } {
+    const consumptionMap = new Map<string, number>()
+    const dateConsumptionMap = new Map<string, number>()
+    for (const c of consumption) {
+      consumptionMap.set(`${c.date}|${c.account_id}`, c.premium_consumed)
+      dateConsumptionMap.set(
+        c.date,
+        (dateConsumptionMap.get(c.date) ?? 0) + c.premium_consumed,
+      )
+    }
+
+    const allDates = new Set([
+      ...dailyMetrics.map((m) => m.date),
+      ...consumption.map((c) => c.date),
+    ])
+    const metricsMap = new Map(dailyMetrics.map((m) => [m.date, m]))
+
+    const daily: Array<DailyStats> = [...allDates].sort().map((date) => {
+      const m = metricsMap.get(date)
+      return {
+        date,
+        request_count: m?.request_count ?? 0,
+        premium_consumed: dateConsumptionMap.get(date) ?? 0,
+        tokens_total: m?.tokens_total ?? 0,
+        error_count: m?.error_count ?? 0,
+      }
+    })
+
+    const allAccountDateKeys = new Set([
+      ...byAccountMetrics.map((m) => `${m.date}|${m.account_id}`),
+      ...consumption.map((c) => `${c.date}|${c.account_id}`),
+    ])
+    const byAccountMetricsMap = new Map(
+      byAccountMetrics.map((m) => [`${m.date}|${m.account_id}`, m]),
+    )
+
+    const byAccount: Array<DailyAccountStats> = [...allAccountDateKeys]
+      .sort()
+      .map((key) => {
+        const [date, account_id] = key.split("|")
+        const m = byAccountMetricsMap.get(key)
+        return {
+          date,
+          account_id,
+          request_count: m?.request_count ?? 0,
+          premium_consumed: consumptionMap.get(key) ?? 0,
+          tokens_total: m?.tokens_total ?? 0,
+          error_count: m?.error_count ?? 0,
+        }
+      })
+
+    return { daily, byAccount }
   }
 }

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -30,6 +30,7 @@ export function toLocalDateString(ms: number): string {
 export class StatsStore {
   private readonly db: Database
   private readonly upsertStmt: ReturnType<Database["query"]>
+  private readonly insertSnapshotStmt: ReturnType<Database["query"]>
 
   constructor(db: Database) {
     this.db = db
@@ -43,6 +44,11 @@ export class StatsStore {
         tokens_total    = tokens_total   + excluded.tokens_total,
         error_count     = error_count    + excluded.error_count,
         updated_at_ms   = excluded.updated_at_ms
+    `)
+    this.insertSnapshotStmt = db.query(`
+      INSERT INTO quota_snapshots
+        (account_id, snapshot_at_ms, remaining, entitlement, unlimited, source)
+      VALUES (?, ?, ?, ?, ?, ?)
     `)
   }
 
@@ -61,6 +67,24 @@ export class StatsStore {
       record.tokensTotal,
       record.hasError ? 1 : 0,
       Date.now(),
+    )
+  }
+
+  insertQuotaSnapshot(record: {
+    accountId: string
+    snapshotAtMs: number
+    remaining: number
+    entitlement: number
+    unlimited: boolean
+    source: string
+  }): void {
+    this.insertSnapshotStmt.run(
+      record.accountId,
+      record.snapshotAtMs,
+      record.remaining,
+      record.entitlement,
+      record.unlimited ? 1 : 0,
+      record.source,
     )
   }
 

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -102,18 +102,23 @@ export class StatsStore {
     const accountFilter = params.accountId ? " AND account_id = ?" : ""
     const args: Array<string | number> = []
 
+    // baseline CTE: WHERE snapshot_at_ms < ?
     args.push(params.fromMs)
+    // baseline CTE: AND account_id = ? (if filtered)
     if (params.accountId) args.push(params.accountId)
 
+    // all_snaps CTE: WHERE snapshot_at_ms >= ? AND snapshot_at_ms <= ?
     args.push(params.fromMs, params.toMs)
+    // all_snaps CTE: AND account_id = ? (if filtered)
     if (params.accountId) args.push(params.accountId)
 
+    // outer WHERE: snapshot_at_ms >= ?
     args.push(params.fromMs)
 
     return this.db
       .query(
         `WITH baseline AS (
-          SELECT qs.account_id, qs.snapshot_at_ms, qs.remaining
+          SELECT qs.account_id, qs.snapshot_at_ms, qs.remaining, qs.id
           FROM quota_snapshots qs
           INNER JOIN (
             SELECT account_id, MAX(snapshot_at_ms) AS max_ts
@@ -125,10 +130,10 @@ export class StatsStore {
                   AND qs.snapshot_at_ms = latest.max_ts
         ),
         all_snaps AS (
-          SELECT account_id, snapshot_at_ms, remaining
+          SELECT account_id, snapshot_at_ms, remaining, id
           FROM baseline
           UNION ALL
-          SELECT account_id, snapshot_at_ms, remaining
+          SELECT account_id, snapshot_at_ms, remaining, id
           FROM quota_snapshots
           WHERE snapshot_at_ms >= ? AND snapshot_at_ms <= ?
             AND unlimited = 0${accountFilter}
@@ -139,7 +144,7 @@ export class StatsStore {
             snapshot_at_ms,
             remaining,
             LAG(remaining) OVER (
-              PARTITION BY account_id ORDER BY snapshot_at_ms
+              PARTITION BY account_id ORDER BY snapshot_at_ms, id
             ) AS prev_remaining
           FROM all_snaps
         )
@@ -295,14 +300,13 @@ export class StatsStore {
     retentionDays: number = DEFAULT_STATS_RETENTION_DAYS,
   ): void {
     try {
-      const cutoffDate = toLocalDateString(
-        Date.now() - retentionDays * 24 * 60 * 60 * 1000,
-      )
+      const nowMs = Date.now()
+      const cutoffMs = nowMs - retentionDays * 24 * 60 * 60 * 1000
+      const cutoffDate = toLocalDateString(cutoffMs)
       this.db
         .query("DELETE FROM daily_premium_stats WHERE date < ?;")
         .run(cutoffDate)
 
-      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000
       this.db
         .query("DELETE FROM quota_snapshots WHERE snapshot_at_ms < ?;")
         .run(cutoffMs)

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -88,6 +88,82 @@ export class StatsStore {
     )
   }
 
+  getConsumptionFromSnapshots(params: {
+    fromMs: number
+    toMs: number
+    granularity: "day" | "hour"
+    accountId?: string
+  }): Array<{ date: string; account_id: string; premium_consumed: number }> {
+    const dateExpr =
+      params.granularity === "hour" ?
+        "strftime('%Y-%m-%d %H:00', snapshot_at_ms / 1000, 'unixepoch')"
+      : "date(snapshot_at_ms / 1000, 'unixepoch')"
+
+    const accountFilter = params.accountId ? " AND account_id = ?" : ""
+    const args: Array<string | number> = []
+
+    args.push(params.fromMs)
+    if (params.accountId) args.push(params.accountId)
+
+    args.push(params.fromMs, params.toMs)
+    if (params.accountId) args.push(params.accountId)
+
+    args.push(params.fromMs)
+
+    return this.db
+      .query(
+        `WITH baseline AS (
+          SELECT qs.account_id, qs.snapshot_at_ms, qs.remaining
+          FROM quota_snapshots qs
+          INNER JOIN (
+            SELECT account_id, MAX(snapshot_at_ms) AS max_ts
+            FROM quota_snapshots
+            WHERE snapshot_at_ms < ?
+              AND unlimited = 0${accountFilter}
+            GROUP BY account_id
+          ) latest ON qs.account_id = latest.account_id
+                  AND qs.snapshot_at_ms = latest.max_ts
+        ),
+        all_snaps AS (
+          SELECT account_id, snapshot_at_ms, remaining
+          FROM baseline
+          UNION ALL
+          SELECT account_id, snapshot_at_ms, remaining
+          FROM quota_snapshots
+          WHERE snapshot_at_ms >= ? AND snapshot_at_ms <= ?
+            AND unlimited = 0${accountFilter}
+        ),
+        with_prev AS (
+          SELECT
+            account_id,
+            snapshot_at_ms,
+            remaining,
+            LAG(remaining) OVER (
+              PARTITION BY account_id ORDER BY snapshot_at_ms
+            ) AS prev_remaining
+          FROM all_snaps
+        )
+        SELECT
+          ${dateExpr} AS date,
+          account_id,
+          SUM(
+            CASE WHEN prev_remaining IS NOT NULL AND prev_remaining > remaining
+                 THEN prev_remaining - remaining
+                 ELSE 0
+            END
+          ) AS premium_consumed
+        FROM with_prev
+        WHERE snapshot_at_ms >= ?
+        GROUP BY 1, 2
+        ORDER BY 1, 2`,
+      )
+      .all(...args) as Array<{
+      date: string
+      account_id: string
+      premium_consumed: number
+    }>
+  }
+
   getDailyPremiumStats(params: {
     from: string
     to: string

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -212,7 +212,7 @@ export class StatsStore {
     }>
 
     const fromMs = this.localDateToMs(params.from)
-    const toMs = this.localDateToMs(params.to) + 86_399_999
+    const toMs = this.localDateEndMs(params.to)
 
     const consumption = this.getConsumptionFromSnapshots({
       fromMs,
@@ -307,9 +307,25 @@ export class StatsStore {
         .query("DELETE FROM daily_premium_stats WHERE date < ?;")
         .run(cutoffDate)
 
+      // Keep the latest snapshot per account before the cutoff as baseline
+      // for getConsumptionFromSnapshots() which needs a pre-range reference.
       this.db
-        .query("DELETE FROM quota_snapshots WHERE snapshot_at_ms < ?;")
-        .run(cutoffMs)
+        .query(
+          `DELETE FROM quota_snapshots
+           WHERE snapshot_at_ms < ?
+             AND id NOT IN (
+               SELECT qs.id
+               FROM quota_snapshots qs
+               INNER JOIN (
+                 SELECT account_id, MAX(snapshot_at_ms) AS max_ts
+                 FROM quota_snapshots
+                 WHERE snapshot_at_ms < ?
+                 GROUP BY account_id
+               ) latest ON qs.account_id = latest.account_id
+                        AND qs.snapshot_at_ms = latest.max_ts
+             );`,
+        )
+        .run(cutoffMs, cutoffMs)
     } catch (error) {
       consola.debug("Failed to cleanup stats retention", error)
     }
@@ -318,6 +334,12 @@ export class StatsStore {
   private localDateToMs(dateStr: string): number {
     const [y, m, d] = dateStr.split("-").map(Number)
     return new Date(y, m - 1, d).getTime()
+  }
+
+  /** End-of-day ms (next local midnight - 1ms), DST-safe. */
+  private localDateEndMs(dateStr: string): number {
+    const [y, m, d] = dateStr.split("-").map(Number)
+    return new Date(y, m - 1, d + 1).getTime() - 1
   }
 
   private mergeMetricsAndConsumption(

--- a/tests/session-affinity-store.test.ts
+++ b/tests/session-affinity-store.test.ts
@@ -4,14 +4,14 @@ import { expect, test } from "bun:test"
 import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
 import { SessionAffinityStore } from "../src/lib/session-affinity-store"
 
-test("initAdminDb migrates admin DB to user_version 9", () => {
+test("initAdminDb migrates admin DB to user_version 10", () => {
   const db = new Database(":memory:")
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(9)
+  expect(getAdminDbUserVersion(db)).toBe(10)
 })
 
-test("initAdminDb upgrades an existing v7 DB to v8 and creates session_affinity", () => {
+test("initAdminDb upgrades an existing v7 DB to v10 and creates session_affinity", () => {
   const db = new Database(":memory:")
 
   db.run("PRAGMA user_version = 7;")
@@ -32,7 +32,7 @@ test("initAdminDb upgrades an existing v7 DB to v8 and creates session_affinity"
     )
     .get() as { name?: string } | null
 
-  expect(getAdminDbUserVersion(db)).toBe(9)
+  expect(getAdminDbUserVersion(db)).toBe(10)
   expect(after?.name).toBe("session_affinity")
 })
 

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -689,6 +689,70 @@ test("cleanupStatsRetention removes old stats", () => {
   expect(remaining.date).toBe(toLocalDateString(recentDate))
 })
 
+test("cleanupStatsRetention preserves baseline snapshot per account", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // Very old snapshot (should be deleted)
+  const veryOld = new Date("2024-01-01T10:00:00").getTime()
+  // Old snapshot but latest before cutoff (should be PRESERVED as baseline)
+  const oldLatest = new Date("2025-01-01T10:00:00").getTime()
+  // Recent snapshot (should be preserved)
+  const recent = new Date("2026-04-10T10:00:00").getTime()
+
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: veryOld,
+    remaining: 300,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: oldLatest,
+    remaining: 250,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: recent,
+    remaining: 200,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  const beforeCount = (
+    db.query("SELECT COUNT(*) as cnt FROM quota_snapshots").get() as {
+      cnt: number
+    }
+  ).cnt
+  expect(beforeCount).toBe(3)
+
+  // 30 days retention — veryOld and oldLatest are both before cutoff
+  store.cleanupStatsRetention(30)
+
+  const afterRows = db
+    .query(
+      "SELECT account_id, snapshot_at_ms, remaining FROM quota_snapshots ORDER BY snapshot_at_ms",
+    )
+    .all() as Array<{
+    account_id: string
+    snapshot_at_ms: number
+    remaining: number
+  }>
+
+  // veryOld deleted, oldLatest preserved as baseline, recent preserved
+  expect(afterRows.length).toBe(2)
+  expect(afterRows[0].snapshot_at_ms).toBe(oldLatest)
+  expect(afterRows[0].remaining).toBe(250)
+  expect(afterRows[1].snapshot_at_ms).toBe(recent)
+})
+
 test("toLocalDateString formats correctly", () => {
   // Use a known date in local time
   const ms = new Date(2026, 3, 10).getTime() // April 10, 2026 (month is 0-indexed)

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -49,6 +49,38 @@ test("quota_snapshots table has the expected columns", () => {
   ])
 })
 
+test("insertQuotaSnapshot inserts a row into quota_snapshots", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: Date.now(),
+    remaining: 280,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  const rows = db
+    .query("SELECT account_id, remaining, entitlement, unlimited, source FROM quota_snapshots")
+    .all() as Array<{
+    account_id: string
+    remaining: number
+    entitlement: number
+    unlimited: number
+    source: string
+  }>
+
+  expect(rows.length).toBe(1)
+  expect(rows[0].account_id).toBe("acct-a")
+  expect(rows[0].remaining).toBe(280)
+  expect(rows[0].entitlement).toBe(300)
+  expect(rows[0].unlimited).toBe(0)
+  expect(rows[0].source).toBe("refresh")
+})
+
 test("v9 migration backfills from existing request_log data", () => {
   const db = new Database(":memory:")
   initAdminDb(db)

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -4,11 +4,11 @@ import { expect, test } from "bun:test"
 import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
 import { StatsStore, toLocalDateString } from "../src/lib/stats-store"
 
-test("initAdminDb migrates admin DB to user_version 9", () => {
+test("initAdminDb migrates admin DB to user_version 10", () => {
   const db = new Database(":memory:")
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(9)
+  expect(getAdminDbUserVersion(db)).toBe(10)
 })
 
 test("daily_premium_stats table has the expected columns", () => {
@@ -27,6 +27,25 @@ test("daily_premium_stats table has the expected columns", () => {
     "tokens_total",
     "error_count",
     "updated_at_ms",
+  ])
+})
+
+test("quota_snapshots table has the expected columns", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  const columns = db
+    .query("PRAGMA table_info(quota_snapshots);")
+    .all() as Array<{ name: string }>
+
+  expect(columns.map((c) => c.name)).toEqual([
+    "id",
+    "account_id",
+    "snapshot_at_ms",
+    "remaining",
+    "entitlement",
+    "unlimited",
+    "source",
   ])
 })
 
@@ -53,7 +72,7 @@ test("v9 migration backfills from existing request_log data", () => {
   // Re-run migration (should trigger v9 since user_version is 8)
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(9)
+  expect(getAdminDbUserVersion(db)).toBe(10)
 
   const rows = db
     .query(
@@ -83,6 +102,77 @@ test("v9 migration backfills from existing request_log data", () => {
   expect(acctB?.cost_units_sum).toBe(8.0)
   expect(acctB?.tokens_total).toBe(800)
   expect(acctB?.error_count).toBe(0)
+})
+
+test("v10 migration backfills quota_snapshots from request_log", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  db.run("PRAGMA user_version = 9;")
+  db.run("DROP TABLE IF EXISTS quota_snapshots;")
+
+  const baseMs = new Date("2026-04-10T12:00:00").getTime()
+  db.run(
+    `INSERT INTO request_log
+       (request_id, started_at_ms, finished_at_ms, method, path, account_id,
+        cost_units, premium_remaining_after, premium_unlimited_after)
+     VALUES
+       ('qs-1', ?, ?, 'POST', '/v1/messages', 'acct-a', 10.0, 290, 0),
+       ('qs-2', ?, ?, 'POST', '/v1/messages', 'acct-a', 5.0, 285, NULL),
+       ('qs-3', ?, ?, 'POST', '/v1/messages', 'acct-b', 8.0, 192, 1)`,
+    [
+      baseMs,
+      baseMs + 100,
+      baseMs + 1000,
+      baseMs + 1100,
+      baseMs + 2000,
+      baseMs + 2100,
+    ],
+  )
+
+  initAdminDb(db)
+
+  expect(getAdminDbUserVersion(db)).toBe(10)
+
+  const rows = db
+    .query(
+      "SELECT account_id, snapshot_at_ms, remaining, entitlement, unlimited, source FROM quota_snapshots ORDER BY snapshot_at_ms",
+    )
+    .all() as Array<{
+    account_id: string
+    snapshot_at_ms: number
+    remaining: number
+    entitlement: number
+    unlimited: number
+    source: string
+  }>
+
+  expect(rows).toEqual([
+    {
+      account_id: "acct-a",
+      snapshot_at_ms: baseMs + 100,
+      remaining: 290,
+      entitlement: 0,
+      unlimited: 0,
+      source: "backfill",
+    },
+    {
+      account_id: "acct-a",
+      snapshot_at_ms: baseMs + 1100,
+      remaining: 285,
+      entitlement: 0,
+      unlimited: 0,
+      source: "backfill",
+    },
+    {
+      account_id: "acct-b",
+      snapshot_at_ms: baseMs + 2100,
+      remaining: 192,
+      entitlement: 0,
+      unlimited: 1,
+      source: "backfill",
+    },
+  ])
 })
 
 test("upsertDailyStats creates new rows", () => {

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -64,7 +64,9 @@ test("insertQuotaSnapshot inserts a row into quota_snapshots", () => {
   })
 
   const rows = db
-    .query("SELECT account_id, remaining, entitlement, unlimited, source FROM quota_snapshots")
+    .query(
+      "SELECT account_id, remaining, entitlement, unlimited, source FROM quota_snapshots",
+    )
     .all() as Array<{
     account_id: string
     remaining: number
@@ -79,6 +81,202 @@ test("insertQuotaSnapshot inserts a row into quota_snapshots", () => {
   expect(rows[0].entitlement).toBe(300)
   expect(rows[0].unlimited).toBe(0)
   expect(rows[0].source).toBe("refresh")
+})
+
+test("getConsumptionFromSnapshots computes daily consumption from remaining deltas", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // Day 1: remaining goes 300 → 290 → 280 (consumed 20)
+  const day1_t1 = new Date(2026, 3, 10, 8, 0, 0).getTime()
+  const day1_t2 = new Date(2026, 3, 10, 12, 0, 0).getTime()
+  const day1_t3 = new Date(2026, 3, 10, 16, 0, 0).getTime()
+
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: day1_t1,
+    remaining: 300,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: day1_t2,
+    remaining: 290,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: day1_t3,
+    remaining: 280,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  // Day 2: remaining goes 280 → 270 (consumed 10)
+  const day2_t1 = new Date(2026, 3, 11, 10, 0, 0).getTime()
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: day2_t1,
+    remaining: 270,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  const fromMs = new Date(2026, 3, 10, 0, 0, 0).getTime()
+  const toMs = new Date(2026, 3, 11, 23, 59, 59, 999).getTime()
+
+  const result = store.getConsumptionFromSnapshots({
+    fromMs,
+    toMs,
+    granularity: "day",
+  })
+
+  const day1 = result.find(
+    (r) => r.date.includes("04-10") && r.account_id === "acct-a",
+  )
+  expect(day1?.premium_consumed).toBe(20)
+
+  const day2 = result.find(
+    (r) => r.date.includes("04-11") && r.account_id === "acct-a",
+  )
+  expect(day2?.premium_consumed).toBe(10)
+})
+
+test("getConsumptionFromSnapshots handles quota reset (remaining increases)", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // remaining: 50 → 20 (consumed 30), then reset → 300 → 290 (consumed 10)
+  const t1 = new Date(2026, 3, 10, 8, 0, 0).getTime()
+  const t2 = new Date(2026, 3, 10, 10, 0, 0).getTime()
+  const t3 = new Date(2026, 3, 10, 12, 0, 0).getTime() // reset
+  const t4 = new Date(2026, 3, 10, 14, 0, 0).getTime()
+
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t1,
+    remaining: 50,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t2,
+    remaining: 20,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t3,
+    remaining: 300,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t4,
+    remaining: 290,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  const result = store.getConsumptionFromSnapshots({
+    fromMs: t1,
+    toMs: t4 + 1,
+    granularity: "day",
+  })
+
+  const day = result.find((r) => r.account_id === "acct-a")
+  // 30 (50→20) + 0 (reset 20→300) + 10 (300→290) = 40
+  expect(day?.premium_consumed).toBe(40)
+})
+
+test("getConsumptionFromSnapshots excludes unlimited accounts", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const t1 = new Date(2026, 3, 10, 8, 0, 0).getTime()
+  const t2 = new Date(2026, 3, 10, 12, 0, 0).getTime()
+
+  store.insertQuotaSnapshot({
+    accountId: "acct-unlimited",
+    snapshotAtMs: t1,
+    remaining: 999,
+    entitlement: 999,
+    unlimited: true,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-unlimited",
+    snapshotAtMs: t2,
+    remaining: 990,
+    entitlement: 999,
+    unlimited: true,
+    source: "refresh",
+  })
+
+  const result = store.getConsumptionFromSnapshots({
+    fromMs: t1,
+    toMs: t2 + 1,
+    granularity: "day",
+  })
+
+  expect(result.length).toBe(0)
+})
+
+test("getConsumptionFromSnapshots uses baseline snapshot before range", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // Baseline: before range
+  const baseline = new Date(2026, 3, 9, 23, 0, 0).getTime()
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: baseline,
+    remaining: 300,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  // In range: remaining drops
+  const t1 = new Date(2026, 3, 10, 8, 0, 0).getTime()
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t1,
+    remaining: 290,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  const fromMs = new Date(2026, 3, 10, 0, 0, 0).getTime()
+  const toMs = new Date(2026, 3, 10, 23, 59, 59, 999).getTime()
+
+  const result = store.getConsumptionFromSnapshots({
+    fromMs,
+    toMs,
+    granularity: "day",
+  })
+
+  const day = result.find((r) => r.account_id === "acct-a")
+  // Baseline 300 → 290 = consumed 10
+  expect(day?.premium_consumed).toBe(10)
 })
 
 test("v9 migration backfills from existing request_log data", () => {

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -88,10 +88,12 @@ test("getConsumptionFromSnapshots computes daily consumption from remaining delt
   initAdminDb(db)
   const store = new StatsStore(db)
 
+  // Use hours that fall on the same calendar date in both UTC and UTC+8
+  // (bun test runs JS in UTC, SQLite 'localtime' uses system TZ)
   // Day 1: remaining goes 300 → 290 → 280 (consumed 20)
-  const day1_t1 = new Date(2026, 3, 10, 8, 0, 0).getTime()
-  const day1_t2 = new Date(2026, 3, 10, 12, 0, 0).getTime()
-  const day1_t3 = new Date(2026, 3, 10, 16, 0, 0).getTime()
+  const day1_t1 = new Date(2026, 3, 10, 2, 0, 0).getTime()
+  const day1_t2 = new Date(2026, 3, 10, 6, 0, 0).getTime()
+  const day1_t3 = new Date(2026, 3, 10, 10, 0, 0).getTime()
 
   store.insertQuotaSnapshot({
     accountId: "acct-a",
@@ -119,7 +121,7 @@ test("getConsumptionFromSnapshots computes daily consumption from remaining delt
   })
 
   // Day 2: remaining goes 280 → 270 (consumed 10)
-  const day2_t1 = new Date(2026, 3, 11, 10, 0, 0).getTime()
+  const day2_t1 = new Date(2026, 3, 11, 2, 0, 0).getTime()
   store.insertQuotaSnapshot({
     accountId: "acct-a",
     snapshotAtMs: day2_t1,
@@ -544,7 +546,7 @@ test("getDailyPremiumStats returns aggregated daily totals", () => {
   expect(result.daily.length).toBe(2)
   expect(result.daily[0].date).toBe("2026-04-10")
   expect(result.daily[0].request_count).toBe(2)
-  expect(result.daily[0].cost_units_sum).toBe(15.0)
+  expect(result.daily[0].premium_consumed).toBe(0) // No snapshots inserted
   expect(result.daily[0].tokens_total).toBe(1500)
   expect(result.daily[0].error_count).toBe(1)
 
@@ -584,7 +586,7 @@ test("getDailyPremiumStats filters by account_id", () => {
 
   expect(result.daily.length).toBe(1)
   expect(result.daily[0].request_count).toBe(1)
-  expect(result.daily[0].cost_units_sum).toBe(10.0)
+  expect(result.daily[0].premium_consumed).toBe(0) // No snapshots inserted
 
   expect(result.byAccount.length).toBe(1)
   expect(result.byAccount[0].account_id).toBe("acct-a")
@@ -632,7 +634,7 @@ test("getHourlyPremiumStats aggregates by hour from request_log", () => {
   expect(result.daily.length).toBe(2)
   // First hour should have 2 requests aggregated
   expect(result.daily[0].request_count).toBe(2)
-  expect(result.daily[0].cost_units_sum).toBe(15.0)
+  expect(result.daily[0].premium_consumed).toBe(0) // No snapshots inserted
   // Second hour should have 1 request
   expect(result.daily[1].request_count).toBe(1)
 


### PR DESCRIPTION
## Summary

- Replace model-multiplier-based `cost_units_sum` with actual Premium quota consumption derived from `quota_snapshots` table
- Stats API now merges snapshot consumption data (via SQLite LAG window function) with request metrics from `daily_premium_stats` / `request_log`
- Add `localtime` timezone handling to snapshot date grouping for consistency with existing hourly stats
- Extend `cleanupStatsRetention()` to also clean `quota_snapshots` table

## Changes

| File | Change |
|---|---|
| `src/lib/stats-store.ts` | Interface rename `cost_units_sum` → `premium_consumed`; rewrite `getDailyPremiumStats`/`getHourlyPremiumStats` to merge snapshot consumption; add `localtime` to `getConsumptionFromSnapshots`; add snapshot retention cleanup; add `localDateToMs`/`mergeMetricsAndConsumption` helpers |
| `tests/stats-store.test.ts` | Fix timezone-sensitive timestamps (bun test UTC vs system UTC+8); update assertions for `premium_consumed` |
| `admin-ui/src/lib/admin-api.ts` | `DailyStatsItem.cost_units_sum` → `premium_consumed` |
| `admin-ui/.../premium-usage-chart.tsx` | Update `dataKey` and tooltip reference |
| `admin-ui/.../account-usage-chart.tsx` | Update pivot field reference |

## Test plan

- [x] 399 tests pass (0 fail)
- [x] TypeScript typecheck clean
- [x] ESLint lint clean
- [x] Full build successful
- [x] Timezone edge case tested: bun test (UTC) + SQLite localtime (system TZ) consistency verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加配额快照跟踪，记录并存储账户配额快照以便统计。

* **改进**
  * 统计与图表现在显示并使用“高级用量（premium_consumed）”指标，更多基于快照差值计算消耗，提升使用量准确性。
  * 报表按日/小时合并并对缺失数据进行零填充。

* **测试**
  * 更新并扩展迁移与消费计算相关测试，覆盖快照写入与回填场景。

* **Chores**
  * 升级数据库迁移到新版本并支持快照回填。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->