### PR TITLE
fix: correct statistics range and adaptive number lint

### DIFF
--- a/admin-ui/src/components/ui/adaptive-number-ticker.tsx
+++ b/admin-ui/src/components/ui/adaptive-number-ticker.tsx
@@ -1,0 +1,394 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { ComponentPropsWithoutRef } from "react"
+
+import {
+  buildAdaptiveNumberFormatCandidates,
+  buildAdaptiveNumberPairCandidates,
+  pickAdaptiveNumberFormatCandidate,
+  pickAdaptiveNumberPairCandidate,
+  resolveAdaptiveNumberFormatCandidate,
+  resolveAdaptiveNumberPairCandidate,
+  type AdaptiveNumberFormatCandidate,
+  type AdaptiveNumberPairCandidate,
+} from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+import { NumberTicker, numberTickerTextClassName } from "./number-ticker"
+
+interface AdaptiveNumberTickerProps extends ComponentPropsWithoutRef<"span"> {
+  value: number
+  startValue?: number
+  direction?: "up" | "down"
+  delay?: number
+  decimalPlaces?: number
+}
+
+interface AdaptiveNumberPairProps extends ComponentPropsWithoutRef<"div"> {
+  primaryValue: number
+  secondaryValue: number
+  primaryStartValue?: number
+  primaryDirection?: "up" | "down"
+  primaryDelay?: number
+  primaryDecimalPlaces?: number
+  secondaryDecimalPlaces?: number
+  separator?: string
+}
+
+interface MeasuredAdaptiveNumberTickerProps extends AdaptiveNumberTickerProps {
+  candidates: AdaptiveNumberFormatCandidate[]
+}
+
+interface MeasuredAdaptiveNumberPairProps extends Omit<AdaptiveNumberPairProps, "secondaryValue" | "secondaryDecimalPlaces"> {
+  candidates: AdaptiveNumberPairCandidate[]
+}
+
+const adaptiveNumberContainerClassName = "block min-w-0 max-w-full grow overflow-hidden"
+const adaptiveMeasureClassName = "pointer-events-none invisible absolute left-0 top-0 whitespace-nowrap"
+const secondaryNumberTextClassName = "text-muted-foreground text-sm whitespace-nowrap"
+const fallbackCandidate: AdaptiveNumberFormatCandidate = {
+  text: "",
+  formatOptions: {},
+}
+const fallbackPairCandidate: AdaptiveNumberPairCandidate = {
+  primaryCandidate: fallbackCandidate,
+  secondaryCandidate: fallbackCandidate,
+  text: "",
+}
+
+export function AdaptiveNumberTicker({
+  value,
+  startValue = 0,
+  direction = "up",
+  delay = 0,
+  className,
+  decimalPlaces = 0,
+  ...props
+}: AdaptiveNumberTickerProps) {
+  const candidates = useMemo(
+    () => buildAdaptiveNumberFormatCandidates(value, decimalPlaces),
+    [value, decimalPlaces]
+  )
+
+  if (candidates.length === 1) {
+    const candidate = candidates[0] ?? fallbackCandidate
+
+    return (
+      <span
+        className={cn(adaptiveNumberContainerClassName, className)}
+        {...props}
+      >
+        <NumberTicker
+          value={value}
+          startValue={startValue}
+          direction={direction}
+          delay={delay}
+          decimalPlaces={decimalPlaces}
+          formatOptions={candidate.formatOptions}
+          className="whitespace-nowrap"
+        />
+      </span>
+    )
+  }
+
+  return (
+    <MeasuredAdaptiveNumberTicker
+      value={value}
+      startValue={startValue}
+      direction={direction}
+      delay={delay}
+      decimalPlaces={decimalPlaces}
+      className={className}
+      candidates={candidates}
+      {...props}
+    />
+  )
+}
+
+export function AdaptiveNumberPair({
+  primaryValue,
+  secondaryValue,
+  primaryStartValue = 0,
+  primaryDirection = "up",
+  primaryDelay = 0,
+  className,
+  primaryDecimalPlaces = 0,
+  secondaryDecimalPlaces = 0,
+  separator = " / ",
+  ...props
+}: AdaptiveNumberPairProps) {
+  const candidates = useMemo(
+    () =>
+      buildAdaptiveNumberPairCandidates(
+        primaryValue,
+        secondaryValue,
+        primaryDecimalPlaces,
+        secondaryDecimalPlaces,
+        separator
+      ),
+    [
+      primaryValue,
+      secondaryValue,
+      primaryDecimalPlaces,
+      secondaryDecimalPlaces,
+      separator,
+    ]
+  )
+
+  if (candidates.length === 1) {
+    const candidate = candidates[0] ?? fallbackPairCandidate
+
+    return (
+      <div
+        className={cn("relative flex min-w-0 items-baseline gap-1 overflow-hidden", className)}
+        {...props}
+      >
+        <span className={adaptiveNumberContainerClassName}>
+          <NumberTicker
+            value={primaryValue}
+            startValue={primaryStartValue}
+            direction={primaryDirection}
+            delay={primaryDelay}
+            decimalPlaces={primaryDecimalPlaces}
+            formatOptions={candidate.primaryCandidate.formatOptions}
+            className="whitespace-nowrap"
+          />
+        </span>
+        <span className={cn(secondaryNumberTextClassName, "shrink-0")}>
+          {separator}{candidate.secondaryCandidate.text}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <MeasuredAdaptiveNumberPair
+      primaryValue={primaryValue}
+      primaryStartValue={primaryStartValue}
+      primaryDirection={primaryDirection}
+      primaryDelay={primaryDelay}
+      primaryDecimalPlaces={primaryDecimalPlaces}
+      separator={separator}
+      className={className}
+      candidates={candidates}
+      {...props}
+    />
+  )
+}
+
+function MeasuredAdaptiveNumberTicker({
+  value,
+  startValue = 0,
+  direction = "up",
+  delay = 0,
+  className,
+  decimalPlaces = 0,
+  candidates,
+  ...props
+}: MeasuredAdaptiveNumberTickerProps) {
+  const containerRef = useRef<HTMLSpanElement>(null)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const [selectedCandidate, setSelectedCandidate] = useState<AdaptiveNumberFormatCandidate>(
+    () => candidates[candidates.length - 1] ?? fallbackCandidate
+  )
+
+  const renderCandidate = resolveAdaptiveNumberFormatCandidate(
+    candidates,
+    selectedCandidate
+  )
+
+  const syncCandidate = useCallback(() => {
+    const container = containerRef.current
+    const measure = measureRef.current
+
+    if (!container || !measure) {
+      return
+    }
+
+    const availableWidth = container.clientWidth
+    if (availableWidth <= 0) {
+      return
+    }
+
+    const nextCandidate = pickAdaptiveNumberFormatCandidate(candidates, (candidate) => {
+      measure.textContent = candidate.text
+      return measure.scrollWidth <= availableWidth
+    })
+
+    setSelectedCandidate((currentCandidate) => {
+      const currentRenderCandidate = resolveAdaptiveNumberFormatCandidate(
+        candidates,
+        currentCandidate
+      )
+      if (currentRenderCandidate.text === nextCandidate.text) {
+        return currentCandidate
+      }
+
+      return nextCandidate
+    })
+  }, [candidates])
+
+  useEffect(() => {
+    syncCandidate()
+
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", syncCandidate)
+      return () => {
+        window.removeEventListener("resize", syncCandidate)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(syncCandidate)
+    resizeObserver.observe(container)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [syncCandidate])
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn("relative", adaptiveNumberContainerClassName, className)}
+      {...props}
+    >
+      <NumberTicker
+        value={value}
+        startValue={startValue}
+        direction={direction}
+        delay={delay}
+        decimalPlaces={decimalPlaces}
+        formatOptions={renderCandidate.formatOptions}
+        className="whitespace-nowrap"
+      />
+      <span
+        ref={measureRef}
+        aria-hidden
+        className={cn(adaptiveMeasureClassName, numberTickerTextClassName)}
+      />
+    </span>
+  )
+}
+
+function MeasuredAdaptiveNumberPair({
+  primaryValue,
+  primaryStartValue = 0,
+  primaryDirection = "up",
+  primaryDelay = 0,
+  className,
+  primaryDecimalPlaces = 0,
+  separator = " / ",
+  candidates,
+  ...props
+}: MeasuredAdaptiveNumberPairProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const measureRef = useRef<HTMLDivElement>(null)
+  const measurePrimaryRef = useRef<HTMLSpanElement>(null)
+  const measureSecondaryRef = useRef<HTMLSpanElement>(null)
+  const [selectedCandidate, setSelectedCandidate] = useState<AdaptiveNumberPairCandidate>(
+    () => candidates[candidates.length - 1] ?? fallbackPairCandidate
+  )
+
+  const renderCandidate = resolveAdaptiveNumberPairCandidate(
+    candidates,
+    selectedCandidate
+  )
+
+  const syncCandidate = useCallback(() => {
+    const container = containerRef.current
+    const measure = measureRef.current
+    const measurePrimary = measurePrimaryRef.current
+    const measureSecondary = measureSecondaryRef.current
+
+    if (!container || !measure || !measurePrimary || !measureSecondary) {
+      return
+    }
+
+    const availableWidth = container.clientWidth
+    if (availableWidth <= 0) {
+      return
+    }
+
+    const nextCandidate = pickAdaptiveNumberPairCandidate(candidates, (candidate) => {
+      measurePrimary.textContent = candidate.primaryCandidate.text
+      measureSecondary.textContent = `${separator}${candidate.secondaryCandidate.text}`
+      return measure.scrollWidth <= availableWidth
+    })
+
+    setSelectedCandidate((currentCandidate) => {
+      const currentRenderCandidate = resolveAdaptiveNumberPairCandidate(
+        candidates,
+        currentCandidate
+      )
+      if (currentRenderCandidate.text === nextCandidate.text) {
+        return currentCandidate
+      }
+
+      return nextCandidate
+    })
+  }, [candidates, separator])
+
+  useEffect(() => {
+    syncCandidate()
+
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", syncCandidate)
+      return () => {
+        window.removeEventListener("resize", syncCandidate)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(syncCandidate)
+    resizeObserver.observe(container)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [syncCandidate])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative flex min-w-0 items-baseline gap-1 overflow-hidden", className)}
+      {...props}
+    >
+      <span className={adaptiveNumberContainerClassName}>
+        <NumberTicker
+          value={primaryValue}
+          startValue={primaryStartValue}
+          direction={primaryDirection}
+          delay={primaryDelay}
+          decimalPlaces={primaryDecimalPlaces}
+          formatOptions={renderCandidate.primaryCandidate.formatOptions}
+          className="whitespace-nowrap"
+        />
+      </span>
+      <span className={cn(secondaryNumberTextClassName, "shrink-0")}>
+        {separator}{renderCandidate.secondaryCandidate.text}
+      </span>
+      <div
+        ref={measureRef}
+        aria-hidden
+        className={cn(adaptiveMeasureClassName, "flex items-baseline gap-1")}
+      >
+        <span
+          ref={measurePrimaryRef}
+          className={numberTickerTextClassName}
+        />
+        <span
+          ref={measureSecondaryRef}
+          className={secondaryNumberTextClassName}
+        />
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/components/ui/number-ticker.tsx
+++ b/admin-ui/src/components/ui/number-ticker.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import type { ComponentPropsWithoutRef } from "react"
 import { useInView, useMotionValue, useSpring } from "motion/react"
 
 import { cn } from "@/lib/utils"
+
+export const numberTickerTextClassName =
+  "inline-block tracking-wider text-black tabular-nums dark:text-white"
 
 interface NumberTickerProps extends ComponentPropsWithoutRef<"span"> {
   value: number
@@ -10,6 +13,7 @@ interface NumberTickerProps extends ComponentPropsWithoutRef<"span"> {
   direction?: "up" | "down"
   delay?: number
   decimalPlaces?: number
+  formatOptions?: Intl.NumberFormatOptions
 }
 
 export function NumberTicker({
@@ -19,10 +23,21 @@ export function NumberTicker({
   delay = 0,
   className,
   decimalPlaces = 0,
+  formatOptions,
   ...props
 }: NumberTickerProps) {
   const ref = useRef<HTMLSpanElement>(null)
-  const motionValue = useMotionValue(direction === "down" ? value : startValue)
+  const formatter = useMemo(
+    () =>
+      new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: decimalPlaces,
+        maximumFractionDigits: decimalPlaces,
+        ...formatOptions,
+      }),
+    [decimalPlaces, formatOptions]
+  )
+  const shouldAnimate = formatOptions?.notation !== "compact"
+  const motionValue = useMotionValue(shouldAnimate ? direction === "down" ? value : startValue : value)
   const springValue = useSpring(motionValue, {
     damping: 60,
     stiffness: 100,
@@ -32,45 +47,54 @@ export function NumberTicker({
 
   // Initial animation on first view
   useEffect(() => {
-    if (isInView && !hasAnimated.current) {
-      hasAnimated.current = true
-      const timer = setTimeout(() => {
-        motionValue.set(direction === "down" ? startValue : value)
-      }, delay * 1000)
-      return () => clearTimeout(timer)
+    if (!isInView || hasAnimated.current) {
+      return
     }
-  }, [motionValue, isInView, delay, value, direction, startValue])
+
+    hasAnimated.current = true
+    if (!shouldAnimate) {
+      motionValue.set(value)
+      return
+    }
+
+    const timer = setTimeout(() => {
+      motionValue.set(direction === "down" ? startValue : value)
+    }, delay * 1000)
+    return () => clearTimeout(timer)
+  }, [motionValue, isInView, delay, value, direction, startValue, shouldAnimate])
 
   // Subsequent value changes: spring smoothly to new value (auto-refresh)
   useEffect(() => {
-    if (hasAnimated.current) {
+    if (hasAnimated.current && shouldAnimate) {
       motionValue.set(direction === "down" ? startValue : value)
     }
-  }, [motionValue, value, direction, startValue])
+  }, [motionValue, value, direction, startValue, shouldAnimate])
 
-  useEffect(
-    () =>
-      springValue.on("change", (latest) => {
-        if (ref.current) {
-          ref.current.textContent = Intl.NumberFormat("en-US", {
-            minimumFractionDigits: decimalPlaces,
-            maximumFractionDigits: decimalPlaces,
-          }).format(Number(latest.toFixed(decimalPlaces)))
-        }
-      }),
-    [springValue, decimalPlaces]
-  )
+  useEffect(() => {
+    const updateText = (latest: number) => {
+      if (!ref.current) {
+        return
+      }
+
+      ref.current.textContent = formatter.format(Number(latest.toFixed(decimalPlaces)))
+    }
+
+    if (!shouldAnimate) {
+      updateText(value)
+      return
+    }
+
+    updateText(springValue.get())
+    return springValue.on("change", updateText)
+  }, [springValue, decimalPlaces, formatter, shouldAnimate, value])
 
   return (
     <span
       ref={ref}
-      className={cn(
-        "inline-block tracking-wider text-black tabular-nums dark:text-white",
-        className
-      )}
+      className={cn(numberTickerTextClassName, className)}
       {...props}
     >
-      {startValue}
+      {shouldAnimate ? startValue : formatter.format(Number(value.toFixed(decimalPlaces)))}
     </span>
   )
 }

--- a/admin-ui/src/lib/format.ts
+++ b/admin-ui/src/lib/format.ts
@@ -1,3 +1,205 @@
+const numberLocale = "en-US"
+
+export interface AdaptiveNumberFormatCandidate {
+  text: string
+  formatOptions: Intl.NumberFormatOptions
+}
+
+export interface AdaptiveNumberPairCandidate {
+  primaryCandidate: AdaptiveNumberFormatCandidate
+  secondaryCandidate: AdaptiveNumberFormatCandidate
+  text: string
+}
+
+export function formatNumberWithOptions(
+  value: number,
+  formatOptions?: Intl.NumberFormatOptions
+): string {
+  return Intl.NumberFormat(numberLocale, formatOptions).format(value)
+}
+
+function normalizeDecimalPlaces(decimalPlaces = 0): number {
+  return Math.max(0, decimalPlaces)
+}
+
+function roundNumberForDisplay(value: number, decimalPlaces: number): number {
+  return Number(value.toFixed(decimalPlaces))
+}
+
+function shouldBuildCompactNumberCandidates(
+  value: number,
+  decimalPlaces: number
+): boolean {
+  return Math.abs(roundNumberForDisplay(value, decimalPlaces)) >= 1000
+}
+
+function dedupeAdaptiveNumberFormatCandidates(
+  candidates: AdaptiveNumberFormatCandidate[]
+): AdaptiveNumberFormatCandidate[] {
+  const seen = new Set<string>()
+
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate.text)) {
+      return false
+    }
+
+    seen.add(candidate.text)
+    return true
+  })
+}
+
+function dedupeAdaptiveNumberPairCandidates(
+  candidates: AdaptiveNumberPairCandidate[]
+): AdaptiveNumberPairCandidate[] {
+  const seen = new Set<string>()
+
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate.text)) {
+      return false
+    }
+
+    seen.add(candidate.text)
+    return true
+  })
+}
+
+export function buildAdaptiveNumberFormatCandidates(
+  value: number,
+  decimalPlaces = 0
+): AdaptiveNumberFormatCandidate[] {
+  const normalizedDecimalPlaces = normalizeDecimalPlaces(decimalPlaces)
+  const fullFormatOptions: Intl.NumberFormatOptions = {
+    minimumFractionDigits: normalizedDecimalPlaces,
+    maximumFractionDigits: normalizedDecimalPlaces,
+  }
+  const fullCandidate: AdaptiveNumberFormatCandidate = {
+    text: formatNumberWithOptions(value, fullFormatOptions),
+    formatOptions: fullFormatOptions,
+  }
+
+  if (!shouldBuildCompactNumberCandidates(value, normalizedDecimalPlaces)) {
+    return [fullCandidate]
+  }
+
+  const compactDecimalPlaces = Math.max(1, normalizedDecimalPlaces)
+  const compactWithPrecision: AdaptiveNumberFormatCandidate = {
+    text: formatNumberWithOptions(value, {
+      notation: "compact",
+      compactDisplay: "short",
+      minimumFractionDigits: compactDecimalPlaces,
+      maximumFractionDigits: compactDecimalPlaces,
+    }),
+    formatOptions: {
+      notation: "compact",
+      compactDisplay: "short",
+      minimumFractionDigits: compactDecimalPlaces,
+      maximumFractionDigits: compactDecimalPlaces,
+    },
+  }
+  const compactWithoutFraction: AdaptiveNumberFormatCandidate = {
+    text: formatNumberWithOptions(value, {
+      notation: "compact",
+      compactDisplay: "short",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }),
+    formatOptions: {
+      notation: "compact",
+      compactDisplay: "short",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    },
+  }
+
+  return dedupeAdaptiveNumberFormatCandidates([
+    fullCandidate,
+    compactWithPrecision,
+    compactWithoutFraction,
+  ])
+}
+
+export function buildAdaptiveNumberPairCandidates(
+  primaryValue: number,
+  secondaryValue: number,
+  primaryDecimalPlaces = 0,
+  secondaryDecimalPlaces = 0,
+  separator = " / "
+): AdaptiveNumberPairCandidate[] {
+  const primaryCandidates = buildAdaptiveNumberFormatCandidates(
+    primaryValue,
+    primaryDecimalPlaces
+  )
+  const secondaryCandidates = buildAdaptiveNumberFormatCandidates(
+    secondaryValue,
+    secondaryDecimalPlaces
+  )
+  const candidates: AdaptiveNumberPairCandidate[] = []
+  const maxLevel = primaryCandidates.length + secondaryCandidates.length - 2
+
+  for (let level = 0; level <= maxLevel; level += 1) {
+    for (
+      let primaryIndex = Math.min(level, primaryCandidates.length - 1);
+      primaryIndex >= 0;
+      primaryIndex -= 1
+    ) {
+      const secondaryIndex = level - primaryIndex
+      if (secondaryIndex < 0 || secondaryIndex >= secondaryCandidates.length) {
+        continue
+      }
+
+      const primaryCandidate = primaryCandidates[primaryIndex]
+      const secondaryCandidate = secondaryCandidates[secondaryIndex]
+      candidates.push({
+        primaryCandidate,
+        secondaryCandidate,
+        text: `${primaryCandidate.text}${separator}${secondaryCandidate.text}`,
+      })
+    }
+  }
+
+  return dedupeAdaptiveNumberPairCandidates(candidates)
+}
+
+export function pickAdaptiveNumberFormatCandidate(
+  candidates: readonly AdaptiveNumberFormatCandidate[],
+  fits: (candidate: AdaptiveNumberFormatCandidate) => boolean
+): AdaptiveNumberFormatCandidate {
+  return candidates.find(fits) ?? candidates[candidates.length - 1] ?? { text: "", formatOptions: {} }
+}
+
+export function pickAdaptiveNumberPairCandidate(
+  candidates: readonly AdaptiveNumberPairCandidate[],
+  fits: (candidate: AdaptiveNumberPairCandidate) => boolean
+): AdaptiveNumberPairCandidate {
+  return candidates.find(fits) ?? candidates[candidates.length - 1] ?? {
+    primaryCandidate: { text: "", formatOptions: {} },
+    secondaryCandidate: { text: "", formatOptions: {} },
+    text: "",
+  }
+}
+
+export function resolveAdaptiveNumberFormatCandidate(
+  candidates: readonly AdaptiveNumberFormatCandidate[],
+  currentCandidate?: AdaptiveNumberFormatCandidate
+): AdaptiveNumberFormatCandidate {
+  return candidates.find((candidate) => candidate.text === currentCandidate?.text)
+    ?? candidates[candidates.length - 1]
+    ?? { text: "", formatOptions: {} }
+}
+
+export function resolveAdaptiveNumberPairCandidate(
+  candidates: readonly AdaptiveNumberPairCandidate[],
+  currentCandidate?: AdaptiveNumberPairCandidate
+): AdaptiveNumberPairCandidate {
+  return candidates.find((candidate) => candidate.text === currentCandidate?.text)
+    ?? candidates[candidates.length - 1]
+    ?? {
+      primaryCandidate: { text: "", formatOptions: {} },
+      secondaryCandidate: { text: "", formatOptions: {} },
+      text: "",
+    }
+}
+
 export function fmtIso(ms?: number | null): string {
   if (ms == null) return ""
   const d = new Date(ms)
@@ -26,7 +228,7 @@ export function fmtLocalDateTime(ms?: number | null): string {
 export function fmtNum(n?: number | null): string {
   if (n == null) return ""
   if (!Number.isFinite(n)) return ""
-  return Intl.NumberFormat("en-US").format(n)
+  return formatNumberWithOptions(n)
 }
 
 export function fmtDurationSeconds(ms?: number | null): string {

--- a/admin-ui/src/lib/statistics-range.ts
+++ b/admin-ui/src/lib/statistics-range.ts
@@ -1,0 +1,44 @@
+export type StatisticsTimePreset = "today" | "7d" | "month" | "custom"
+
+export type StatisticsRange = {
+  from: string
+  to: string
+  granularity: "day" | "hour"
+}
+
+function toDateString(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, "0")
+  const d = String(date.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
+}
+
+export function resolveStatisticsRange(params: {
+  preset: StatisticsTimePreset
+  customFrom: string
+  customTo: string
+  now?: Date
+}): StatisticsRange {
+  const { preset, customFrom, customTo, now = new Date() } = params
+  const today = toDateString(now)
+
+  if (preset === "today") {
+    return { from: today, to: today, granularity: "hour" }
+  }
+
+  if (preset === "7d") {
+    const weekAgo = new Date(now.getTime() - 7 * 86_400_000)
+    return { from: toDateString(weekAgo), to: today, granularity: "day" }
+  }
+
+  if (preset === "month") {
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    return { from: toDateString(startOfMonth), to: today, granularity: "day" }
+  }
+
+  return {
+    from: customFrom || today,
+    to: customTo || today,
+    granularity: "day",
+  }
+}

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -563,7 +563,7 @@
     "tokensTotal": "Total Tokens",
     "errorCount": "Errors",
     "timeRange": {
-      "24h": "24h",
+      "today": "Today",
       "7d": "7 Days",
       "month": "This Month",
       "custom": "Custom"

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -563,7 +563,7 @@
     "tokensTotal": "总 Token 数",
     "errorCount": "错误数",
     "timeRange": {
-      "24h": "24 小时",
+      "today": "今日",
       "7d": "7 天",
       "month": "本月",
       "custom": "自定义"

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -50,7 +50,10 @@ import { Progress } from "@/components/ui/progress"
 import { Switch } from "@/components/ui/switch"
 import { BentoGrid } from "@/components/ui/bento-grid"
 import { MagicCard } from "@/components/ui/magic-card"
-import { NumberTicker } from "@/components/ui/number-ticker"
+import {
+  AdaptiveNumberPair,
+  AdaptiveNumberTicker,
+} from "@/components/ui/adaptive-number-ticker"
 import { Button } from "@/components/ui/button"
 import { RainbowButton } from "@/components/ui/rainbow-button"
 import { AddAccountDialog } from "@/components/add-account-dialog"
@@ -111,7 +114,7 @@ function KpiValue({
   value: number
   decimalPlaces?: number
 }): React.JSX.Element {
-  return <NumberTicker value={value} decimalPlaces={decimalPlaces} />
+  return <AdaptiveNumberTicker value={value} decimalPlaces={decimalPlaces} />
 }
 
 function KpiLabel({
@@ -512,7 +515,7 @@ export function AccountsPage(): React.JSX.Element {
           >
             <div className="p-4">
               <KpiLabel label={kpi.label} tooltip={kpi.tooltip} />
-              <div className="mt-1 flex items-baseline gap-1 text-2xl font-semibold">
+              <div className="mt-1 flex min-w-0 items-baseline gap-1 text-2xl font-semibold">
                 <KpiValue value={kpi.value} />
               </div>
             </div>
@@ -535,12 +538,11 @@ export function AccountsPage(): React.JSX.Element {
               </div>
             ) : (
               <>
-                <div className="mt-1 flex items-baseline gap-1 text-2xl font-semibold">
-                  <KpiValue value={kpis.totalPremiumUsed} />
-                  <span className="text-muted-foreground text-sm">
-                    / {fmtNum(kpis.totalPremiumEntitlement)}
-                  </span>
-                </div>
+                <AdaptiveNumberPair
+                  className="mt-1 text-2xl font-semibold"
+                  primaryValue={kpis.totalPremiumUsed}
+                  secondaryValue={kpis.totalPremiumEntitlement}
+                />
                 <Progress
                   value={kpis.premiumUsedPercent}
                   className="mt-1.5 h-1.5"
@@ -567,7 +569,7 @@ export function AccountsPage(): React.JSX.Element {
           >
             <div className="p-4">
               <KpiLabel label={kpi.label} tooltip={kpi.tooltip} />
-              <div className="mt-1 flex items-baseline gap-1 text-2xl font-semibold">
+              <div className="mt-1 flex min-w-0 items-baseline gap-1 text-2xl font-semibold">
                 <KpiValue value={kpi.value} decimalPlaces={kpi.decimal ?? 0} />
                 {kpi.suffix ? <span className="text-muted-foreground text-sm">{kpi.suffix}</span> : null}
               </div>

--- a/admin-ui/src/pages/statistics-page.tsx
+++ b/admin-ui/src/pages/statistics-page.tsx
@@ -2,6 +2,15 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
+import { AccountUsageChart } from "@/components/charts/account-usage-chart"
+import { PremiumUsageChart } from "@/components/charts/premium-usage-chart"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   AdminApiError,
   type DailyAccountStatsItem,
@@ -10,54 +19,11 @@ import {
 } from "@/lib/admin-api"
 import { i18n } from "@/lib/i18n"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { PremiumUsageChart } from "@/components/charts/premium-usage-chart"
-import { AccountUsageChart } from "@/components/charts/account-usage-chart"
+  type StatisticsTimePreset,
+  resolveStatisticsRange,
+} from "@/lib/statistics-range"
 
-type TimePreset = "24h" | "7d" | "month" | "custom"
-
-function toDateString(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, "0")
-  const d = String(date.getDate()).padStart(2, "0")
-  return `${y}-${m}-${d}`
-}
-
-function presetToRange(preset: TimePreset, customFrom: string, customTo: string): {
-  from: string
-  to: string
-  granularity: "day" | "hour"
-} {
-  const now = new Date()
-  const today = toDateString(now)
-
-  if (preset === "24h") {
-    const yesterday = new Date(now.getTime() - 86_400_000)
-    return { from: toDateString(yesterday), to: today, granularity: "hour" }
-  }
-
-  if (preset === "7d") {
-    const weekAgo = new Date(now.getTime() - 7 * 86_400_000)
-    return { from: toDateString(weekAgo), to: today, granularity: "day" }
-  }
-
-  if (preset === "month") {
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
-    return { from: toDateString(startOfMonth), to: today, granularity: "day" }
-  }
-
-  // custom
-  return {
-    from: customFrom || today,
-    to: customTo || today,
-    granularity: "day",
-  }
-}
+type TimePreset = StatisticsTimePreset
 
 export function StatisticsPage(): React.JSX.Element {
   const { t } = useTranslation()
@@ -81,7 +47,11 @@ export function StatisticsPage(): React.JSX.Element {
     setLoading(true)
 
     try {
-      const range = presetToRange(preset, customFrom, customTo)
+      const range = resolveStatisticsRange({
+        preset,
+        customFrom,
+        customTo,
+      })
       const res = await getAdminPremiumStats({
         from: range.from,
         to: range.to,
@@ -146,15 +116,24 @@ export function StatisticsPage(): React.JSX.Element {
         <h1 className="text-xl font-semibold">{t("statistics.title")}</h1>
 
         <div className="flex items-center gap-2">
-          <Select value={preset} onValueChange={(v) => setPreset(v as TimePreset)}>
+          <Select
+            value={preset}
+            onValueChange={(v) => setPreset(v as TimePreset)}
+          >
             <SelectTrigger size="sm" className="w-32">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="24h">{t("statistics.timeRange.24h")}</SelectItem>
+              <SelectItem value="today">
+                {t("statistics.timeRange.today")}
+              </SelectItem>
               <SelectItem value="7d">{t("statistics.timeRange.7d")}</SelectItem>
-              <SelectItem value="month">{t("statistics.timeRange.month")}</SelectItem>
-              <SelectItem value="custom">{t("statistics.timeRange.custom")}</SelectItem>
+              <SelectItem value="month">
+                {t("statistics.timeRange.month")}
+              </SelectItem>
+              <SelectItem value="custom">
+                {t("statistics.timeRange.custom")}
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -184,31 +163,41 @@ export function StatisticsPage(): React.JSX.Element {
               <span className="bg-primary relative inline-flex h-2 w-2 rounded-full" />
             </span>
           )}
-          <Select value={String(autoRefreshMs)} onValueChange={(v) => setAutoRefreshMs(Number(v))}>
+          <Select
+            value={String(autoRefreshMs)}
+            onValueChange={(v) => setAutoRefreshMs(Number(v))}
+          >
             <SelectTrigger size="sm" className="w-40">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="0">{t("statistics.autoRefresh.off")}</SelectItem>
-              <SelectItem value="30000">{t("statistics.autoRefresh.30s")}</SelectItem>
-              <SelectItem value="60000">{t("statistics.autoRefresh.60s")}</SelectItem>
-              <SelectItem value="300000">{t("statistics.autoRefresh.5m")}</SelectItem>
+              <SelectItem value="0">
+                {t("statistics.autoRefresh.off")}
+              </SelectItem>
+              <SelectItem value="30000">
+                {t("statistics.autoRefresh.30s")}
+              </SelectItem>
+              <SelectItem value="60000">
+                {t("statistics.autoRefresh.60s")}
+              </SelectItem>
+              <SelectItem value="300000">
+                {t("statistics.autoRefresh.5m")}
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>
       </div>
 
-      {loading && daily.length === 0 ? (
+      {loading && daily.length === 0 ?
         <div className="space-y-6">
           <div className="bg-muted h-[380px] animate-pulse rounded-xl" />
           <div className="bg-muted h-[380px] animate-pulse rounded-xl" />
         </div>
-      ) : (
-        <>
+      : <>
           <PremiumUsageChart data={daily} isHourly={isHourly} />
           <AccountUsageChart data={byAccount} isHourly={isHourly} />
         </>
-      )}
+      }
     </div>
   )
 }

--- a/admin-ui/tests/adaptive-number-format.test.ts
+++ b/admin-ui/tests/adaptive-number-format.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+
+import * as format from "../src/lib/format"
+import {
+  buildAdaptiveNumberFormatCandidates,
+  buildAdaptiveNumberPairCandidates,
+  pickAdaptiveNumberFormatCandidate,
+  pickAdaptiveNumberPairCandidate,
+} from "../src/lib/format"
+
+test("buildAdaptiveNumberFormatCandidates returns full and compact fallbacks for large values", () => {
+  const candidates = buildAdaptiveNumberFormatCandidates(1001802257)
+
+  expect(candidates.map((candidate) => candidate.text)).toEqual([
+    "1,001,802,257",
+    "1.0B",
+    "1B",
+  ])
+})
+
+test("buildAdaptiveNumberFormatCandidates keeps exact precision for smaller values", () => {
+  const candidates = buildAdaptiveNumberFormatCandidates(123.4, 1)
+
+  expect(candidates.map((candidate) => candidate.text)).toEqual(["123.4"])
+})
+
+test("buildAdaptiveNumberFormatCandidates adds compact fallbacks when rounded display crosses 1000", () => {
+  const candidates = buildAdaptiveNumberFormatCandidates(999.95, 1)
+
+  expect(candidates.map((candidate) => candidate.text)).toEqual([
+    "1,000.0",
+    "1.0K",
+    "1K",
+  ])
+})
+
+test("buildAdaptiveNumberPairCandidates degrades the primary value before the secondary value", () => {
+  const candidates = buildAdaptiveNumberPairCandidates(1001802257, 1001802257)
+
+  expect(candidates[0]?.text).toBe("1,001,802,257 / 1,001,802,257")
+  expect(candidates[1]?.text).toBe("1.0B / 1,001,802,257")
+  expect(candidates[candidates.length - 1]?.text).toBe("1B / 1B")
+})
+
+test("pickAdaptiveNumberFormatCandidate returns the first candidate that fits", () => {
+  const candidates = buildAdaptiveNumberFormatCandidates(1001802257)
+
+  const selected = pickAdaptiveNumberFormatCandidate(candidates, (candidate) => candidate.text.length <= 4)
+
+  expect(selected.text).toBe("1.0B")
+})
+
+test("pickAdaptiveNumberFormatCandidate falls back to the shortest candidate when none fit", () => {
+  const candidates = buildAdaptiveNumberFormatCandidates(1001802257)
+
+  const selected = pickAdaptiveNumberFormatCandidate(candidates, () => false)
+
+  expect(selected.text).toBe("1B")
+})
+
+test("pickAdaptiveNumberPairCandidate returns the first pair that fits", () => {
+  const candidates = buildAdaptiveNumberPairCandidates(1001802257, 1001802257)
+
+  const selected = pickAdaptiveNumberPairCandidate(candidates, (candidate) => candidate.text.length <= 9)
+
+  expect(selected.text).toBe("1B / 1.0B")
+})
+
+test("pickAdaptiveNumberPairCandidate falls back to the shortest pair when none fit", () => {
+  const candidates = buildAdaptiveNumberPairCandidates(1001802257, 1001802257)
+
+  const selected = pickAdaptiveNumberPairCandidate(candidates, () => false)
+
+  expect(selected.text).toBe("1B / 1B")
+})
+
+test("resolveAdaptiveNumberFormatCandidate reuses the current candidate when it still exists", () => {
+  const candidates = buildAdaptiveNumberFormatCandidates(1001802257)
+  const currentCandidate = candidates[1]
+
+  expect(
+    format.resolveAdaptiveNumberFormatCandidate?.(candidates, currentCandidate),
+  ).toEqual(currentCandidate)
+})
+
+test("resolveAdaptiveNumberFormatCandidate falls back to the shortest candidate when the current one is stale", () => {
+  const currentCandidate = buildAdaptiveNumberFormatCandidates(1001802257)[0]
+  const nextCandidates = buildAdaptiveNumberFormatCandidates(1000)
+
+  expect(
+    format.resolveAdaptiveNumberFormatCandidate?.(nextCandidates, currentCandidate),
+  ).toEqual(nextCandidates[nextCandidates.length - 1])
+})
+
+test("resolveAdaptiveNumberPairCandidate falls back to the shortest pair when the current pair is stale", () => {
+  const currentCandidate = buildAdaptiveNumberPairCandidates(1001802257, 1001802257)[0]
+  const nextCandidates = buildAdaptiveNumberPairCandidates(1000, 1000)
+
+  expect(
+    format.resolveAdaptiveNumberPairCandidate?.(nextCandidates, currentCandidate),
+  ).toEqual(nextCandidates[nextCandidates.length - 1])
+})

--- a/admin-ui/tests/adaptive-number-format.test.ts
+++ b/admin-ui/tests/adaptive-number-format.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "bun:test"
 
-import * as format from "../src/lib/format"
 import {
   buildAdaptiveNumberFormatCandidates,
   buildAdaptiveNumberPairCandidates,
   pickAdaptiveNumberFormatCandidate,
   pickAdaptiveNumberPairCandidate,
+  resolveAdaptiveNumberFormatCandidate,
+  resolveAdaptiveNumberPairCandidate,
 } from "../src/lib/format"
 
 test("buildAdaptiveNumberFormatCandidates returns full and compact fallbacks for large values", () => {
@@ -79,7 +80,7 @@ test("resolveAdaptiveNumberFormatCandidate reuses the current candidate when it 
   const currentCandidate = candidates[1]
 
   expect(
-    format.resolveAdaptiveNumberFormatCandidate?.(candidates, currentCandidate),
+    resolveAdaptiveNumberFormatCandidate(candidates, currentCandidate),
   ).toEqual(currentCandidate)
 })
 
@@ -88,7 +89,7 @@ test("resolveAdaptiveNumberFormatCandidate falls back to the shortest candidate 
   const nextCandidates = buildAdaptiveNumberFormatCandidates(1000)
 
   expect(
-    format.resolveAdaptiveNumberFormatCandidate?.(nextCandidates, currentCandidate),
+    resolveAdaptiveNumberFormatCandidate(nextCandidates, currentCandidate),
   ).toEqual(nextCandidates[nextCandidates.length - 1])
 })
 
@@ -97,6 +98,6 @@ test("resolveAdaptiveNumberPairCandidate falls back to the shortest pair when th
   const nextCandidates = buildAdaptiveNumberPairCandidates(1000, 1000)
 
   expect(
-    format.resolveAdaptiveNumberPairCandidate?.(nextCandidates, currentCandidate),
+    resolveAdaptiveNumberPairCandidate(nextCandidates, currentCandidate),
   ).toEqual(nextCandidates[nextCandidates.length - 1])
 })

--- a/admin-ui/tests/adaptive-number-ticker.test.tsx
+++ b/admin-ui/tests/adaptive-number-ticker.test.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { AdaptiveNumberPair } from "../src/components/ui/adaptive-number-ticker"
+
+test("AdaptiveNumberPair does not forward internal measurement props to the DOM", () => {
+  const html = renderToStaticMarkup(
+    <AdaptiveNumberPair
+      primaryValue={1001802257}
+      secondaryValue={1001802257}
+      secondaryDecimalPlaces={2}
+      data-testid="adaptive-pair"
+    />
+  )
+
+  expect(html).toContain("data-testid=\"adaptive-pair\"")
+  expect(html).not.toContain("secondaryValue")
+  expect(html).not.toContain("secondaryDecimalPlaces")
+})

--- a/admin-ui/tests/statistics-range.test.ts
+++ b/admin-ui/tests/statistics-range.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+
+async function loadRangeModule() {
+  return (await import("../src/lib/statistics-range").catch(() => null)) as
+    | null
+    | typeof import("../src/lib/statistics-range");
+}
+
+test("resolveStatisticsRange maps today preset to a same-day hourly range", async () => {
+  const fixedNow = new Date("2026-04-15T13:45:00");
+  const mod = await loadRangeModule();
+
+  expect(
+    mod?.resolveStatisticsRange({
+      preset: "today",
+      customFrom: "",
+      customTo: "",
+      now: fixedNow,
+    }),
+  ).toEqual({
+    from: "2026-04-15",
+    to: "2026-04-15",
+    granularity: "hour",
+  });
+});
+
+test("resolveStatisticsRange keeps 7d as a daily calendar range", async () => {
+  const fixedNow = new Date("2026-04-15T13:45:00");
+  const mod = await loadRangeModule();
+
+  expect(
+    mod?.resolveStatisticsRange({
+      preset: "7d",
+      customFrom: "",
+      customTo: "",
+      now: fixedNow,
+    }),
+  ).toEqual({
+    from: "2026-04-08",
+    to: "2026-04-15",
+    granularity: "day",
+  });
+});

--- a/admin-ui/tests/statistics-range.test.ts
+++ b/admin-ui/tests/statistics-range.test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "bun:test";
 
 async function loadRangeModule() {
-  return (await import("../src/lib/statistics-range").catch(() => null)) as
-    | null
-    | typeof import("../src/lib/statistics-range");
+  return import("../src/lib/statistics-range");
 }
 
 test("resolveStatisticsRange maps today preset to a same-day hourly range", async () => {
@@ -11,7 +9,7 @@ test("resolveStatisticsRange maps today preset to a same-day hourly range", asyn
   const mod = await loadRangeModule();
 
   expect(
-    mod?.resolveStatisticsRange({
+    mod.resolveStatisticsRange({
       preset: "today",
       customFrom: "",
       customTo: "",
@@ -29,7 +27,7 @@ test("resolveStatisticsRange keeps 7d as a daily calendar range", async () => {
   const mod = await loadRangeModule();
 
   expect(
-    mod?.resolveStatisticsRange({
+    mod.resolveStatisticsRange({
       preset: "7d",
       customFrom: "",
       customTo: "",
@@ -38,6 +36,42 @@ test("resolveStatisticsRange keeps 7d as a daily calendar range", async () => {
   ).toEqual({
     from: "2026-04-08",
     to: "2026-04-15",
+    granularity: "day",
+  });
+});
+
+test("resolveStatisticsRange maps month preset to the first day of the month", async () => {
+  const fixedNow = new Date("2026-04-15T13:45:00");
+  const mod = await loadRangeModule();
+
+  expect(
+    mod.resolveStatisticsRange({
+      preset: "month",
+      customFrom: "",
+      customTo: "",
+      now: fixedNow,
+    }),
+  ).toEqual({
+    from: "2026-04-01",
+    to: "2026-04-15",
+    granularity: "day",
+  });
+});
+
+test("resolveStatisticsRange uses custom dates when provided", async () => {
+  const fixedNow = new Date("2026-04-15T13:45:00");
+  const mod = await loadRangeModule();
+
+  expect(
+    mod.resolveStatisticsRange({
+      preset: "custom",
+      customFrom: "2026-03-01",
+      customTo: "2026-03-31",
+      now: fixedNow,
+    }),
+  ).toEqual({
+    from: "2026-03-01",
+    to: "2026-03-31",
     granularity: "day",
   });
 });


### PR DESCRIPTION
## Summary
- replace the statistics 24h preset with a today/hourly range helper so the chart only shows current-day premium usage
- add adaptive number ticker/pair behavior for KPI displays and remove effect-driven candidate resets plus leaked pair props
- add regression coverage for statistics ranges, adaptive candidate reuse, and DOM prop forwarding

## Test plan
- [x] bun test "/Volumes/Nick-OMV-Storage/Workspace/copilot-api/admin-ui/tests"
- [x] bun run --cwd "/Volumes/Nick-OMV-Storage/Workspace/copilot-api" build:admin
- [x] bun run --cwd "/Volumes/Nick-OMV-Storage/Workspace/copilot-api" lint:admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强了仪表板数字显示的响应式布局，确保数据在各种屏幕宽度下正确呈现
  * 优化了配对数值展示（如已用/总配额）的自适应格式化

* **改进**
  * 将统计页面的时间范围选项从"24小时"更新为"今日"
  * 改进了 KPI 值容器的大小控制和排版行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->