### PR TITLE
fix: align admin-ui time handling with local time

### DIFF
--- a/admin-ui/src/components/charts/account-usage-chart.tsx
+++ b/admin-ui/src/components/charts/account-usage-chart.tsx
@@ -12,6 +12,12 @@ import {
 
 import type { DailyAccountStatsItem } from "@/lib/admin-api"
 import {
+  formatDailyLabel,
+  formatHourlyLabel,
+  formatHourlyTooltip,
+  hourlyDataCrossesDays,
+} from "@/lib/chart-format"
+import {
   Card,
   CardContent,
   CardHeader,
@@ -37,15 +43,16 @@ function renderTooltip(
   const payload = props.payload as
     | ReadonlyArray<{ payload?: Record<string, number | string> }>
     | undefined
-  const label = props.label as string | number | undefined
 
   if (!active || !payload?.length) return null
   const row = payload[0]?.payload
   if (!row) return null
 
+  const header = (row.tooltipDate as string | undefined) ?? String(row.label ?? "")
+
   return (
     <div className="bg-popover text-popover-foreground rounded-md border px-3 py-2 text-xs shadow-md">
-      <div className="mb-1 font-medium">{String(label ?? "")}</div>
+      <div className="mb-1 font-medium">{header}</div>
       <div className="space-y-0.5">
         {accountIds.map((id, idx) => (
           <div key={id} className="flex items-center justify-between gap-4">
@@ -62,15 +69,6 @@ function renderTooltip(
       </div>
     </div>
   )
-}
-
-function formatXLabel(dateStr: string, isHourly: boolean): string {
-  if (isHourly) {
-    const match = /(\d{2}):00/.exec(dateStr) ?? /T(\d{2})/.exec(dateStr)
-    return match ? `${match[1]}:00` : dateStr
-  }
-  const match = /(\d{2})-(\d{2})$/.exec(dateStr)
-  return match ? `${match[1]}-${match[2]}` : dateStr
 }
 
 export function AccountUsageChart({
@@ -99,18 +97,31 @@ export function AccountUsageChart({
 
     const ids = [...accountSet]
 
+    const sortedEntries = [...dateMap.entries()].sort(([a], [b]) => a.localeCompare(b))
+    const crossesDays = isHourly ? hourlyDataCrossesDays(sortedEntries.map(([date]) => date)) : false
+    const baseLabels = isHourly ? sortedEntries.map(([date]) => formatHourlyLabel(date, crossesDays)) : []
+    const duplicateLabels = new Set(
+      baseLabels.filter((label, index) => baseLabels.indexOf(label) !== index),
+    )
+
     // Zero-fill: ensure every date row has a value for every account
-    const rows = [...dateMap.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, values]) => {
-        const row: Record<string, number | string> = {
-          label: formatXLabel(date, isHourly),
-        }
-        for (const id of ids) {
-          row[id] = values[id] ?? 0
-        }
-        return row
-      })
+    const rows = sortedEntries.map(([date, values], index) => {
+      const baseLabel = baseLabels[index]
+      const includeOffset = isHourly && duplicateLabels.has(baseLabel)
+      const row: Record<string, number | string> = {
+        label:
+          isHourly ?
+            formatHourlyLabel(date, crossesDays, { includeOffset })
+          : formatDailyLabel(date),
+      }
+      if (isHourly) {
+        row.tooltipDate = formatHourlyTooltip(date, { includeOffset: true })
+      }
+      for (const id of ids) {
+        row[id] = values[id] ?? 0
+      }
+      return row
+    })
 
     return { pivoted: rows, accountIds: ids }
   }, [data, isHourly])

--- a/admin-ui/src/components/charts/premium-usage-chart.tsx
+++ b/admin-ui/src/components/charts/premium-usage-chart.tsx
@@ -12,20 +12,19 @@ import {
 
 import type { DailyStatsItem } from "@/lib/admin-api"
 import {
+  formatDailyLabel,
+  formatHourlyLabel,
+  formatHourlyTooltip,
+  hourlyDataCrossesDays,
+} from "@/lib/chart-format"
+import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
 
-function formatXLabel(dateStr: string, isHourly: boolean): string {
-  if (isHourly) {
-    const match = /(\d{2}):00/.exec(dateStr) ?? /T(\d{2})/.exec(dateStr)
-    return match ? `${match[1]}:00` : dateStr
-  }
-  const match = /(\d{2})-(\d{2})$/.exec(dateStr)
-  return match ? `${match[1]}-${match[2]}` : dateStr
-}
+type ChartItem = DailyStatsItem & { label: string; tooltipDate?: string }
 
 function renderTooltip(
   t: (key: string) => string,
@@ -34,17 +33,18 @@ function renderTooltip(
 ): React.JSX.Element | null {
   const active = props.active as boolean | undefined
   const payload = props.payload as
-    | ReadonlyArray<{ payload?: DailyStatsItem }>
+    | ReadonlyArray<{ payload?: ChartItem }>
     | undefined
-  const label = props.label as string | number | undefined
 
   if (!active || !payload?.length) return null
   const item = payload[0]?.payload
   if (!item) return null
 
+  const header = item.tooltipDate ?? String(item.label ?? "")
+
   return (
     <div className="bg-popover text-popover-foreground rounded-md border px-3 py-2 text-xs shadow-md">
-      <div className="mb-1 font-medium">{String(label ?? "")}</div>
+      <div className="mb-1 font-medium">{header}</div>
       <div className="space-y-0.5">
         <div className="flex justify-between gap-4">
           <span className="text-muted-foreground">
@@ -92,14 +92,30 @@ export function PremiumUsageChart({
 }): React.JSX.Element {
   const { t } = useTranslation()
 
-  const chartData = useMemo(
-    () =>
-      data.map((d) => ({
+  const chartData = useMemo(() => {
+    if (!isHourly) {
+      return data.map((d) => ({
         ...d,
-        label: formatXLabel(d.date, isHourly),
-      })),
-    [data, isHourly],
-  )
+        label: formatDailyLabel(d.date),
+      }))
+    }
+
+    const crossesDays = hourlyDataCrossesDays(data.map((d) => d.date))
+    const baseLabels = data.map((d) => formatHourlyLabel(d.date, crossesDays))
+    const duplicateLabels = new Set(
+      baseLabels.filter((label, index) => baseLabels.indexOf(label) !== index),
+    )
+
+    return data.map((d, index) => {
+      const baseLabel = baseLabels[index]
+      const includeOffset = duplicateLabels.has(baseLabel)
+      return {
+        ...d,
+        label: formatHourlyLabel(d.date, crossesDays, { includeOffset }),
+        tooltipDate: formatHourlyTooltip(d.date, { includeOffset: true }),
+      }
+    })
+  }, [data, isHourly])
 
   return (
     <Card>

--- a/admin-ui/src/lib/accounts-export.ts
+++ b/admin-ui/src/lib/accounts-export.ts
@@ -1,0 +1,43 @@
+import type { AdminAccountItem } from "@/lib/admin-api"
+import { fmtDurationSeconds, fmtLocalDateTime } from "@/lib/format"
+
+function escapeCsvCell(value: string): string {
+  const neutralized = /^[=+\-@]/u.test(value) ? `'${value}` : value
+  return `"${neutralized.replaceAll('"', '""')}"`
+}
+
+export function getAccountsCsvFilename(now: Date = new Date()): string {
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, "0")
+  const dd = String(now.getDate()).padStart(2, "0")
+  return `accounts-${yyyy}-${mm}-${dd}.csv`
+}
+
+export function buildAccountsCsv(accounts: readonly AdminAccountItem[]): string {
+  const headers = [
+    "account_id",
+    "status",
+    "account_type",
+    "requests",
+    "errors",
+    "tokens",
+    "avg_duration_s",
+    "last_request",
+  ]
+
+  const rows = accounts.map((account) => [
+    account.account_id,
+    account.runtime?.failed ? "failed" : "ok",
+    account.account_type ?? "free",
+    String(account.stats?.request_count ?? 0),
+    String(account.stats?.error_count ?? 0),
+    String(account.stats?.tokens_total ?? 0),
+    fmtDurationSeconds(account.stats?.avg_duration_ms),
+    fmtLocalDateTime(account.stats?.last_request_at_ms),
+  ])
+
+  return [
+    headers.join(","),
+    ...rows.map((row) => row.map((cell) => escapeCsvCell(cell)).join(",")),
+  ].join("\n")
+}

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -355,12 +355,16 @@ export async function getAdminPremiumStats(params: {
   to?: string
   accountId?: string
   granularity?: "day" | "hour"
+  fromMs?: number
+  toMs?: number
 }): Promise<PremiumStatsResponse> {
   const q = new URLSearchParams()
   if (params.from) q.set("from", params.from)
   if (params.to) q.set("to", params.to)
   if (params.accountId) q.set("account_id", params.accountId)
   if (params.granularity) q.set("granularity", params.granularity)
+  if (params.fromMs != null) q.set("from_ms", String(params.fromMs))
+  if (params.toMs != null) q.set("to_ms", String(params.toMs))
   return fetchAdminJson<PremiumStatsResponse>(
     `/api/admin/stats/premium-daily?${q.toString()}`,
   )

--- a/admin-ui/src/lib/chart-format.ts
+++ b/admin-ui/src/lib/chart-format.ts
@@ -1,0 +1,109 @@
+type HourlyFormatOptions = {
+  timeZone?: string
+  includeOffset?: boolean
+}
+
+type LocalHourParts = {
+  year: string
+  month: string
+  day: string
+  hour: string
+}
+
+function getResolvedTimeZone(timeZone?: string): string | undefined {
+  return timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone || undefined
+}
+
+function getLocalHourParts(
+  utcIso: string,
+  timeZone?: string,
+): LocalHourParts | null {
+  const date = new Date(utcIso)
+  if (Number.isNaN(date.getTime())) return null
+
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: getResolvedTimeZone(timeZone),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+  })
+
+  const parts = formatter.formatToParts(date)
+  const year = parts.find((part) => part.type === "year")?.value
+  const month = parts.find((part) => part.type === "month")?.value
+  const day = parts.find((part) => part.type === "day")?.value
+  const hour = parts.find((part) => part.type === "hour")?.value
+
+  if (!year || !month || !day || !hour) return null
+  return { year, month, day, hour }
+}
+
+function getOffsetLabel(utcIso: string, timeZone?: string): string | null {
+  const date = new Date(utcIso)
+  if (Number.isNaN(date.getTime())) return null
+
+  const formatter = new Intl.DateTimeFormat("en", {
+    timeZone: getResolvedTimeZone(timeZone),
+    hour: "2-digit",
+    hourCycle: "h23",
+    timeZoneName: "shortOffset",
+  })
+
+  return (
+    formatter
+      .formatToParts(date)
+      .find((part) => part.type === "timeZoneName")
+      ?.value ?? null
+  )
+}
+
+/** Format daily date label: "YYYY-MM-DD" -> "MM-DD" */
+export function formatDailyLabel(dateStr: string): string {
+  const match = /(\d{2})-(\d{2})$/.exec(dateStr)
+  return match ? `${match[1]}-${match[2]}` : dateStr
+}
+
+/**
+ * Format a UTC ISO hour bucket (e.g., "2026-04-15T14:00:00Z")
+ * for display in browser local time.
+ */
+export function formatHourlyLabel(
+  utcIso: string,
+  showDate: boolean,
+  options: HourlyFormatOptions = {},
+): string {
+  const parts = getLocalHourParts(utcIso, options.timeZone)
+  if (!parts) return utcIso
+
+  const prefix = showDate ? `${parts.month}-${parts.day} ` : ""
+  const suffix = options.includeOffset ? ` ${getOffsetLabel(utcIso, options.timeZone) ?? ""}` : ""
+  return `${prefix}${parts.hour}:00${suffix}`.trimEnd()
+}
+
+/** Check if UTC ISO hour buckets span multiple local calendar days. */
+export function hourlyDataCrossesDays(
+  dates: string[],
+  timeZone?: string,
+): boolean {
+  const localDays = new Set<string>()
+  for (const value of dates) {
+    const parts = getLocalHourParts(value, timeZone)
+    if (!parts) continue
+    localDays.add(`${parts.year}-${parts.month}-${parts.day}`)
+  }
+  return localDays.size > 1
+}
+
+/** Format full local date+time for tooltip. */
+export function formatHourlyTooltip(
+  utcIso: string,
+  options: HourlyFormatOptions = {},
+): string {
+  const parts = getLocalHourParts(utcIso, options.timeZone)
+  if (!parts) return utcIso
+
+  const suffix = options.includeOffset ? ` ${getOffsetLabel(utcIso, options.timeZone) ?? ""}` : ""
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:00${suffix}`.trimEnd()
+}

--- a/admin-ui/src/lib/requests-time-range.ts
+++ b/admin-ui/src/lib/requests-time-range.ts
@@ -1,0 +1,33 @@
+const MINUTE_END_OFFSET_MS = 59_999
+
+function parseLocalInputMs(value: string): number | null {
+  if (!value) return null
+
+  const ms = Date.parse(value)
+  return Number.isFinite(ms) ? ms : null
+}
+
+export function localInputToFromMs(value: string): string {
+  const ms = parseLocalInputMs(value)
+  return ms == null ? "" : String(ms)
+}
+
+export function localInputToToMs(value: string): string {
+  const ms = parseLocalInputMs(value)
+  return ms == null ? "" : String(ms + MINUTE_END_OFFSET_MS)
+}
+
+export function msToLocalInput(ms: string): string {
+  const n = Number(ms)
+  if (!Number.isFinite(n)) return ""
+
+  const d = new Date(n)
+  const pad2 = (x: number) => String(x).padStart(2, "0")
+  const yyyy = d.getFullYear()
+  const mm = pad2(d.getMonth() + 1)
+  const dd = pad2(d.getDate())
+  const hh = pad2(d.getHours())
+  const min = pad2(d.getMinutes())
+
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}`
+}

--- a/admin-ui/src/lib/statistics-local-aggregation.ts
+++ b/admin-ui/src/lib/statistics-local-aggregation.ts
@@ -1,0 +1,91 @@
+import type {
+  DailyAccountStatsItem,
+  DailyStatsItem,
+} from "@/lib/admin-api"
+
+function getResolvedTimeZone(timeZone?: string): string | undefined {
+  return timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone || undefined
+}
+
+function getLocalDayKey(utcIso: string, timeZone?: string): string {
+  const date = new Date(utcIso)
+  if (Number.isNaN(date.getTime())) return utcIso
+
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: getResolvedTimeZone(timeZone),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+
+  const parts = formatter.formatToParts(date)
+  const year = parts.find((part) => part.type === "year")?.value
+  const month = parts.find((part) => part.type === "month")?.value
+  const day = parts.find((part) => part.type === "day")?.value
+
+  if (!year || !month || !day) return utcIso
+  return `${year}-${month}-${day}`
+}
+
+export function aggregateHourlyStatsToLocalDays(
+  items: readonly DailyStatsItem[],
+  timeZone?: string,
+): Array<DailyStatsItem> {
+  const byDate = new Map<string, DailyStatsItem>()
+
+  for (const item of items) {
+    const date = getLocalDayKey(item.date, timeZone)
+    const existing = byDate.get(date)
+    if (existing) {
+      existing.request_count += item.request_count
+      existing.premium_consumed += item.premium_consumed
+      existing.tokens_total += item.tokens_total
+      existing.error_count += item.error_count
+      continue
+    }
+
+    byDate.set(date, {
+      date,
+      request_count: item.request_count,
+      premium_consumed: item.premium_consumed,
+      tokens_total: item.tokens_total,
+      error_count: item.error_count,
+    })
+  }
+
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
+}
+
+export function aggregateHourlyAccountStatsToLocalDays(
+  items: readonly DailyAccountStatsItem[],
+  timeZone?: string,
+): Array<DailyAccountStatsItem> {
+  const byDateAccount = new Map<string, DailyAccountStatsItem>()
+
+  for (const item of items) {
+    const date = getLocalDayKey(item.date, timeZone)
+    const key = `${date}|${item.account_id}`
+    const existing = byDateAccount.get(key)
+    if (existing) {
+      existing.request_count += item.request_count
+      existing.premium_consumed += item.premium_consumed
+      existing.tokens_total += item.tokens_total
+      existing.error_count += item.error_count
+      continue
+    }
+
+    byDateAccount.set(key, {
+      date,
+      account_id: item.account_id,
+      request_count: item.request_count,
+      premium_consumed: item.premium_consumed,
+      tokens_total: item.tokens_total,
+      error_count: item.error_count,
+    })
+  }
+
+  return [...byDateAccount.values()].sort((a, b) => {
+    if (a.date === b.date) return a.account_id.localeCompare(b.account_id)
+    return a.date.localeCompare(b.date)
+  })
+}

--- a/admin-ui/src/lib/statistics-range.ts
+++ b/admin-ui/src/lib/statistics-range.ts
@@ -4,6 +4,10 @@ export type StatisticsRange = {
   from: string
   to: string
   granularity: "day" | "hour"
+  /** Browser-local start-of-day ms (only set for hourly granularity). */
+  fromMs?: number
+  /** Browser-local end-of-day ms (only set for hourly granularity). */
+  toMs?: number
 }
 
 function toDateString(date: Date): string {
@@ -11,6 +15,31 @@ function toDateString(date: Date): string {
   const m = String(date.getMonth() + 1).padStart(2, "0")
   const d = String(date.getDate()).padStart(2, "0")
   return `${y}-${m}-${d}`
+}
+
+/** End-of-day ms for a YYYY-MM-DD string. DST-safe (uses next-midnight − 1). */
+export function localDateEndMs(dateStr: string): number {
+  const [y, m, d] = dateStr.split("-").map(Number)
+  return new Date(y, m - 1, d + 1).getTime() - 1
+}
+
+/** Start-of-day ms for a YYYY-MM-DD string. */
+export function localDateToMs(dateStr: string): number {
+  const [y, m, d] = dateStr.split("-").map(Number)
+  return new Date(y, m - 1, d).getTime()
+}
+
+/**
+ * Validate a custom date range.
+ * Partial input is allowed so callers can still fall back to today.
+ */
+export function validateCustomRange(
+  from: string,
+  to: string,
+): string | null {
+  if (!from || !to) return null
+  if (from > to) return "From date must not be after to date"
+  return null
 }
 
 export function resolveStatisticsRange(params: {
@@ -23,22 +52,58 @@ export function resolveStatisticsRange(params: {
   const today = toDateString(now)
 
   if (preset === "today") {
-    return { from: today, to: today, granularity: "hour" }
+    const startMs = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    ).getTime()
+    const endMs =
+      new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() + 1,
+      ).getTime() - 1
+    return {
+      from: today,
+      to: today,
+      granularity: "hour",
+      fromMs: startMs,
+      toMs: endMs,
+    }
   }
 
   if (preset === "7d") {
-    const weekAgo = new Date(now.getTime() - 7 * 86_400_000)
-    return { from: toDateString(weekAgo), to: today, granularity: "day" }
+    // 7 natural days including today: use calendar-day arithmetic to stay DST-safe.
+    const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6)
+    const from = toDateString(weekAgo)
+    return {
+      from,
+      to: today,
+      granularity: "day",
+      fromMs: localDateToMs(from),
+      toMs: localDateEndMs(today),
+    }
   }
 
   if (preset === "month") {
     const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
-    return { from: toDateString(startOfMonth), to: today, granularity: "day" }
+    const from = toDateString(startOfMonth)
+    return {
+      from,
+      to: today,
+      granularity: "day",
+      fromMs: localDateToMs(from),
+      toMs: localDateEndMs(today),
+    }
   }
 
+  const from = customFrom || today
+  const to = customTo || today
   return {
-    from: customFrom || today,
-    to: customTo || today,
+    from,
+    to,
     granularity: "day",
+    fromMs: localDateToMs(from),
+    toMs: localDateEndMs(to),
   }
 }

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -12,6 +12,10 @@ import {
   getAdminMeta,
   patchAccount,
 } from "@/lib/admin-api"
+import {
+  buildAccountsCsv,
+  getAccountsCsvFilename,
+} from "@/lib/accounts-export"
 import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
@@ -299,46 +303,15 @@ export function AccountsPage(): React.JSX.Element {
   }, [refresh])
 
   // CSV export
-  function escapeCsvCell(value: string): string {
-    const neutralized = /^[=+\-@]/u.test(value) ? `'${value}` : value
-    return `"${neutralized.replaceAll('"', '""')}"`
-  }
-
   const handleExportCsv = useCallback(() => {
     if (accounts.length === 0) return
 
-    const headers = [
-      "account_id",
-      "status",
-      "account_type",
-      "requests",
-      "errors",
-      "tokens",
-      "avg_duration_s",
-      "last_request",
-    ]
-    const rows = accounts.map((a) => [
-      a.account_id,
-      a.runtime?.failed ? "failed" : "ok",
-      a.account_type ?? "free",
-      String(a.stats?.request_count ?? 0),
-      String(a.stats?.error_count ?? 0),
-      String(a.stats?.tokens_total ?? 0),
-      fmtDurationSeconds(a.stats?.avg_duration_ms),
-      a.stats?.last_request_at_ms
-        ? new Date(a.stats.last_request_at_ms).toISOString()
-        : "",
-    ])
-
-    const csv = [
-      headers.join(","),
-      ...rows.map((r) => r.map((c) => escapeCsvCell(c)).join(",")),
-    ].join("\n")
+    const csv = buildAccountsCsv(accounts)
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" })
     const url = URL.createObjectURL(blob)
     const a = document.createElement("a")
     a.href = url
-    a.download = `accounts-${new Date().toISOString().slice(0, 10)}.csv`
+    a.download = getAccountsCsvFilename()
     a.click()
     URL.revokeObjectURL(url)
     toast.success(t("accountsPage.exportSuccess"))

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -11,6 +11,11 @@ import {
 } from "@/lib/admin-api"
 import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
+import {
+  localInputToFromMs,
+  localInputToToMs,
+  msToLocalInput,
+} from "@/lib/requests-time-range"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -130,28 +135,6 @@ function validateTimeRange(
   }
 
   return null
-}
-
-function localInputToMs(value: string): string {
-  if (!value) return ""
-  const ms = Date.parse(value)
-  if (!Number.isFinite(ms)) return ""
-  return String(ms)
-}
-
-function msToLocalInput(ms: string): string {
-  const n = Number(ms)
-  if (!Number.isFinite(n)) return ""
-  const d = new Date(n)
-
-  const pad2 = (x: number) => String(x).padStart(2, "0")
-  const yyyy = d.getFullYear()
-  const mm = pad2(d.getMonth() + 1)
-  const dd = pad2(d.getDate())
-  const hh = pad2(d.getHours())
-  const min = pad2(d.getMinutes())
-
-  return `${yyyy}-${mm}-${dd}T${hh}:${min}`
 }
 
 function presetToRange(preset: Exclude<TimeRange, "__any__" | "custom">): {
@@ -542,7 +525,7 @@ export function RequestsPage(): React.JSX.Element {
                           setTimeRange("custom")
                           setFilters((p) => ({
                             ...p,
-                            from_ms: localInputToMs(e.target.value),
+                            from_ms: localInputToFromMs(e.target.value),
                           }))
                         }}
                       />
@@ -560,7 +543,7 @@ export function RequestsPage(): React.JSX.Element {
                           setTimeRange("custom")
                           setFilters((p) => ({
                             ...p,
-                            to_ms: localInputToMs(e.target.value),
+                            to_ms: localInputToToMs(e.target.value),
                           }))
                         }}
                       />

--- a/admin-ui/src/pages/statistics-page.tsx
+++ b/admin-ui/src/pages/statistics-page.tsx
@@ -19,11 +19,18 @@ import {
 } from "@/lib/admin-api"
 import { i18n } from "@/lib/i18n"
 import {
+  aggregateHourlyAccountStatsToLocalDays,
+  aggregateHourlyStatsToLocalDays,
+} from "@/lib/statistics-local-aggregation"
+import {
   type StatisticsTimePreset,
   resolveStatisticsRange,
+  validateCustomRange,
 } from "@/lib/statistics-range"
 
 type TimePreset = StatisticsTimePreset
+
+const MAX_LOCAL_STATS_RANGE_MS = 35 * 24 * 60 * 60 * 1000
 
 export function StatisticsPage(): React.JSX.Element {
   const { t } = useTranslation()
@@ -43,6 +50,18 @@ export function StatisticsPage(): React.JSX.Element {
 
   const refresh = useCallback(async () => {
     if (loadInFlightRef.current) return
+
+    // Validate custom range before making the request
+    if (preset === "custom") {
+      const rangeError = validateCustomRange(customFrom, customTo)
+      if (rangeError) {
+        toast.error(i18n.t("statistics.loadFailed"), {
+          description: rangeError,
+        })
+        return
+      }
+    }
+
     loadInFlightRef.current = true
     setLoading(true)
 
@@ -52,14 +71,31 @@ export function StatisticsPage(): React.JSX.Element {
         customFrom,
         customTo,
       })
+      const fromMs = range.fromMs
+      const toMs = range.toMs
+      const hasMsRange = fromMs != null && toMs != null
+      const canUseLocalAggregation =
+        hasMsRange
+        && toMs - fromMs < MAX_LOCAL_STATS_RANGE_MS
+      const requestGranularity =
+        canUseLocalAggregation ? "hour" : range.granularity
       const res = await getAdminPremiumStats({
         from: range.from,
         to: range.to,
-        granularity: range.granularity,
+        granularity: requestGranularity,
+        fromMs: canUseLocalAggregation ? fromMs : undefined,
+        toMs: canUseLocalAggregation ? toMs : undefined,
       })
-      setDaily(res.daily)
-      setByAccount(res.by_account)
-      setIsHourly(range.granularity === "hour")
+
+      if (range.granularity === "day" && requestGranularity === "hour") {
+        setDaily(aggregateHourlyStatsToLocalDays(res.daily))
+        setByAccount(aggregateHourlyAccountStatsToLocalDays(res.by_account))
+        setIsHourly(false)
+      } else {
+        setDaily(res.daily)
+        setByAccount(res.by_account)
+        setIsHourly(range.granularity === "hour")
+      }
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
       toast.error(i18n.t("statistics.loadFailed"), { description: msg })

--- a/admin-ui/tests/accounts-export.test.ts
+++ b/admin-ui/tests/accounts-export.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+
+import type { AdminAccountItem } from "../src/lib/admin-api"
+import {
+  buildAccountsCsv,
+  getAccountsCsvFilename,
+} from "../src/lib/accounts-export"
+import { fmtLocalDateTime } from "../src/lib/format"
+
+test("buildAccountsCsv formats last_request with the same local time string as the table", () => {
+  const account: AdminAccountItem = {
+    account_id: "acct-1",
+    account_type: "free",
+    runtime: { failed: false },
+    stats: {
+      since_ms: Date.parse("2026-04-01T00:00:00"),
+      request_count: 3,
+      error_count: 1,
+      tokens_total: 42,
+      avg_duration_ms: 1234,
+      last_request_at_ms: Date.parse("2026-04-15T13:45:23"),
+    },
+  }
+
+  const csv = buildAccountsCsv([account])
+
+  expect(csv).toContain(`"${fmtLocalDateTime(account.stats?.last_request_at_ms)}"`)
+})
+
+test("getAccountsCsvFilename uses the browser local date instead of UTC", () => {
+  const now = new Date(2026, 3, 15, 23, 30, 0)
+
+  expect(getAccountsCsvFilename(now)).toBe("accounts-2026-04-15.csv")
+})

--- a/admin-ui/tests/chart-format.test.ts
+++ b/admin-ui/tests/chart-format.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+
+async function loadModule() {
+  return import("../src/lib/chart-format")
+}
+
+test("formatHourlyLabel shows HH:00 when showDate is false", async () => {
+  const mod = await loadModule()
+  // Construct a local-time Date, convert to UTC ISO, then format back
+  const local = new Date(2026, 3, 15, 14, 0, 0)
+  const utcIso = local.toISOString()
+  expect(mod.formatHourlyLabel(utcIso, false)).toBe("14:00")
+})
+
+test("formatHourlyLabel shows MM-DD HH:00 when showDate is true", async () => {
+  const mod = await loadModule()
+  const local = new Date(2026, 3, 15, 14, 0, 0)
+  const utcIso = local.toISOString()
+  expect(mod.formatHourlyLabel(utcIso, true)).toBe("04-15 14:00")
+})
+
+test("formatHourlyLabel pads single-digit hours", async () => {
+  const mod = await loadModule()
+  const local = new Date(2026, 3, 15, 9, 0, 0)
+  const utcIso = local.toISOString()
+  expect(mod.formatHourlyLabel(utcIso, false)).toBe("09:00")
+})
+
+test("hourlyDataCrossesDays returns false for same-day data", async () => {
+  const mod = await loadModule()
+  const d1 = new Date(2026, 3, 15, 10, 0, 0).toISOString()
+  const d2 = new Date(2026, 3, 15, 14, 0, 0).toISOString()
+  expect(mod.hourlyDataCrossesDays([d1, d2])).toBe(false)
+})
+
+test("hourlyDataCrossesDays returns true for multi-day data", async () => {
+  const mod = await loadModule()
+  const d1 = new Date(2026, 3, 15, 23, 0, 0).toISOString()
+  const d2 = new Date(2026, 3, 16, 1, 0, 0).toISOString()
+  expect(mod.hourlyDataCrossesDays([d1, d2])).toBe(true)
+})
+
+test("hourlyDataCrossesDays returns false for empty array", async () => {
+  const mod = await loadModule()
+  expect(mod.hourlyDataCrossesDays([])).toBe(false)
+})
+
+test("formatHourlyTooltip shows full local date and time", async () => {
+  const mod = await loadModule()
+  const local = new Date(2026, 3, 15, 14, 0, 0)
+  const utcIso = local.toISOString()
+  expect(mod.formatHourlyTooltip(utcIso)).toBe("2026-04-15 14:00")
+})
+
+test("formatHourlyLabel can disambiguate repeated DST fallback hours with offsets", async () => {
+  const mod = await loadModule()
+  const beforeFallback = mod.formatHourlyLabel(
+    "2026-11-01T05:00:00.000Z",
+    true,
+    { timeZone: "America/New_York", includeOffset: true },
+  )
+  const afterFallback = mod.formatHourlyLabel(
+    "2026-11-01T06:00:00.000Z",
+    true,
+    { timeZone: "America/New_York", includeOffset: true },
+  )
+
+  expect(beforeFallback).toContain("11-01 01:00")
+  expect(afterFallback).toContain("11-01 01:00")
+  expect(beforeFallback).not.toBe(afterFallback)
+})
+
+test("formatDailyLabel extracts MM-DD from YYYY-MM-DD", async () => {
+  const mod = await loadModule()
+  expect(mod.formatDailyLabel("2026-04-15")).toBe("04-15")
+  expect(mod.formatDailyLabel("2026-01-01")).toBe("01-01")
+})

--- a/admin-ui/tests/requests-time-range.test.ts
+++ b/admin-ui/tests/requests-time-range.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+
+import {
+  localInputToFromMs,
+  localInputToToMs,
+  msToLocalInput,
+} from "../src/lib/requests-time-range"
+
+test("localInputToFromMs keeps the selected minute start", () => {
+  const value = "2026-04-15T13:45"
+
+  expect(localInputToFromMs(value)).toBe(String(Date.parse(value)))
+})
+
+test("localInputToToMs expands the selected minute to the inclusive end", () => {
+  const value = "2026-04-15T13:45"
+
+  expect(localInputToToMs(value)).toBe(String(Date.parse(value) + 59_999))
+})
+
+test("msToLocalInput formats milliseconds as a datetime-local value", () => {
+  const value = "2026-04-15T13:45"
+
+  expect(msToLocalInput(String(Date.parse(value) + 42_000))).toBe(value)
+})

--- a/admin-ui/tests/statistics-local-aggregation.test.ts
+++ b/admin-ui/tests/statistics-local-aggregation.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+
+import {
+  aggregateHourlyAccountStatsToLocalDays,
+  aggregateHourlyStatsToLocalDays,
+} from "../src/lib/statistics-local-aggregation"
+
+test("aggregateHourlyStatsToLocalDays folds UTC buckets into the browser local day", () => {
+  const result = aggregateHourlyStatsToLocalDays(
+    [
+      {
+        date: "2026-04-14T16:00:00Z",
+        request_count: 1,
+        premium_consumed: 2,
+        tokens_total: 3,
+        error_count: 0,
+      },
+      {
+        date: "2026-04-15T15:00:00Z",
+        request_count: 4,
+        premium_consumed: 5,
+        tokens_total: 6,
+        error_count: 1,
+      },
+    ],
+    "Asia/Shanghai",
+  )
+
+  expect(result).toEqual([
+    {
+      date: "2026-04-15",
+      request_count: 5,
+      premium_consumed: 7,
+      tokens_total: 9,
+      error_count: 1,
+    },
+  ])
+})
+
+test("aggregateHourlyAccountStatsToLocalDays keeps account splits while folding by local day", () => {
+  const result = aggregateHourlyAccountStatsToLocalDays(
+    [
+      {
+        date: "2026-04-14T16:00:00Z",
+        account_id: "acct-a",
+        request_count: 1,
+        premium_consumed: 2,
+        tokens_total: 3,
+        error_count: 0,
+      },
+      {
+        date: "2026-04-15T01:00:00Z",
+        account_id: "acct-b",
+        request_count: 4,
+        premium_consumed: 5,
+        tokens_total: 6,
+        error_count: 1,
+      },
+      {
+        date: "2026-04-15T15:00:00Z",
+        account_id: "acct-a",
+        request_count: 7,
+        premium_consumed: 8,
+        tokens_total: 9,
+        error_count: 1,
+      },
+    ],
+    "Asia/Shanghai",
+  )
+
+  expect(result).toEqual([
+    {
+      date: "2026-04-15",
+      account_id: "acct-a",
+      request_count: 8,
+      premium_consumed: 10,
+      tokens_total: 12,
+      error_count: 1,
+    },
+    {
+      date: "2026-04-15",
+      account_id: "acct-b",
+      request_count: 4,
+      premium_consumed: 5,
+      tokens_total: 6,
+      error_count: 1,
+    },
+  ])
+})

--- a/admin-ui/tests/statistics-range.test.ts
+++ b/admin-ui/tests/statistics-range.test.ts
@@ -4,7 +4,7 @@ async function loadRangeModule() {
   return import("../src/lib/statistics-range");
 }
 
-test("resolveStatisticsRange maps today preset to a same-day hourly range", async () => {
+test("resolveStatisticsRange maps today preset to a same-day hourly range with fromMs/toMs", async () => {
   const fixedNow = new Date("2026-04-15T13:45:00");
   const mod = await loadRangeModule();
 
@@ -19,10 +19,12 @@ test("resolveStatisticsRange maps today preset to a same-day hourly range", asyn
     from: "2026-04-15",
     to: "2026-04-15",
     granularity: "hour",
+    fromMs: new Date(2026, 3, 15).getTime(),
+    toMs: new Date(2026, 3, 16).getTime() - 1,
   });
 });
 
-test("resolveStatisticsRange keeps 7d as a daily calendar range", async () => {
+test("resolveStatisticsRange 7d includes today plus 6 prior days", async () => {
   const fixedNow = new Date("2026-04-15T13:45:00");
   const mod = await loadRangeModule();
 
@@ -34,9 +36,11 @@ test("resolveStatisticsRange keeps 7d as a daily calendar range", async () => {
       now: fixedNow,
     }),
   ).toEqual({
-    from: "2026-04-08",
+    from: "2026-04-09",
     to: "2026-04-15",
     granularity: "day",
+    fromMs: new Date(2026, 3, 9).getTime(),
+    toMs: new Date(2026, 3, 16).getTime() - 1,
   });
 });
 
@@ -55,6 +59,8 @@ test("resolveStatisticsRange maps month preset to the first day of the month", a
     from: "2026-04-01",
     to: "2026-04-15",
     granularity: "day",
+    fromMs: new Date(2026, 3, 1).getTime(),
+    toMs: new Date(2026, 3, 16).getTime() - 1,
   });
 });
 
@@ -73,5 +79,54 @@ test("resolveStatisticsRange uses custom dates when provided", async () => {
     from: "2026-03-01",
     to: "2026-03-31",
     granularity: "day",
+    fromMs: new Date(2026, 2, 1).getTime(),
+    toMs: new Date(2026, 3, 1).getTime() - 1,
   });
+});
+
+test("validateCustomRange returns null for valid range (from <= to)", async () => {
+  const mod = await loadRangeModule();
+  expect(mod.validateCustomRange("2026-03-01", "2026-03-31")).toBeNull();
+  expect(mod.validateCustomRange("2026-04-15", "2026-04-15")).toBeNull();
+});
+
+test("validateCustomRange returns error when from > to", async () => {
+  const mod = await loadRangeModule();
+  const error = mod.validateCustomRange("2026-04-15", "2026-04-01");
+  expect(typeof error).toBe("string");
+  expect(error).not.toBeNull();
+});
+
+test("validateCustomRange allows partial input so custom range can fall back to today", async () => {
+  const mod = await loadRangeModule();
+  expect(mod.validateCustomRange("", "2026-04-15")).toBeNull();
+  expect(mod.validateCustomRange("2026-04-15", "")).toBeNull();
+  expect(mod.validateCustomRange("", "")).toBeNull();
+});
+
+test("resolveStatisticsRange falls back missing custom dates to today", async () => {
+  const fixedNow = new Date("2026-04-15T13:45:00");
+  const mod = await loadRangeModule();
+
+  expect(
+    mod.resolveStatisticsRange({
+      preset: "custom",
+      customFrom: "",
+      customTo: "",
+      now: fixedNow,
+    }),
+  ).toEqual({
+    from: "2026-04-15",
+    to: "2026-04-15",
+    granularity: "day",
+    fromMs: new Date(2026, 3, 15).getTime(),
+    toMs: new Date(2026, 3, 16).getTime() - 1,
+  });
+});
+
+test("localDateEndMs computes end-of-day DST-safe", async () => {
+  const mod = await loadRangeModule();
+  // End of April 15 should be one ms before midnight April 16
+  const expected = new Date(2026, 3, 16).getTime() - 1;
+  expect(mod.localDateEndMs("2026-04-15")).toBe(expected);
 });

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -20,7 +20,7 @@ import type { AffinityKeySource } from "./utils"
 import { getAdminDb, getAdminDbPath, getAdminDbUserVersion } from "./admin-db"
 import { StatsStore } from "./stats-store"
 
-const DEFAULT_RETENTION_DAYS = 14
+const DEFAULT_RETENTION_DAYS = 35
 const DEFAULT_MAX_ROWS = 200_000
 
 const INSERT_WARN_THROTTLE_MS = 30_000

--- a/src/lib/stats-store.ts
+++ b/src/lib/stats-store.ts
@@ -96,7 +96,7 @@ export class StatsStore {
   }): Array<{ date: string; account_id: string; premium_consumed: number }> {
     const dateExpr =
       params.granularity === "hour" ?
-        "strftime('%Y-%m-%d %H:00', snapshot_at_ms / 1000, 'unixepoch', 'localtime')"
+        "strftime('%Y-%m-%dT%H:00:00Z', snapshot_at_ms / 1000, 'unixepoch')"
       : "date(snapshot_at_ms / 1000, 'unixepoch', 'localtime')"
 
     const accountFilter = params.accountId ? " AND account_id = ?" : ""
@@ -239,7 +239,7 @@ export class StatsStore {
 
     const dailyMetrics = this.db
       .query(
-        `SELECT strftime('%Y-%m-%d %H:00', started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
+        `SELECT strftime('%Y-%m-%dT%H:00:00Z', started_at_ms / 1000, 'unixepoch') AS date,
                 COUNT(*)                                                   AS request_count,
                 COALESCE(SUM(tokens_total), 0)                             AS tokens_total,
                 SUM(CASE WHEN error_name IS NOT NULL THEN 1 ELSE 0 END)    AS error_count
@@ -263,7 +263,7 @@ export class StatsStore {
 
     const byAccountMetrics = this.db
       .query(
-        `SELECT strftime('%Y-%m-%d %H:00', started_at_ms / 1000, 'unixepoch', 'localtime') AS date,
+        `SELECT strftime('%Y-%m-%dT%H:00:00Z', started_at_ms / 1000, 'unixepoch') AS date,
                 account_id,
                 COUNT(*)                                                   AS request_count,
                 COALESCE(SUM(tokens_total), 0)                             AS tokens_total,

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1668,7 +1668,10 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
   const todayStr = toLocalDateString(now.getTime())
 
   const resolvedFrom =
-    from || toLocalDateString(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+    from
+    || toLocalDateString(
+      new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6).getTime(),
+    )
   const resolvedTo = to || todayStr
 
   // Parse YYYY-MM-DD as local time (not UTC)
@@ -1677,18 +1680,10 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
     return new Date(y, m - 1, d)
   }
 
-  // Validate granularity=hour range <= 48h
-  if (granularity === "hour") {
-    const fromDate = parseLocalDate(resolvedFrom)
-    const toDate = parseLocalDate(resolvedTo)
-    const diffMs = toDate.getTime() - fromDate.getTime() + 24 * 60 * 60 * 1000
-    if (diffMs > 48 * 60 * 60 * 1000) {
-      return jsonError(c, 400, {
-        message:
-          "Hourly granularity is only supported for ranges up to 48 hours.",
-        type: "bad_request",
-      })
-    }
+  /** DST-safe end-of-day: next local midnight minus 1 ms. */
+  function localDateEndMs(dateStr: string): number {
+    const [y, m, d] = dateStr.split("-").map(Number)
+    return new Date(y, m - 1, d + 1).getTime() - 1
   }
 
   const statsStore = getStatsStore()
@@ -1701,8 +1696,31 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
   }
 
   if (granularity === "hour") {
-    const fromMs = parseLocalDate(resolvedFrom).getTime()
-    const toMs = parseLocalDate(resolvedTo).getTime() + 86_399_999
+    // Prefer client-provided ms boundaries (browser local time)
+    const clientFromMs = parseFiniteNumber(p.get("from_ms"))
+    const clientToMs = parseFiniteNumber(p.get("to_ms"))
+
+    let fromMs: number
+    let toMs: number
+
+    if (clientFromMs !== undefined && clientToMs !== undefined) {
+      fromMs = clientFromMs
+      toMs = clientToMs
+    } else {
+      // Fallback: DST-safe computation from date strings
+      fromMs = parseLocalDate(resolvedFrom).getTime()
+      toMs = localDateEndMs(resolvedTo)
+    }
+
+    // Keep raw-hour transport within a bounded range so the admin query stays predictable.
+    if (toMs - fromMs > 35 * 24 * 60 * 60 * 1000) {
+      return jsonError(c, 400, {
+        message:
+          "Hourly granularity is only supported for ranges up to 35 days.",
+        type: "bad_request",
+      })
+    }
+
     const result = statsStore.getHourlyPremiumStats({
       fromMs,
       toMs,

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -761,3 +761,63 @@ test("toLocalDateString formats correctly", () => {
   const ms2 = new Date(2026, 0, 1).getTime() // January 1, 2026
   expect(toLocalDateString(ms2)).toBe("2026-01-01")
 })
+
+test("getHourlyPremiumStats returns UTC ISO hour bucket format", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  // Use explicit UTC hours so the expected bucket is timezone-independent
+  const t1 = Date.UTC(2026, 3, 10, 14, 30, 0)
+
+  db.run(
+    `INSERT INTO request_log
+       (request_id, started_at_ms, method, path, account_id, cost_units, tokens_total, error_name)
+     VALUES ('utc-1', ?, 'POST', '/v1/messages', 'acct-a', 10.0, 1000, NULL)`,
+    [t1],
+  )
+
+  const result = store.getHourlyPremiumStats({
+    fromMs: t1 - 1000,
+    toMs: t1 + 1000,
+  })
+
+  expect(result.daily.length).toBe(1)
+  expect(result.daily[0].date).toBe("2026-04-10T14:00:00Z")
+})
+
+test("getConsumptionFromSnapshots hourly uses UTC ISO hour bucket format", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new StatsStore(db)
+
+  const t1 = Date.UTC(2026, 3, 10, 14, 0, 0)
+  const t2 = Date.UTC(2026, 3, 10, 14, 30, 0)
+
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t1,
+    remaining: 300,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+  store.insertQuotaSnapshot({
+    accountId: "acct-a",
+    snapshotAtMs: t2,
+    remaining: 290,
+    entitlement: 300,
+    unlimited: false,
+    source: "refresh",
+  })
+
+  const result = store.getConsumptionFromSnapshots({
+    fromMs: t1,
+    toMs: t2 + 1,
+    granularity: "hour",
+  })
+
+  expect(result.length).toBe(1)
+  expect(result[0].date).toBe("2026-04-10T14:00:00Z")
+  expect(result[0].premium_consumed).toBe(10)
+})


### PR DESCRIPTION
## Summary
- route hourly statistics through UTC hour buckets and re-aggregate <=35 day day views in the browser's local timezone
- fix Statistics range/DST boundaries plus hourly chart labels/tooltips so local-time display stays correct across timezone shifts
- align Requests datetime-local filtering and Accounts CSV export with browser-local time semantics, with focused regression tests

## Test plan
- [x] bun test
- [x] bun run lint:admin
- [x] bun run build
- [x] bun run typecheck