### PR TITLE
feat(admin-ui): Developer Mode with Request Replay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,13 @@ All stored in `~/.local/share/copilot-api/`:
 - `/v1/messages/count_tokens` forwards Claude requests to Anthropic when `anthropicApiKey` is configured.
 - Otherwise it falls back to GPT `o200k_base` estimation with the project’s compatibility multiplier.
 
+### Developer Mode (Request Replay)
+
+- Config switches: `config.devMode.enabled` (main gate, default false) + `config.devMode.capture4xx` (capture gate, default false).
+- When `capture4xx` is on, `copilotFetch` helper tee-captures 4xx upstream responses into `request_outbound` table (FK CASCADE to `request_log`, auto-cleaned with 35-day retention).
+- Admin-UI `/requests/:id/replay` page allows editing body + business headers and replaying via a different account. Replay is pure bypass: no `request_log`, no premium stats, no affinity writes.
+- Key files: `src/services/copilot/copilot-fetch.ts`, `src/lib/request-outbound.ts`, `src/lib/dev-mode.ts`, `src/routes/admin-api/replay.ts`, `src/routes/admin-api/replay-translation.ts`, `admin-ui/src/pages/request-replay-page.tsx`.
+
 ## Agent Notes
 
 - When working on `/v1/messages`, verify behavior in `tests/messages-handler.test.ts`, `tests/messages-preprocess.test.ts`, `tests/create-messages.test.ts`, and `tests/warmup-probe.test.ts`.

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -5,6 +5,7 @@ import { AccountsPage } from "@/pages/accounts-page"
 import { ModelsPage } from "@/pages/models-page"
 import { NotFoundPage } from "@/pages/not-found-page"
 import { RequestDetailPage } from "@/pages/request-detail-page"
+import { RequestReplayPage } from "@/pages/request-replay-page"
 import { RequestsPage } from "@/pages/requests-page"
 import { SettingsPage } from "@/pages/settings-page"
 import { StatisticsPage } from "@/pages/statistics-page"
@@ -20,6 +21,7 @@ export default function App(): React.JSX.Element {
         <Route path="/models" element={<ModelsPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/request/:requestId" element={<RequestDetailPage />} />
+        <Route path="/requests/:requestId/replay" element={<RequestReplayPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Route>
     </Routes>

--- a/admin-ui/src/components/replay/replay-account-select.tsx
+++ b/admin-ui/src/components/replay/replay-account-select.tsx
@@ -1,0 +1,162 @@
+import { AlertCircleIcon } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  getAdminAccounts,
+  type AdminAccountItem,
+} from "@/lib/admin-api"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+const ACCOUNTS_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
+
+type ReplayAccountSelectProps = {
+  value: string
+  originalAccountId: string | null
+  onChange: (accountId: string) => void
+}
+
+function sortAccounts(
+  accounts: AdminAccountItem[],
+  originalAccountId: string | null,
+): AdminAccountItem[] {
+  return [...accounts].sort((left, right) => {
+    if (left.account_id === originalAccountId && right.account_id !== originalAccountId) {
+      return -1
+    }
+    if (right.account_id === originalAccountId && left.account_id !== originalAccountId) {
+      return 1
+    }
+    return left.account_id.localeCompare(right.account_id)
+  })
+}
+
+export function ReplayAccountSelect({
+  value,
+  originalAccountId,
+  onChange,
+}: ReplayAccountSelectProps): React.JSX.Element {
+  const { t } = useTranslation()
+  const [accounts, setAccounts] = useState<AdminAccountItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadAccounts(): Promise<void> {
+      setLoading(true)
+      try {
+        const response = await getAdminAccounts({
+          sinceMs: Date.now() - ACCOUNTS_LOOKBACK_MS,
+          includeStats: false,
+        })
+
+        if (cancelled) return
+
+        const enabledAccounts = response.items.filter(
+          (item) => item.runtime?.enabled !== false,
+        )
+        setAccounts(sortAccounts(enabledAccounts, originalAccountId))
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadAccounts()
+
+    return () => {
+      cancelled = true
+    }
+  }, [originalAccountId])
+
+  const selectableAccounts = useMemo(
+    () => accounts.filter((item) => item.runtime?.failed !== true),
+    [accounts],
+  )
+
+  const failedAccounts = useMemo(
+    () => accounts.filter((item) => item.runtime?.failed === true),
+    [accounts],
+  )
+
+  const allOptions = useMemo(
+    () => [...selectableAccounts, ...failedAccounts],
+    [failedAccounts, selectableAccounts],
+  )
+
+  const hasOptions = allOptions.length > 0
+  const placeholder = hasOptions
+    ? t("replayPage.account.label")
+    : t("replayPage.account.noAccounts")
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("replayPage.account.label")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <Select value={value} onValueChange={onChange} disabled={loading || !hasOptions}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {selectableAccounts.map((account) => {
+                const isOriginal = account.account_id === originalAccountId
+                return (
+                  <SelectItem key={account.account_id} value={account.account_id}>
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate font-mono text-xs">{account.account_id}</span>
+                      {isOriginal ? (
+                        <Badge variant="secondary">{t("replayPage.account.original")}</Badge>
+                      ) : null}
+                    </span>
+                  </SelectItem>
+                )
+              })}
+
+              {failedAccounts.map((account) => {
+                const isOriginal = account.account_id === originalAccountId
+                const reason = account.runtime?.failureReason || t("common.failed")
+                return (
+                  <Tooltip key={account.account_id}>
+                    <TooltipTrigger asChild>
+                      <div>
+                        <SelectItem value={account.account_id} disabled>
+                          <span className="flex min-w-0 items-center gap-2">
+                            <span className="truncate font-mono text-xs">{account.account_id}</span>
+                            {isOriginal ? (
+                              <Badge variant="secondary">{t("replayPage.account.original")}</Badge>
+                            ) : null}
+                            <AlertCircleIcon className="text-destructive size-3.5" />
+                          </span>
+                        </SelectItem>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>{reason}</TooltipContent>
+                  </Tooltip>
+                )
+              })}
+            </SelectContent>
+          </Select>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  )
+}

--- a/admin-ui/src/components/replay/replay-account-select.tsx
+++ b/admin-ui/src/components/replay/replay-account-select.tsx
@@ -71,7 +71,8 @@ export function ReplayAccountSelect({
           (item) => item.runtime?.enabled !== false,
         )
         setAccounts(sortAccounts(enabledAccounts, originalAccountId))
-      } catch {
+      } catch (error) {
+        console.error("Failed to load accounts", error)
         if (!cancelled) {
           setAccounts([])
         }

--- a/admin-ui/src/components/replay/replay-account-select.tsx
+++ b/admin-ui/src/components/replay/replay-account-select.tsx
@@ -71,6 +71,10 @@ export function ReplayAccountSelect({
           (item) => item.runtime?.enabled !== false,
         )
         setAccounts(sortAccounts(enabledAccounts, originalAccountId))
+      } catch {
+        if (!cancelled) {
+          setAccounts([])
+        }
       } finally {
         if (!cancelled) {
           setLoading(false)
@@ -135,22 +139,20 @@ export function ReplayAccountSelect({
                 const isOriginal = account.account_id === originalAccountId
                 const reason = account.runtime?.failureReason || t("common.failed")
                 return (
-                  <Tooltip key={account.account_id}>
-                    <TooltipTrigger asChild>
-                      <div>
-                        <SelectItem value={account.account_id} disabled>
-                          <span className="flex min-w-0 items-center gap-2">
-                            <span className="truncate font-mono text-xs">{account.account_id}</span>
-                            {isOriginal ? (
-                              <Badge variant="secondary">{t("replayPage.account.original")}</Badge>
-                            ) : null}
-                            <AlertCircleIcon className="text-destructive size-3.5" />
-                          </span>
-                        </SelectItem>
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>{reason}</TooltipContent>
-                  </Tooltip>
+                  <SelectItem key={account.account_id} value={account.account_id} disabled>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="truncate font-mono text-xs">{account.account_id}</span>
+                          {isOriginal ? (
+                            <Badge variant="secondary">{t("replayPage.account.original")}</Badge>
+                          ) : null}
+                          <AlertCircleIcon className="text-destructive size-3.5" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>{reason}</TooltipContent>
+                    </Tooltip>
+                  </SelectItem>
                 )
               })}
             </SelectContent>

--- a/admin-ui/src/components/replay/replay-body-editor.tsx
+++ b/admin-ui/src/components/replay/replay-body-editor.tsx
@@ -1,0 +1,119 @@
+import { CircleCheckIcon, OctagonXIcon } from "lucide-react"
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+export type ReplayBodyKind = "json" | "text" | "binary"
+
+export type ReplayBodyEditorProps = {
+  value: string
+  kind: ReplayBodyKind
+  originalValue: string
+  onChange: (value: string) => void
+}
+
+export function validateReplayBody(
+  bodyText: string,
+  kind: ReplayBodyKind,
+): { ok: true } | { ok: false; message: string } {
+  if (kind !== "json") return { ok: true }
+  if (!bodyText.trim()) return { ok: true }
+  try {
+    JSON.parse(bodyText)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, message: (err as Error).message }
+  }
+}
+
+export function ReplayBodyEditor({
+  value,
+  kind,
+  originalValue,
+  onChange,
+}: ReplayBodyEditorProps): React.JSX.Element {
+  const { t } = useTranslation()
+  const validation = useMemo(() => validateReplayBody(value, kind), [kind, value])
+  const binaryPreview = value.length > 600 ? `${value.slice(0, 600)}…` : value
+
+  function reset(): void {
+    onChange(originalValue)
+  }
+
+  function formatJson(): void {
+    try {
+      const formatted = JSON.stringify(JSON.parse(value), null, 2)
+      onChange(formatted)
+    } catch {
+      toast.error(t("replayPage.body.formatError"))
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="text-base">{t("replayPage.body.title")}</CardTitle>
+          <div className="flex items-center gap-2">
+            {kind === "json" ? (
+              <Button type="button" variant="outline" size="sm" onClick={formatJson}>
+                {t("replayPage.body.format")}
+              </Button>
+            ) : null}
+            {kind !== "binary" ? (
+              <Button type="button" variant="outline" size="sm" onClick={reset}>
+                {t("replayPage.body.reset")}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+
+        {kind === "json" ? (
+          <div
+            className={cn(
+              "flex items-start gap-2 text-sm",
+              validation.ok ? "text-green-600 dark:text-green-400" : "text-destructive",
+            )}
+            role="status"
+            aria-live="polite"
+          >
+            {validation.ok ? (
+              <CircleCheckIcon className="mt-0.5 size-4 shrink-0" />
+            ) : (
+              <OctagonXIcon className="mt-0.5 size-4 shrink-0" />
+            )}
+            <span>
+              {validation.ok
+                ? t("replayPage.body.valid")
+                : `${t("replayPage.body.invalid")}: ${validation.message}`}
+            </span>
+          </div>
+        ) : null}
+      </CardHeader>
+
+      <CardContent>
+        {kind === "binary" ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">{t("replayPage.body.binaryReadOnly")}</p>
+            <div className="max-h-[320px] overflow-auto rounded-md border bg-muted/30 p-3 font-mono text-xs whitespace-pre-wrap break-all text-muted-foreground">
+              {binaryPreview || "—"}
+            </div>
+          </div>
+        ) : (
+          <Textarea
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            className="min-h-[300px] resize-y font-mono text-sm"
+            aria-invalid={kind === "json" && !validation.ok}
+            spellCheck={false}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/admin-ui/src/components/replay/replay-context-card.tsx
+++ b/admin-ui/src/components/replay/replay-context-card.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from "react-i18next"
+
+import type { OutboundBlob } from "@/lib/admin-api"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "@/components/ui/table"
+
+const EMPTY = "—"
+
+type ReplayContextCardProps = {
+  blob: OutboundBlob
+}
+
+function StatusBadge({ status }: { status: number }): React.JSX.Element {
+  return status >= 400 ? (
+    <Badge variant="destructive">{status}</Badge>
+  ) : (
+    <Badge variant="secondary">{status}</Badge>
+  )
+}
+
+export function ReplayContextCard({
+  blob,
+}: ReplayContextCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("replayPage.contextTitle")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell className="w-40 text-muted-foreground">
+                request_id
+              </TableCell>
+              <TableCell className="font-mono text-xs whitespace-normal break-words">
+                {blob.request_id}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">path</TableCell>
+              <TableCell className="font-mono text-xs whitespace-normal break-words">
+                {blob.original?.path || EMPTY}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">
+                upstream_endpoint
+              </TableCell>
+              <TableCell className="font-mono text-xs whitespace-normal break-words">
+                {blob.original?.upstream_endpoint || EMPTY}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">
+                upstream_model
+              </TableCell>
+              <TableCell className="font-mono text-xs whitespace-normal break-words">
+                {blob.original?.upstream_model || EMPTY}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">client_model</TableCell>
+              <TableCell className="font-mono text-xs whitespace-normal break-words">
+                {blob.original?.client_model || EMPTY}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">
+                response_status
+              </TableCell>
+              <TableCell>
+                <StatusBadge status={blob.response_status} />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/admin-ui/src/components/replay/replay-headers-editor.tsx
+++ b/admin-ui/src/components/replay/replay-headers-editor.tsx
@@ -1,0 +1,159 @@
+import { PlusIcon, TrashIcon } from "lucide-react"
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+
+export type HeaderEntry = {
+  key: string
+  value: string
+  editable: boolean
+}
+
+type ReplayHeadersEditorProps = {
+  headers: Array<HeaderEntry>
+  onChange: (headers: Array<HeaderEntry>) => void
+}
+
+const HEADER_KEY_PATTERN = /^[A-Za-z0-9-]+$/
+const SENSITIVE_HEADER_PATTERNS = [
+  /^authorization$/i,
+  /^x-github-token$/i,
+  /-token$/i,
+  /-secret$/i,
+  /^cookie$/i,
+  /^x-api-key$/i,
+]
+
+function isSensitiveHeaderKey(value: string): boolean {
+  return SENSITIVE_HEADER_PATTERNS.some((pattern) => pattern.test(value.trim()))
+}
+
+function isValidHeaderKey(value: string): boolean {
+  return value.length > 0 && HEADER_KEY_PATTERN.test(value)
+}
+
+export function ReplayHeadersEditor({
+  headers,
+  onChange,
+}: ReplayHeadersEditorProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const lockedHeaders = useMemo(
+    () => headers.filter((header) => !header.editable),
+    [headers],
+  )
+  const editableHeaders = useMemo(
+    () => headers.filter((header) => header.editable),
+    [headers],
+  )
+
+  function updateEditableHeader(
+    index: number,
+    field: "key" | "value",
+    nextValue: string,
+  ): void {
+    const nextHeaders = editableHeaders.map((header, headerIndex) => {
+      if (headerIndex !== index) return header
+
+      if (field === "key" && isSensitiveHeaderKey(nextValue)) {
+        toast.error(t("replayPage.headers.sensitiveKey"))
+        return header
+      }
+
+      return {
+        ...header,
+        [field]: nextValue,
+      }
+    })
+
+    onChange([...lockedHeaders, ...nextHeaders])
+  }
+
+  function deleteEditableHeader(index: number): void {
+    onChange([
+      ...lockedHeaders,
+      ...editableHeaders.filter((_, headerIndex) => headerIndex !== index),
+    ])
+  }
+
+  function addHeader(): void {
+    onChange([
+      ...lockedHeaders,
+      ...editableHeaders,
+      { key: "", value: "", editable: true },
+    ])
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("replayPage.headers.title")}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {lockedHeaders.length > 0 ? (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">
+              {t("replayPage.headers.authTitle")}
+            </p>
+            <div className="space-y-2">
+              {lockedHeaders.map((header, index) => (
+                <div key={`${header.key}-${index}`} className="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                  <Input value={header.key} disabled readOnly />
+                  <Input value="***" disabled readOnly />
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="space-y-2">
+          {editableHeaders.map((header, index) => {
+            const showInvalidState = header.key.length > 0 && !isValidHeaderKey(header.key)
+            return (
+              <div
+                key={`${header.key}-${index}`}
+                className="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+              >
+                <Input
+                  value={header.key}
+                  onChange={(event) => updateEditableHeader(index, "key", event.target.value)}
+                  placeholder={t("replayPage.headers.keyPlaceholder")}
+                  aria-invalid={showInvalidState}
+                />
+                <Input
+                  value={header.value}
+                  onChange={(event) => updateEditableHeader(index, "value", event.target.value)}
+                  placeholder={t("replayPage.headers.valuePlaceholder")}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0 self-start text-muted-foreground"
+                  onClick={() => deleteEditableHeader(index)}
+                  aria-label={t("settingsPage.common.remove")}
+                >
+                  <TrashIcon className="size-4" />
+                </Button>
+                {showInvalidState ? (
+                  <p className="text-destructive md:col-span-3 text-xs" role="alert">
+                    {t("replayPage.headers.invalidKey")}
+                  </p>
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+
+        <Button type="button" variant="outline" onClick={addHeader}>
+          <PlusIcon className="size-4" />
+          {t("replayPage.headers.addHeader")}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/admin-ui/src/components/replay/replay-response-panel.tsx
+++ b/admin-ui/src/components/replay/replay-response-panel.tsx
@@ -1,0 +1,286 @@
+import {
+  ClipboardCopyIcon,
+  DownloadIcon,
+  LoaderCircleIcon,
+} from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+
+import { type ReplayCollectResult } from "@/lib/admin-api"
+import type { SSEEvent } from "@/lib/sse"
+import { fmtLocalDateTime } from "@/lib/format"
+import { JsonViewer } from "@/components/json/json-viewer"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+export type ReplayResponsePanelProps = {
+  result: ReplayCollectResult | null
+  liveEvents: Array<SSEEvent> | null
+  loading: boolean
+  originalPath: string | null
+}
+
+/* ---- helpers ---- */
+
+function statusVariant(status: number): "destructive" | "secondary" {
+  return status >= 400 ? "destructive" : "secondary"
+}
+
+function tryParseJson(text: string): unknown | null {
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return null
+  }
+}
+
+const HIGHLIGHT_HEADERS = [
+  "retry-after",
+  "x-request-id",
+  "x-ratelimit-limit",
+  "x-ratelimit-remaining",
+  "x-ratelimit-reset",
+]
+
+function getRawText(result: ReplayCollectResult | null, liveEvents: Array<SSEEvent> | null): string {
+  if (result) return result.raw.body
+  if (liveEvents) return liveEvents.map((e) => (e.event ? `event: ${e.event}\n` : "") + `data: ${e.data}`).join("\n\n")
+  return ""
+}
+
+function copyRaw(text: string, t: (k: string) => string): void {
+  void navigator.clipboard.writeText(text).then(
+    () => toast.success(t("requestDetailPage.toast.copiedJson")),
+    (err) => toast.error(t("requestDetailPage.toast.copyFailed"), { description: String(err) }),
+  )
+}
+
+function downloadRaw(text: string, requestId: string, t: (k: string) => string): void {
+  try {
+    const blob = new Blob([text], { type: "text/plain" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `replay-${requestId}.txt`
+    a.click()
+    URL.revokeObjectURL(url)
+    toast.success(t("requestDetailPage.toast.downloadedJson"))
+  } catch (err) {
+    toast.error(t("requestDetailPage.toast.downloadFailed"), { description: String(err) })
+  }
+}
+
+export function ReplayResponsePanel({
+  result,
+  liveEvents,
+  loading,
+  originalPath,
+}: ReplayResponsePanelProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  const hasData = Boolean(result) || (liveEvents && liveEvents.length > 0)
+  const rawText = getRawText(result, liveEvents)
+
+  return (
+    <Card className="flex flex-col overflow-hidden">
+      <CardHeader className="flex-row items-center gap-2 space-y-0 pb-2">
+        <CardTitle className="text-base">{t("replayPage.response.title")}</CardTitle>
+        {hasData && (
+          <div className="ml-auto flex items-center gap-1.5">
+            <Button variant="ghost" size="sm" onClick={() => copyRaw(rawText, t)}>
+              <ClipboardCopyIcon className="size-4" />
+              {t("common.copy")}
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => downloadRaw(rawText, "response", t)}>
+              <DownloadIcon className="size-4" />
+              {t("common.download")}
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+
+      {/* Summary bar */}
+      {result && (
+        <div className="border-b px-4 pb-2 flex flex-wrap items-center gap-3 text-xs">
+          <span className="text-muted-foreground">{t("replayPage.response.status")}</span>
+          <Badge variant={statusVariant(result.status)}>{result.status} {result.statusText}</Badge>
+          <span className="text-muted-foreground">{t("replayPage.response.duration")}</span>
+          <span className="font-mono">{result.durationMs}ms</span>
+          <span className="text-muted-foreground">{t("replayPage.response.replayedAt")}</span>
+          <span className="font-mono">{fmtLocalDateTime(result.replayedAt) ?? "—"}</span>
+        </div>
+      )}
+
+      <CardContent className="flex-1 overflow-auto pt-2">
+        {loading && (
+          <div className="flex items-center justify-center py-12">
+            <LoaderCircleIcon className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {!loading && !hasData && (
+          <p className="text-muted-foreground text-sm py-8 text-center">
+            {t("replayPage.response.empty")}
+          </p>
+        )}
+
+        {!loading && hasData && (
+          <ResponseTabs result={result} liveEvents={liveEvents} originalPath={originalPath} />
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ResponseTabs({
+  result,
+  liveEvents,
+  originalPath,
+}: {
+  result: ReplayCollectResult | null
+  liveEvents: Array<SSEEvent> | null
+  originalPath: string | null
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Tabs defaultValue="raw" className="gap-2">
+      <TabsList>
+        <TabsTrigger value="raw">{t("replayPage.response.tabRaw")}</TabsTrigger>
+        <TabsTrigger value="translated">{t("replayPage.response.tabTranslated")}</TabsTrigger>
+        <TabsTrigger value="headers">{t("replayPage.response.tabHeaders")}</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="raw">
+        <RawTab result={result} liveEvents={liveEvents} />
+      </TabsContent>
+
+      <TabsContent value="translated">
+        <TranslatedTab result={result} liveEvents={liveEvents} originalPath={originalPath} />
+      </TabsContent>
+
+      <TabsContent value="headers">
+        <HeadersTab result={result} />
+      </TabsContent>
+    </Tabs>
+  )
+}
+
+function RawTab({
+  result,
+  liveEvents,
+}: {
+  result: ReplayCollectResult | null
+  liveEvents: Array<SSEEvent> | null
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  if (liveEvents && !result) {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+          <LoaderCircleIcon className="size-3.5 animate-spin" />
+          {t("replayPage.response.streamingChunks", { count: liveEvents.length })}
+        </p>
+        <pre className="bg-muted/20 overflow-auto rounded-md border p-3 font-mono text-xs max-h-[60vh] whitespace-pre-wrap break-words">
+          {liveEvents.map((e) => (e.event ? `event: ${e.event}\n` : "") + `data: ${e.data}`).join("\n\n")}
+        </pre>
+      </div>
+    )
+  }
+
+  if (!result) return <></>
+
+  if (result.raw.kind === "json") {
+    const parsed = tryParseJson(result.raw.body)
+    if (parsed !== null) return <JsonViewer value={parsed} defaultExpandedDepth={3} />
+    return <pre className="bg-muted/20 overflow-auto rounded-md border p-3 font-mono text-xs max-h-[60vh] whitespace-pre-wrap break-words">{result.raw.body}</pre>
+  }
+
+  return (
+    <pre className="bg-muted/20 overflow-auto rounded-md border p-3 font-mono text-xs max-h-[60vh] whitespace-pre-wrap break-words">
+      {result.raw.body}
+    </pre>
+  )
+}
+
+function TranslatedTab({
+  result,
+  liveEvents,
+  originalPath,
+}: {
+  result: ReplayCollectResult | null
+  liveEvents: Array<SSEEvent> | null
+  originalPath: string | null
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  if (originalPath !== "/v1/messages") {
+    return <p className="text-muted-foreground text-sm py-4">{t("replayPage.response.translationUnavailable")}</p>
+  }
+
+  if (liveEvents && !result) {
+    return (
+      <p className="text-muted-foreground text-sm py-4 flex items-center gap-1.5">
+        <LoaderCircleIcon className="size-3.5 animate-spin" />
+        {t("replayPage.response.streamingTranslation")}
+      </p>
+    )
+  }
+
+  if (!result) return <></>
+
+  const translated = result.translated
+  if (translated && typeof translated === "object" && "error" in (translated as Record<string, unknown>)) {
+    return (
+      <p className="text-destructive text-sm py-4">
+        {t("replayPage.response.translationError")}: {String((translated as { error: unknown }).error)}
+      </p>
+    )
+  }
+
+  if (translated != null) return <JsonViewer value={translated} defaultExpandedDepth={3} />
+
+  return <p className="text-muted-foreground text-sm py-4">{t("replayPage.response.translationUnavailable")}</p>
+}
+
+function HeadersTab({
+  result,
+}: {
+  result: ReplayCollectResult | null
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  if (!result) {
+    return <p className="text-muted-foreground text-sm py-4">{t("replayPage.response.empty")}</p>
+  }
+
+  const entries = Object.entries(result.headers)
+  if (entries.length === 0) {
+    return <p className="text-muted-foreground text-sm py-4">No headers</p>
+  }
+
+  return (
+    <div className="overflow-auto rounded-md border">
+      <table className="w-full text-xs">
+        <tbody>
+          {entries.map(([key, value]) => (
+            <tr key={key} className="border-b last:border-b-0">
+              <td className={`px-3 py-1.5 font-mono font-medium whitespace-nowrap ${HIGHLIGHT_HEADERS.some((h) => key.toLowerCase().startsWith(h)) ? "text-foreground bg-accent/30" : "text-muted-foreground"}`}>
+                {key}
+              </td>
+              <td className="px-3 py-1.5 font-mono break-all">{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -115,6 +115,7 @@ export type AdminRequestsResponse = {
 
 export type AdminRequestDetailResponse = {
   item: AdminRequestItem | null
+  has_outbound?: boolean
 }
 
 export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
@@ -396,12 +397,14 @@ export async function queryAdminRequests(params: {
 export async function getAdminRequestDetail(
   requestId: string
 ): Promise<AdminRequestDetailResponse> {
-  const response = await fetchAdminJson<{ item: AdminRequestItemWire | null }>(
-    `/api/admin/requests/${encodeURIComponent(requestId)}`
-  )
+  const response = await fetchAdminJson<{
+    item: AdminRequestItemWire | null
+    has_outbound?: boolean
+  }>(`/api/admin/requests/${encodeURIComponent(requestId)}`)
 
   return {
     item: response.item ? normalizeAdminRequestItem(response.item) : null,
+    has_outbound: response.has_outbound,
   }
 }
 

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -1,5 +1,7 @@
 import { readAdminToken } from "@/lib/admin-token"
 
+import type { SSEEvent } from "./sse"
+
 export const ADMIN_TOKEN_REQUIRED_EVENT = "admin-ui:admin-token-required"
 
 // Wire types from backend (SQLite 0/1/null)
@@ -219,6 +221,53 @@ export type PremiumStatsResponse = {
   range: { from: string; to: string; granularity: "day" | "hour" }
 }
 
+export type DevModeState = {
+  enabled: boolean
+  capture4xx: boolean
+}
+
+export type OutboundBlob = {
+  request_id: string
+  captured_at_ms: number
+  http_status: number
+  upstream_url: string
+  upstream_method: string
+  request_headers: Record<string, string>
+  request_body: string | null
+  request_body_kind: "json" | "text" | "binary"
+  response_status: number
+  response_headers: Record<string, string>
+  response_body: string | null
+  response_body_kind: "json" | "sse" | "text"
+  redacted_header_keys: Array<string>
+  original: {
+    path: string
+    upstream_endpoint: string | null
+    upstream_model: string | null
+    account_id: string | null
+    client_model: string | null
+  } | null
+}
+
+export type ReplayRequest = {
+  accountId: string
+  overrides?: {
+    body?: string
+    headers?: Record<string, string>
+  }
+  mode: "collect" | "live"
+}
+
+export type ReplayCollectResult = {
+  status: number
+  statusText: string
+  headers: Record<string, string>
+  raw: { body: string; kind: "json" | "sse" | "text" }
+  translated: unknown
+  durationMs: number
+  replayedAt: number
+}
+
 export class AdminApiError extends Error {
   readonly status: number
   readonly responseText: string
@@ -235,11 +284,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-async function fetchAdminJson<T>(
-  path: string,
+function buildAdminHeaders(
   init?: RequestInit,
   overrideToken?: string,
-): Promise<T> {
+): Headers {
   const token = overrideToken?.trim() ?? readAdminToken()
   const headers = new Headers(init?.headers ?? undefined)
 
@@ -251,31 +299,44 @@ async function fetchAdminJson<T>(
     headers.set("content-type", "application/json")
   }
 
+  return headers
+}
+
+async function readAdminError(res: Response): Promise<string> {
+  const txt = await res.text().catch(() => "")
+  let message = txt
+
+  try {
+    const parsed = JSON.parse(txt) as unknown
+    if (isPlainObject(parsed) && "error" in parsed) {
+      const err = (parsed as { error?: unknown }).error
+      if (isPlainObject(err) && typeof (err as { message?: unknown }).message === "string") {
+        message = (err as { message: string }).message
+      }
+    }
+  } catch {
+    // ignore JSON parsing errors and keep raw text
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(ADMIN_TOKEN_REQUIRED_EVENT))
+    }
+  }
+
+  return message
+}
+
+async function fetchAdminJson<T>(
+  path: string,
+  init?: RequestInit,
+  overrideToken?: string,
+): Promise<T> {
+  const headers = buildAdminHeaders(init, overrideToken)
   const res = await fetch(path, { ...init, headers })
 
   if (!res.ok) {
-    const txt = await res.text().catch(() => "")
-    let message = txt
-
-    try {
-      const parsed = JSON.parse(txt) as unknown
-      if (isPlainObject(parsed) && "error" in parsed) {
-        const err = (parsed as { error?: unknown }).error
-        if (isPlainObject(err) && typeof (err as { message?: unknown }).message === "string") {
-          message = (err as { message: string }).message
-        }
-      }
-    } catch {
-      // ignore JSON parsing errors and keep raw text
-    }
-
-    if (res.status === 401 || res.status === 403) {
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new Event(ADMIN_TOKEN_REQUIRED_EVENT))
-      }
-    }
-
-    throw new AdminApiError(res.status, message)
+    throw new AdminApiError(res.status, await readAdminError(res))
   }
 
   return (await res.json()) as T
@@ -383,6 +444,73 @@ export async function getAdminPremiumStats(params: {
   return fetchAdminJson<PremiumStatsResponse>(
     `/api/admin/stats/premium-daily?${q.toString()}`,
   )
+}
+
+export async function getDevMode(): Promise<DevModeState> {
+  return fetchAdminJson<DevModeState>("/api/admin/dev-mode")
+}
+
+export async function setDevMode(
+  patch: Partial<DevModeState>,
+): Promise<DevModeState> {
+  return fetchAdminJson<DevModeState>("/api/admin/dev-mode", {
+    method: "POST",
+    body: JSON.stringify(patch),
+  })
+}
+
+export async function getRequestOutbound(
+  requestId: string,
+): Promise<OutboundBlob> {
+  return fetchAdminJson<OutboundBlob>(
+    `/api/admin/requests/${encodeURIComponent(requestId)}/outbound`,
+  )
+}
+
+export async function replayCollect(
+  requestId: string,
+  req: Omit<ReplayRequest, "mode">,
+): Promise<ReplayCollectResult> {
+  return fetchAdminJson<ReplayCollectResult>(
+    `/api/admin/requests/${encodeURIComponent(requestId)}/replay`,
+    {
+      method: "POST",
+      body: JSON.stringify({ ...req, mode: "collect" }),
+    },
+  )
+}
+
+export async function replayLive(
+  requestId: string,
+  req: Omit<ReplayRequest, "mode">,
+  onEvent: (event: SSEEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const headers = buildAdminHeaders(
+    {
+      body: JSON.stringify({ ...req, mode: "live" }),
+      headers: { "content-type": "application/json" },
+    },
+  )
+  const res = await fetch(
+    `/api/admin/requests/${encodeURIComponent(requestId)}/replay`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ ...req, mode: "live" }),
+      signal,
+    },
+  )
+
+  if (!res.ok || !res.body) {
+    throw new AdminApiError(
+      res.status,
+      !res.ok ? await readAdminError(res) : "Response body is missing",
+    )
+  }
+
+  const { parseSSEStream } = await import("./sse")
+  await parseSSEStream(res.body.getReader(), onEvent, signal)
 }
 
 // --- Account Management Types ---

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -51,6 +51,8 @@ type AdminRequestItemWire = {
   selection_reason?: string | null
   upstream_error_message_raw?: string | null
 
+  has_outbound?: boolean
+
   error?: unknown
 }
 
@@ -225,6 +227,8 @@ export type PremiumStatsResponse = {
 export type DevModeState = {
   enabled: boolean
   capture4xx: boolean
+  capture5xx: boolean
+  captureOther: boolean
 }
 
 export type OutboundBlob = {

--- a/admin-ui/src/lib/sse.ts
+++ b/admin-ui/src/lib/sse.ts
@@ -1,0 +1,34 @@
+export type SSEEvent = {
+  event?: string
+  data: string
+}
+
+export async function parseSSEStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  onEvent: (event: SSEEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  while (!signal?.aborted) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    let boundary = buffer.indexOf("\n\n")
+    while (boundary >= 0) {
+      const raw = buffer.slice(0, boundary)
+      buffer = buffer.slice(boundary + 2)
+
+      let event: string | undefined
+      const dataLines: Array<string> = []
+      for (const line of raw.split("\n")) {
+        if (line.startsWith("event:")) event = line.slice(6).trim()
+        else if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart())
+      }
+      if (dataLines.length > 0) onEvent({ event, data: dataLines.join("\n") })
+      boundary = buffer.indexOf("\n\n")
+    }
+  }
+}

--- a/admin-ui/src/lib/sse.ts
+++ b/admin-ui/src/lib/sse.ts
@@ -31,4 +31,5 @@ export async function parseSSEStream(
       boundary = buffer.indexOf("\n\n")
     }
   }
+  buffer += decoder.decode()
 }

--- a/admin-ui/src/lib/sse.ts
+++ b/admin-ui/src/lib/sse.ts
@@ -32,4 +32,14 @@ export async function parseSSEStream(
     }
   }
   buffer += decoder.decode()
+
+  if (buffer.trim()) {
+    let event: string | undefined
+    const dataLines: Array<string> = []
+    for (const line of buffer.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim()
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart())
+    }
+    if (dataLines.length > 0) onEvent({ event, data: dataLines.join("\n") })
+  }
 }

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -352,6 +352,21 @@
       "diff": "Change"
     }
   },
+  "replayPage": {
+    "title": "Request Replay",
+    "back": "Back to detail",
+    "reset": "Reset",
+    "noBlob": "No outbound data captured for this request.",
+    "noBlobHint": "This request did not trigger 4xx capture or predates Developer Mode.",
+    "devModeDisabled": "Developer Mode is disabled.",
+    "devModeDisabledHint": "Enable Developer Mode in Settings to use request replay.",
+    "loadError": "Failed to load replay data.",
+    "contextTitle": "Original Request",
+    "placeholderAccount": "Account selection (coming soon)",
+    "placeholderHeaders": "Headers editor (coming soon)",
+    "placeholderBody": "Body editor (coming soon)",
+    "placeholderResponse": "Response panel (coming soon)"
+  },
   "jsonViewer": {
     "expand": "Expand",
     "collapse": "Collapse",
@@ -377,6 +392,7 @@
       "aliases": "Aliases",
       "prompts": "Prompts",
       "advanced": "Advanced",
+      "devMode": "Developer Mode",
       "providers": "Providers"
     },
     "navigation": {
@@ -390,7 +406,9 @@
       "loadModelsFailed": "Failed to load models",
       "loadConfigFailed": "Failed to load config",
       "configSaved": "Config saved",
-      "saveConfigFailed": "Failed to save config"
+      "saveConfigFailed": "Failed to save config",
+      "devModeSaved": "Developer mode updated",
+      "saveDevModeFailed": "Failed to update developer mode"
     },
     "common": {
       "defaultOption": "(default)",
@@ -461,6 +479,15 @@
       "blockOriginal": "Block original model ID",
       "emptyState": "No model aliases configured.",
       "addButton": "Add alias"
+    },
+    "devMode": {
+      "title": "Developer Mode",
+      "description": "Enable in-app request replay and 4xx outbound capture for debugging.",
+      "enable": "Enable Developer Mode",
+      "enableHint": "Required to access the Replay page. Backend enforces this flag.",
+      "capture": "Capture 4xx upstream payloads",
+      "captureHint": "Persists full outbound body + redacted headers to admin.sqlite when upstream returns 4xx. Cleaned up with request history (35 days).",
+      "captureDisabled": "Enable Developer Mode first."
     },
     "advanced": {
       "title": "Advanced",

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -454,6 +454,7 @@
     },
     "toast": {
       "loadModelsFailed": "Failed to load models",
+      "loadDevModeFailed": "Failed to load Developer Mode settings",
       "loadConfigFailed": "Failed to load config",
       "configSaved": "Config saved",
       "saveConfigFailed": "Failed to save config",

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -77,6 +77,7 @@
     "back": "Back",
     "download": "Download",
     "copyJson": "Copy JSON",
+    "copy": "Copy",
     "actions": "Actions",
     "enabled": "Enabled"
   },

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -209,7 +209,8 @@
       "quota": "Premium interactions quota remaining after this request.",
       "duration": "Total response time in seconds.",
       "tokens": "Total tokens consumed (input + output)."
-    }
+    },
+    "replayAvailable": "Replay available"
   },
   "modelsPage": {
     "title": "Models",
@@ -531,11 +532,14 @@
     },
     "devMode": {
       "title": "Developer Mode",
-      "description": "Enable in-app request replay and 4xx outbound capture for debugging.",
+      "description": "Enable in-app request replay and outbound capture for debugging.",
       "enable": "Enable Developer Mode",
       "enableHint": "Required to access the Replay page. Backend enforces this flag.",
-      "capture": "Capture 4xx upstream payloads",
-      "captureHint": "Persists full outbound body + redacted headers to admin.sqlite when upstream returns 4xx. Cleaned up with request history (35 days).",
+      "captureLabel": "Capture upstream responses",
+      "capture4xx": "4xx",
+      "capture5xx": "5xx",
+      "captureOther": "Other",
+      "captureHint": "Persists full outbound body + redacted headers to admin.sqlite. Cleaned up with request history (35 days).",
       "captureDisabled": "Enable Developer Mode first."
     },
     "advanced": {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -366,8 +366,16 @@
     "devModeDisabledHint": "Enable Developer Mode in Settings to use request replay.",
     "loadError": "Failed to load replay data.",
     "contextTitle": "Original Request",
-    "placeholderBody": "Body editor (coming soon)",
     "placeholderResponse": "Response panel (coming soon)",
+    "body": {
+      "title": "Request Body",
+      "format": "Format",
+      "reset": "Reset",
+      "valid": "Valid JSON",
+      "invalid": "Invalid JSON",
+      "binaryReadOnly": "Binary body — content is read-only.",
+      "formatError": "Cannot format: invalid JSON"
+    },
     "account": {
       "label": "Account",
       "original": "original",

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -350,6 +350,10 @@
       "before": "Before",
       "after": "After",
       "diff": "Change"
+    },
+    "replay": {
+      "button": "Replay",
+      "noBlob": "No outbound data captured. This request did not trigger 4xx capture or predates Developer Mode."
     }
   },
   "replayPage": {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -389,6 +389,30 @@
       "valuePlaceholder": "Header value",
       "invalidKey": "Invalid header name",
       "sensitiveKey": "Cannot add sensitive header — auth headers are managed automatically."
+    },
+    "send": {
+      "button": "Send",
+      "cancel": "Cancel",
+      "sending": "Sending...",
+      "streaming": "Streaming...",
+      "modeCollect": "Collect",
+      "modeLive": "Live",
+      "modeHint": "Collect buffers the full response; Live streams chunks in real-time.",
+      "quotaWarning": "Replay sends a real request to GitHub and consumes upstream quota."
+    },
+    "response": {
+      "title": "Response",
+      "tabRaw": "Raw",
+      "tabTranslated": "Translated",
+      "tabHeaders": "Headers",
+      "empty": "Send a request to see the response.",
+      "translationUnavailable": "Translation only available for /v1/messages requests.",
+      "translationError": "Translation failed",
+      "streamingChunks": "Streaming... {{count}} chunks",
+      "streamingTranslation": "Waiting for translation...",
+      "status": "Status",
+      "duration": "Duration",
+      "replayedAt": "Replayed at"
     }
   },
   "jsonViewer": {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -366,10 +366,22 @@
     "devModeDisabledHint": "Enable Developer Mode in Settings to use request replay.",
     "loadError": "Failed to load replay data.",
     "contextTitle": "Original Request",
-    "placeholderAccount": "Account selection (coming soon)",
-    "placeholderHeaders": "Headers editor (coming soon)",
     "placeholderBody": "Body editor (coming soon)",
-    "placeholderResponse": "Response panel (coming soon)"
+    "placeholderResponse": "Response panel (coming soon)",
+    "account": {
+      "label": "Account",
+      "original": "original",
+      "noAccounts": "No available accounts"
+    },
+    "headers": {
+      "title": "Request Headers",
+      "authTitle": "Auth Headers (read-only)",
+      "addHeader": "Add header",
+      "keyPlaceholder": "Header name",
+      "valuePlaceholder": "Header value",
+      "invalidKey": "Invalid header name",
+      "sensitiveKey": "Cannot add sensitive header — auth headers are managed automatically."
+    }
   },
   "jsonViewer": {
     "expand": "Expand",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -389,6 +389,30 @@
       "valuePlaceholder": "请求头值",
       "invalidKey": "无效的请求头名称",
       "sensitiveKey": "无法添加敏感请求头 — 认证头由系统自动管理。"
+    },
+    "send": {
+      "button": "发送",
+      "cancel": "取消",
+      "sending": "发送中...",
+      "streaming": "流式传输中...",
+      "modeCollect": "收集",
+      "modeLive": "实时",
+      "modeHint": "收集模式缓冲完整响应；实时模式逐块流式传输。",
+      "quotaWarning": "重放会向 GitHub 发送真实请求并消耗上游配额。"
+    },
+    "response": {
+      "title": "响应",
+      "tabRaw": "原始",
+      "tabTranslated": "转换后",
+      "tabHeaders": "响应头",
+      "empty": "发送请求以查看响应。",
+      "translationUnavailable": "转换仅适用于 /v1/messages 请求。",
+      "translationError": "转换失败",
+      "streamingChunks": "流式传输中... {{count}} 个块",
+      "streamingTranslation": "等待转换结果...",
+      "status": "状态",
+      "duration": "耗时",
+      "replayedAt": "重放时间"
     }
   },
   "jsonViewer": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -209,7 +209,8 @@
       "quota": "此请求完成后剩余的 Premium 交互额度。",
       "duration": "总响应时间（秒）。",
       "tokens": "消耗的总 token 数（输入 + 输出）。"
-    }
+    },
+    "replayAvailable": "可重放"
   },
   "modelsPage": {
     "title": "模型",
@@ -531,11 +532,14 @@
     },
     "devMode": {
       "title": "开发者模式",
-      "description": "启用请求重放和 4xx 上游请求捕获，用于调试。",
+      "description": "启用请求重放和上游请求捕获，用于调试。",
       "enable": "启用开发者模式",
       "enableHint": "启用后才能访问重放页面。后端强制校验此开关。",
-      "capture": "捕获 4xx 上游请求",
-      "captureHint": "当上游返回 4xx 时，将完整的出站请求体和脱敏后的请求头持久化到 admin.sqlite。随请求历史一起清理（35 天）。",
+      "captureLabel": "捕获上游响应",
+      "capture4xx": "4xx",
+      "capture5xx": "5xx",
+      "captureOther": "其它",
+      "captureHint": "将完整的出站请求体和脱敏后的请求头持久化到 admin.sqlite。随请求历史一起清理（35 天）。",
       "captureDisabled": "请先启用开发者模式。"
     },
     "advanced": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -352,6 +352,21 @@
       "diff": "变化"
     }
   },
+  "replayPage": {
+    "title": "请求重放",
+    "back": "返回详情",
+    "reset": "重置",
+    "noBlob": "此请求没有捕获到出站数据。",
+    "noBlobHint": "该请求未触发 4xx 捕获，或发生在开发者模式启用之前。",
+    "devModeDisabled": "开发者模式未启用。",
+    "devModeDisabledHint": "请在设置中启用开发者模式以使用请求重放。",
+    "loadError": "加载重放数据失败。",
+    "contextTitle": "原始请求",
+    "placeholderAccount": "账号选择（即将推出）",
+    "placeholderHeaders": "请求头编辑器（即将推出）",
+    "placeholderBody": "请求体编辑器（即将推出）",
+    "placeholderResponse": "响应面板（即将推出）"
+  },
   "jsonViewer": {
     "expand": "展开",
     "collapse": "折叠",
@@ -377,6 +392,7 @@
       "aliases": "别名",
       "prompts": "提示词",
       "advanced": "高级",
+      "devMode": "开发者模式",
       "providers": "上游提供方"
     },
     "navigation": {
@@ -390,7 +406,9 @@
       "loadModelsFailed": "加载模型失败",
       "loadConfigFailed": "加载配置失败",
       "configSaved": "配置已保存",
-      "saveConfigFailed": "保存配置失败"
+      "saveConfigFailed": "保存配置失败",
+      "devModeSaved": "开发者模式已更新",
+      "saveDevModeFailed": "更新开发者模式失败"
     },
     "common": {
       "defaultOption": "(默认)",
@@ -461,6 +479,15 @@
       "blockOriginal": "阻止原始模型 ID",
       "emptyState": "未配置模型别名。",
       "addButton": "添加别名"
+    },
+    "devMode": {
+      "title": "开发者模式",
+      "description": "启用请求重放和 4xx 上游请求捕获，用于调试。",
+      "enable": "启用开发者模式",
+      "enableHint": "启用后才能访问重放页面。后端强制校验此开关。",
+      "capture": "捕获 4xx 上游请求",
+      "captureHint": "当上游返回 4xx 时，将完整的出站请求体和脱敏后的请求头持久化到 admin.sqlite。随请求历史一起清理（35 天）。",
+      "captureDisabled": "请先启用开发者模式。"
     },
     "advanced": {
       "title": "高级",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -454,6 +454,7 @@
     },
     "toast": {
       "loadModelsFailed": "加载模型失败",
+      "loadDevModeFailed": "加载开发者模式设置失败",
       "loadConfigFailed": "加载配置失败",
       "configSaved": "配置已保存",
       "saveConfigFailed": "保存配置失败",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -350,6 +350,10 @@
       "before": "之前",
       "after": "之后",
       "diff": "变化"
+    },
+    "replay": {
+      "button": "重放",
+      "noBlob": "未捕获出站数据。该请求未触发 4xx 捕获，或发生在开发者模式启用之前。"
     }
   },
   "replayPage": {

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -366,8 +366,16 @@
     "devModeDisabledHint": "请在设置中启用开发者模式以使用请求重放。",
     "loadError": "加载重放数据失败。",
     "contextTitle": "原始请求",
-    "placeholderBody": "请求体编辑器（即将推出）",
     "placeholderResponse": "响应面板（即将推出）",
+    "body": {
+      "title": "请求体",
+      "format": "格式化",
+      "reset": "重置",
+      "valid": "有效 JSON",
+      "invalid": "无效 JSON",
+      "binaryReadOnly": "二进制请求体 — 内容为只读。",
+      "formatError": "无法格式化：无效的 JSON"
+    },
     "account": {
       "label": "账号",
       "original": "原始",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -77,6 +77,7 @@
     "back": "返回",
     "download": "下载",
     "copyJson": "复制 JSON",
+    "copy": "复制",
     "actions": "操作",
     "enabled": "启用"
   },

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -366,10 +366,22 @@
     "devModeDisabledHint": "请在设置中启用开发者模式以使用请求重放。",
     "loadError": "加载重放数据失败。",
     "contextTitle": "原始请求",
-    "placeholderAccount": "账号选择（即将推出）",
-    "placeholderHeaders": "请求头编辑器（即将推出）",
     "placeholderBody": "请求体编辑器（即将推出）",
-    "placeholderResponse": "响应面板（即将推出）"
+    "placeholderResponse": "响应面板（即将推出）",
+    "account": {
+      "label": "账号",
+      "original": "原始",
+      "noAccounts": "没有可用账号"
+    },
+    "headers": {
+      "title": "请求头",
+      "authTitle": "认证头（只读）",
+      "addHeader": "添加请求头",
+      "keyPlaceholder": "请求头名称",
+      "valuePlaceholder": "请求头值",
+      "invalidKey": "无效的请求头名称",
+      "sensitiveKey": "无法添加敏感请求头 — 认证头由系统自动管理。"
+    }
   },
   "jsonViewer": {
     "expand": "展开",

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -372,8 +372,8 @@ export function RequestDetailPage(): React.JSX.Element {
           <CardHeader>
             <CardTitle>{t("requestDetailPage.summaryTitle")}</CardTitle>
           </CardHeader>
-          <CardContent>
-            <Table>
+          <CardContent className="overflow-hidden">
+            <Table className="table-fixed">
               <TableBody>
                 {/* ── Request ── */}
                 <SectionHeader

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeftIcon,
   DownloadIcon,
   LoaderCircleIcon,
+  PlayIcon,
   RefreshCwIcon,
 } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -13,6 +14,7 @@ import {
   AdminApiError,
   type AdminRequestItem,
   getAdminRequestDetail,
+  getDevMode,
 } from "@/lib/admin-api"
 import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
@@ -120,6 +122,8 @@ export function RequestDetailPage(): React.JSX.Element {
   const [item, setItem] = useState<AdminRequestItem | null>(null)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [search, setSearch] = useState("")
+  const [devModeEnabled, setDevModeEnabled] = useState(false)
+  const [hasOutbound, setHasOutbound] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -128,14 +132,20 @@ export function RequestDetailPage(): React.JSX.Element {
       setLoading(true)
       setFetchError(null)
       try {
-        const data = await getAdminRequestDetail(requestId)
+        const [detailData, devModeData] = await Promise.all([
+          getAdminRequestDetail(requestId),
+          getDevMode().catch(() => ({ enabled: false, capture4xx: false })),
+        ])
         if (cancelled) return
-        setItem(data.item)
+        setItem(detailData.item)
+        setDevModeEnabled(devModeData.enabled)
+        setHasOutbound(detailData.has_outbound === true)
       } catch (err) {
         if (cancelled) return
         const msg = err instanceof AdminApiError ? err.message : String(err)
         setFetchError(msg)
         setItem(null)
+        setHasOutbound(false)
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -150,9 +160,14 @@ export function RequestDetailPage(): React.JSX.Element {
 
   function refresh(): void {
     setRefreshing(true)
-    getAdminRequestDetail(requestId)
-      .then((data) => {
-        setItem(data.item)
+    Promise.all([
+      getAdminRequestDetail(requestId),
+      getDevMode().catch(() => ({ enabled: false, capture4xx: false })),
+    ])
+      .then(([detailData, devModeData]) => {
+        setItem(detailData.item)
+        setDevModeEnabled(devModeData.enabled)
+        setHasOutbound(detailData.has_outbound === true)
         setFetchError(null)
       })
       .catch((err: unknown) => {
@@ -167,14 +182,20 @@ export function RequestDetailPage(): React.JSX.Element {
   function retry(): void {
     setLoading(true)
     setFetchError(null)
-    getAdminRequestDetail(requestId)
-      .then((data) => {
-        setItem(data.item)
+    Promise.all([
+      getAdminRequestDetail(requestId),
+      getDevMode().catch(() => ({ enabled: false, capture4xx: false })),
+    ])
+      .then(([detailData, devModeData]) => {
+        setItem(detailData.item)
+        setDevModeEnabled(devModeData.enabled)
+        setHasOutbound(detailData.has_outbound === true)
       })
       .catch((err: unknown) => {
         const msg = err instanceof AdminApiError ? err.message : String(err)
         setFetchError(msg)
         setItem(null)
+        setHasOutbound(false)
       })
       .finally(() => setLoading(false))
   }
@@ -287,20 +308,43 @@ export function RequestDetailPage(): React.JSX.Element {
             {t("common.back")}
           </Link>
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="ml-auto"
-          disabled={refreshing}
-          onClick={refresh}
-        >
-          {refreshing ? (
-            <LoaderCircleIcon className="size-4 animate-spin" />
-          ) : (
-            <RefreshCwIcon className="size-4" />
+        <div className="ml-auto flex items-center gap-2">
+          {devModeEnabled && (
+            hasOutbound ? (
+              <Button variant="outline" size="sm" asChild>
+                <Link to={`/requests/${item.request_id}/replay`}>
+                  <PlayIcon className="size-4" />
+                  {t("requestDetailPage.replay.button")}
+                </Link>
+              </Button>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="sm" disabled>
+                    <PlayIcon className="size-4" />
+                    {t("requestDetailPage.replay.button")}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t("requestDetailPage.replay.noBlob")}
+                </TooltipContent>
+              </Tooltip>
+            )
           )}
-          {t("common.refresh")}
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={refreshing}
+            onClick={refresh}
+          >
+            {refreshing ? (
+              <LoaderCircleIcon className="size-4 animate-spin" />
+            ) : (
+              <RefreshCwIcon className="size-4" />
+            )}
+            {t("common.refresh")}
+          </Button>
+        </div>
       </div>
 
       {/* Header card */}

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -49,12 +49,16 @@ type ReplayForm = {
 }
 
 function buildReplayForm(blob: OutboundBlob): ReplayForm {
+  const redactedHeaderKeys = new Set(
+    blob.redacted_header_keys.map((key) => key.toLowerCase()),
+  )
+
   return {
     accountId: blob.original?.account_id ?? "",
     headers: Object.entries(blob.request_headers).map(([key, value]) => ({
       key,
       value,
-      editable: !blob.redacted_header_keys.includes(key),
+      editable: !redactedHeaderKeys.has(key.toLowerCase()),
     })),
     bodyText: blob.request_body ?? "",
     mode: "collect",
@@ -78,6 +82,11 @@ export function RequestReplayPage(): React.JSX.Element {
     let cancelled = false
 
     async function run(): Promise<void> {
+      abortRef.current?.abort()
+      setSending(false)
+      setStreaming(false)
+      setCollectResult(null)
+      setLiveEvents(null)
       setPhase("loading-blob")
       setBlob(null)
       setInitialForm(null)
@@ -432,7 +441,7 @@ export function RequestReplayPage(): React.JSX.Element {
           <ReplayResponsePanel
             result={collectResult}
             liveEvents={liveEvents}
-            loading={sending}
+            loading={sending || streaming}
             originalPath={blob.original?.path ?? null}
           />
         </div>

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -1,0 +1,318 @@
+import { ArrowLeftIcon, RotateCcwIcon } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useParams } from "react-router-dom"
+
+import {
+  AdminApiError,
+  type OutboundBlob,
+  getDevMode,
+  getRequestOutbound,
+} from "@/lib/admin-api"
+import { ReplayContextCard } from "@/components/replay/replay-context-card"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { InlineAlert } from "@/components/ui/inline-alert"
+import { Skeleton } from "@/components/ui/skeleton"
+
+type ReplayPhase = "loading-blob" | "no-blob" | "ready" | "error"
+
+type ReplayForm = {
+  accountId: string
+  headers: Array<{ key: string; value: string; editable: boolean }>
+  bodyText: string
+  mode: "collect" | "live"
+}
+
+function buildReplayForm(blob: OutboundBlob): ReplayForm {
+  return {
+    accountId: blob.original?.account_id ?? "",
+    headers: Object.entries(blob.request_headers).map(([key, value]) => ({
+      key,
+      value,
+      editable: !blob.redacted_header_keys.includes(key),
+    })),
+    bodyText: blob.request_body ?? "",
+    mode: "collect",
+  }
+}
+
+type PlaceholderCardProps = {
+  title: string
+  description: string
+  detail?: string
+}
+
+function PlaceholderCard({
+  title,
+  description,
+  detail,
+}: PlaceholderCardProps): React.JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      {detail ? (
+        <CardContent>
+          <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
+            {detail}
+          </p>
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}
+
+export function RequestReplayPage(): React.JSX.Element {
+  const { t } = useTranslation()
+  const { requestId = "" } = useParams()
+
+  const [phase, setPhase] = useState<ReplayPhase>("loading-blob")
+  const [blob, setBlob] = useState<OutboundBlob | null>(null)
+  const [initialForm, setInitialForm] = useState<ReplayForm | null>(null)
+  const [form, setForm] = useState<ReplayForm | null>(null)
+  const [errorTitle, setErrorTitle] = useState<string | null>(null)
+  const [errorDescription, setErrorDescription] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!requestId) return
+
+    let cancelled = false
+
+    async function run(): Promise<void> {
+      setPhase("loading-blob")
+      setBlob(null)
+      setInitialForm(null)
+      setForm(null)
+      setErrorTitle(null)
+      setErrorDescription(null)
+
+      try {
+        const [devMode, outboundBlob] = await Promise.all([
+          getDevMode(),
+          getRequestOutbound(requestId),
+        ])
+
+        if (cancelled) return
+
+        if (!devMode.enabled) {
+          setPhase("error")
+          setErrorTitle(t("replayPage.devModeDisabled"))
+          setErrorDescription(t("replayPage.devModeDisabledHint"))
+          return
+        }
+
+        const nextForm = buildReplayForm(outboundBlob)
+        setBlob(outboundBlob)
+        setInitialForm(nextForm)
+        setForm(nextForm)
+        setPhase("ready")
+      } catch (err) {
+        if (cancelled) return
+
+        if (err instanceof AdminApiError) {
+          if (err.status === 404) {
+            setPhase("no-blob")
+            return
+          }
+
+          setPhase("error")
+          setErrorTitle(t("replayPage.loadError"))
+          setErrorDescription(err.message)
+          return
+        }
+
+        setPhase("error")
+        setErrorTitle(t("replayPage.loadError"))
+        setErrorDescription(String(err))
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [requestId, t])
+
+  const isDirty = useMemo(() => {
+    if (!initialForm || !form) return false
+    return JSON.stringify(initialForm) !== JSON.stringify(form)
+  }, [form, initialForm])
+
+  function resetForm(): void {
+    if (!initialForm) return
+    setForm(initialForm)
+  }
+
+  if (!requestId) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("replayPage.title")}</CardTitle>
+            <CardDescription>{t("replayPage.loadError")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <InlineAlert
+              variant="error"
+              title={t("replayPage.loadError")}
+              description="Missing requestId"
+            />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (phase === "loading-blob") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("replayPage.title")}</CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-40" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-72" />
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-48 w-full" />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (phase === "no-blob") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={`/request/${encodeURIComponent(requestId)}`}>
+              <ArrowLeftIcon className="size-4" />
+              {t("replayPage.back")}
+            </Link>
+          </Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("replayPage.title")}</CardTitle>
+            <CardDescription>{t("replayPage.noBlobHint")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <InlineAlert
+              variant="warning"
+              title={t("replayPage.noBlob")}
+              description={t("replayPage.noBlobHint")}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={`/request/${encodeURIComponent(requestId)}`}>
+              <ArrowLeftIcon className="size-4" />
+              {t("replayPage.back")}
+            </Link>
+          </Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("replayPage.title")}</CardTitle>
+            <CardDescription>{errorDescription || t("replayPage.loadError")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <InlineAlert
+              variant="error"
+              title={errorTitle || t("replayPage.loadError")}
+              description={errorDescription || undefined}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!blob || !form) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("replayPage.title")}</CardTitle>
+          <CardDescription>{t("replayPage.loadError")}</CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const editableHeaders = form.headers.filter((header) => header.editable).length
+  const lockedHeaders = form.headers.length - editableHeaders
+
+  return (
+    <div className="space-y-4 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-300">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="ghost" size="sm" asChild>
+          <Link to={`/request/${encodeURIComponent(requestId)}`}>
+            <ArrowLeftIcon className="size-4" />
+            {t("replayPage.back")}
+          </Link>
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto"
+          onClick={resetForm}
+          disabled={!isDirty}
+        >
+          <RotateCcwIcon className="size-4" />
+          {t("replayPage.reset")}
+        </Button>
+      </div>
+
+      <ReplayContextCard blob={blob} />
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <div className="space-y-3">
+          <PlaceholderCard
+            title={t("replayPage.placeholderAccount")}
+            description={t("replayPage.placeholderAccount")}
+            detail={`accountId: ${form.accountId || "(empty)"}`}
+          />
+          <PlaceholderCard
+            title={t("replayPage.placeholderHeaders")}
+            description={t("replayPage.placeholderHeaders")}
+            detail={`headers: ${form.headers.length}\neditable: ${editableHeaders}\nlocked: ${lockedHeaders}`}
+          />
+          <PlaceholderCard
+            title={t("replayPage.placeholderBody")}
+            description={t("replayPage.placeholderBody")}
+            detail={`bodyKind: ${blob.request_body_kind}\nlength: ${form.bodyText.length}`}
+          />
+        </div>
+
+        <PlaceholderCard
+          title={t("replayPage.placeholderResponse")}
+          description={t("replayPage.placeholderResponse")}
+          detail={`mode: ${form.mode}\nresponseStatus: ${blob.response_status}`}
+        />
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -9,7 +9,9 @@ import {
   getDevMode,
   getRequestOutbound,
 } from "@/lib/admin-api"
+import { ReplayAccountSelect } from "@/components/replay/replay-account-select"
 import { ReplayContextCard } from "@/components/replay/replay-context-card"
+import { ReplayHeadersEditor } from "@/components/replay/replay-headers-editor"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -41,34 +43,6 @@ function buildReplayForm(blob: OutboundBlob): ReplayForm {
     bodyText: blob.request_body ?? "",
     mode: "collect",
   }
-}
-
-type PlaceholderCardProps = {
-  title: string
-  description: string
-  detail?: string
-}
-
-function PlaceholderCard({
-  title,
-  description,
-  detail,
-}: PlaceholderCardProps): React.JSX.Element {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      {detail ? (
-        <CardContent>
-          <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
-            {detail}
-          </p>
-        </CardContent>
-      ) : null}
-    </Card>
-  )
 }
 
 export function RequestReplayPage(): React.JSX.Element {
@@ -262,9 +236,6 @@ export function RequestReplayPage(): React.JSX.Element {
     )
   }
 
-  const editableHeaders = form.headers.filter((header) => header.editable).length
-  const lockedHeaders = form.headers.length - editableHeaders
-
   return (
     <div className="space-y-4 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-300">
       <div className="flex flex-wrap items-center gap-2">
@@ -290,28 +261,43 @@ export function RequestReplayPage(): React.JSX.Element {
 
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <div className="space-y-3">
-          <PlaceholderCard
-            title={t("replayPage.placeholderAccount")}
-            description={t("replayPage.placeholderAccount")}
-            detail={`accountId: ${form.accountId || "(empty)"}`}
+          <ReplayAccountSelect
+            value={form.accountId}
+            originalAccountId={blob.original?.account_id ?? null}
+            onChange={(accountId) => {
+              setForm({ ...form, accountId })
+            }}
           />
-          <PlaceholderCard
-            title={t("replayPage.placeholderHeaders")}
-            description={t("replayPage.placeholderHeaders")}
-            detail={`headers: ${form.headers.length}\neditable: ${editableHeaders}\nlocked: ${lockedHeaders}`}
+          <ReplayHeadersEditor
+            headers={form.headers}
+            onChange={(headers) => {
+              setForm({ ...form, headers })
+            }}
           />
-          <PlaceholderCard
-            title={t("replayPage.placeholderBody")}
-            description={t("replayPage.placeholderBody")}
-            detail={`bodyKind: ${blob.request_body_kind}\nlength: ${form.bodyText.length}`}
-          />
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">{t("replayPage.placeholderBody")}</CardTitle>
+              <CardDescription>{t("replayPage.placeholderBody")}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
+                {`bodyKind: ${blob.request_body_kind}\nlength: ${form.bodyText.length}`}
+              </p>
+            </CardContent>
+          </Card>
         </div>
 
-        <PlaceholderCard
-          title={t("replayPage.placeholderResponse")}
-          description={t("replayPage.placeholderResponse")}
-          detail={`mode: ${form.mode}\nresponseStatus: ${blob.response_status}`}
-        />
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{t("replayPage.placeholderResponse")}</CardTitle>
+            <CardDescription>{t("replayPage.placeholderResponse")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
+              {`mode: ${form.mode}\nresponseStatus: ${blob.response_status}`}
+            </p>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -153,6 +153,12 @@ export function RequestReplayPage(): React.JSX.Element {
   const [liveEvents, setLiveEvents] = useState<Array<SSEEvent> | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [])
+
   const canSend = bodyValidation.ok && !sending && !streaming && Boolean(form?.accountId)
 
   function buildOverrides(): { body?: string; headers?: Record<string, string> } {
@@ -348,13 +354,13 @@ export function RequestReplayPage(): React.JSX.Element {
             value={form.accountId}
             originalAccountId={blob.original?.account_id ?? null}
             onChange={(accountId) => {
-              setForm({ ...form, accountId })
+              setForm((prev) => (prev ? { ...prev, accountId } : prev))
             }}
           />
           <ReplayHeadersEditor
             headers={form.headers}
             onChange={(headers) => {
-              setForm({ ...form, headers })
+              setForm((prev) => (prev ? { ...prev, headers } : prev))
             }}
           />
           <ReplayBodyEditor
@@ -362,7 +368,7 @@ export function RequestReplayPage(): React.JSX.Element {
             kind={blob.request_body_kind}
             originalValue={blob.request_body ?? ""}
             onChange={(bodyText) => {
-              setForm({ ...form, bodyText })
+              setForm((prev) => (prev ? { ...prev, bodyText } : prev))
             }}
           />
         </div>
@@ -374,7 +380,7 @@ export function RequestReplayPage(): React.JSX.Element {
               <button
                 type="button"
                 className={`px-3 py-1.5 rounded-l-md transition-colors ${form.mode === "collect" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
-                onClick={() => setForm({ ...form, mode: "collect" })}
+                onClick={() => setForm((prev) => (prev ? { ...prev, mode: "collect" } : prev))}
                 disabled={sending || streaming}
               >
                 {t("replayPage.send.modeCollect")}
@@ -382,7 +388,7 @@ export function RequestReplayPage(): React.JSX.Element {
               <button
                 type="button"
                 className={`px-3 py-1.5 rounded-r-md transition-colors ${form.mode === "live" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
-                onClick={() => setForm({ ...form, mode: "live" })}
+                onClick={() => setForm((prev) => (prev ? { ...prev, mode: "live" } : prev))}
                 disabled={sending || streaming}
               >
                 {t("replayPage.send.modeLive")}

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -1,14 +1,25 @@
-import { ArrowLeftIcon, RotateCcwIcon } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import {
+  ArrowLeftIcon,
+  LoaderCircleIcon,
+  RotateCcwIcon,
+  SendIcon,
+  SquareIcon,
+} from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useParams } from "react-router-dom"
+import { toast } from "sonner"
 
 import {
   AdminApiError,
   type OutboundBlob,
+  type ReplayCollectResult,
   getDevMode,
   getRequestOutbound,
+  replayCollect,
+  replayLive,
 } from "@/lib/admin-api"
+import type { SSEEvent } from "@/lib/sse"
 import { ReplayAccountSelect } from "@/components/replay/replay-account-select"
 import {
   ReplayBodyEditor,
@@ -16,6 +27,7 @@ import {
 } from "@/components/replay/replay-body-editor"
 import { ReplayContextCard } from "@/components/replay/replay-context-card"
 import { ReplayHeadersEditor } from "@/components/replay/replay-headers-editor"
+import { ReplayResponsePanel } from "@/components/replay/replay-response-panel"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -133,6 +145,71 @@ export function RequestReplayPage(): React.JSX.Element {
   function resetForm(): void {
     if (!initialForm) return
     setForm(initialForm)
+  }
+
+  /* ---- Send / streaming state ---- */
+  const [sending, setSending] = useState(false)
+  const [streaming, setStreaming] = useState(false)
+  const [collectResult, setCollectResult] = useState<ReplayCollectResult | null>(null)
+  const [liveEvents, setLiveEvents] = useState<Array<SSEEvent> | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const canSend = bodyValidation.ok && !sending && !streaming && Boolean(form?.accountId)
+
+  function buildOverrides(): { body?: string; headers?: Record<string, string> } {
+    if (!form) return {}
+    return {
+      body: form.bodyText,
+      headers: Object.fromEntries(
+        form.headers.filter((h) => h.editable).map((h) => [h.key, h.value]),
+      ),
+    }
+  }
+
+  const handleSend = useCallback(async () => {
+    if (!form || !requestId) return
+
+    const overrides = buildOverrides()
+
+    if (form.mode === "collect") {
+      setSending(true)
+      setCollectResult(null)
+      setLiveEvents(null)
+      try {
+        const res = await replayCollect(requestId, { accountId: form.accountId, overrides })
+        setCollectResult(res)
+      } catch (err) {
+        toast.error(err instanceof AdminApiError ? err.message : String(err))
+      } finally {
+        setSending(false)
+      }
+    } else {
+      setStreaming(true)
+      setCollectResult(null)
+      setLiveEvents([])
+      const controller = new AbortController()
+      abortRef.current = controller
+      try {
+        await replayLive(
+          requestId,
+          { accountId: form.accountId, overrides },
+          (event) => setLiveEvents((prev) => [...(prev ?? []), event]),
+          controller.signal,
+        )
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          toast.error(err instanceof AdminApiError ? err.message : String(err))
+        }
+      } finally {
+        setStreaming(false)
+        abortRef.current = null
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form, requestId])
+
+  function handleCancel(): void {
+    abortRef.current?.abort()
   }
 
   if (!requestId) {
@@ -292,21 +369,69 @@ export function RequestReplayPage(): React.JSX.Element {
           />
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">{t("replayPage.placeholderResponse")}</CardTitle>
-            <CardDescription>
-              {bodyValidation.ok
-                ? t("replayPage.placeholderResponse")
-                : `${t("replayPage.body.invalid")}: ${bodyValidation.message}`}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
-              {`mode: ${form.mode}\nresponseStatus: ${blob.response_status}\ncanSend: ${String(bodyValidation.ok)}`}
-            </p>
-          </CardContent>
-        </Card>
+        <div className="space-y-3">
+          {/* Mode toggle + Send/Cancel toolbar */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="inline-flex rounded-md border text-sm">
+              <button
+                type="button"
+                className={`px-3 py-1.5 rounded-l-md transition-colors ${form.mode === "collect" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
+                onClick={() => setForm({ ...form, mode: "collect" })}
+                disabled={sending || streaming}
+              >
+                {t("replayPage.send.modeCollect")}
+              </button>
+              <button
+                type="button"
+                className={`px-3 py-1.5 rounded-r-md transition-colors ${form.mode === "live" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
+                onClick={() => setForm({ ...form, mode: "live" })}
+                disabled={sending || streaming}
+              >
+                {t("replayPage.send.modeLive")}
+              </button>
+            </div>
+
+            {streaming ? (
+              <Button variant="destructive" size="sm" onClick={handleCancel}>
+                <SquareIcon className="size-4" />
+                {t("replayPage.send.cancel")}
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                disabled={!canSend}
+                onClick={() => void handleSend()}
+              >
+                {sending ? (
+                  <LoaderCircleIcon className="size-4 animate-spin" />
+                ) : (
+                  <SendIcon className="size-4" />
+                )}
+                {sending
+                  ? t("replayPage.send.sending")
+                  : streaming
+                    ? t("replayPage.send.streaming")
+                    : t("replayPage.send.button")}
+              </Button>
+            )}
+
+            <span className="text-xs text-muted-foreground hidden sm:inline">
+              {t("replayPage.send.modeHint")}
+            </span>
+          </div>
+
+          <InlineAlert
+            variant="warning"
+            title={t("replayPage.send.quotaWarning")}
+          />
+
+          <ReplayResponsePanel
+            result={collectResult}
+            liveEvents={liveEvents}
+            loading={sending}
+            originalPath={blob.original?.path ?? null}
+          />
+        </div>
       </div>
     </div>
   )

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -5,7 +5,7 @@ import {
   SendIcon,
   SquareIcon,
 } from "lucide-react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useParams } from "react-router-dom"
 import { toast } from "sonner"
@@ -86,11 +86,7 @@ export function RequestReplayPage(): React.JSX.Element {
       setErrorDescription(null)
 
       try {
-        const [devMode, outboundBlob] = await Promise.all([
-          getDevMode(),
-          getRequestOutbound(requestId),
-        ])
-
+        const devMode = await getDevMode()
         if (cancelled) return
 
         if (!devMode.enabled) {
@@ -99,6 +95,9 @@ export function RequestReplayPage(): React.JSX.Element {
           setErrorDescription(t("replayPage.devModeDisabledHint"))
           return
         }
+
+        const outboundBlob = await getRequestOutbound(requestId)
+        if (cancelled) return
 
         const nextForm = buildReplayForm(outboundBlob)
         setBlob(outboundBlob)
@@ -166,7 +165,7 @@ export function RequestReplayPage(): React.JSX.Element {
     }
   }
 
-  const handleSend = useCallback(async () => {
+  async function handleSend(): Promise<void> {
     if (!form || !requestId) return
 
     const overrides = buildOverrides()
@@ -205,8 +204,7 @@ export function RequestReplayPage(): React.JSX.Element {
         abortRef.current = null
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form, requestId])
+  }
 
   function handleCancel(): void {
     abortRef.current?.abort()

--- a/admin-ui/src/pages/request-replay-page.tsx
+++ b/admin-ui/src/pages/request-replay-page.tsx
@@ -10,6 +10,10 @@ import {
   getRequestOutbound,
 } from "@/lib/admin-api"
 import { ReplayAccountSelect } from "@/components/replay/replay-account-select"
+import {
+  ReplayBodyEditor,
+  validateReplayBody,
+} from "@/components/replay/replay-body-editor"
 import { ReplayContextCard } from "@/components/replay/replay-context-card"
 import { ReplayHeadersEditor } from "@/components/replay/replay-headers-editor"
 import { Button } from "@/components/ui/button"
@@ -121,6 +125,10 @@ export function RequestReplayPage(): React.JSX.Element {
     if (!initialForm || !form) return false
     return JSON.stringify(initialForm) !== JSON.stringify(form)
   }, [form, initialForm])
+  const bodyValidation = useMemo(
+    () => validateReplayBody(form?.bodyText ?? "", blob?.request_body_kind ?? "text"),
+    [blob?.request_body_kind, form?.bodyText],
+  )
 
   function resetForm(): void {
     if (!initialForm) return
@@ -274,27 +282,28 @@ export function RequestReplayPage(): React.JSX.Element {
               setForm({ ...form, headers })
             }}
           />
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">{t("replayPage.placeholderBody")}</CardTitle>
-              <CardDescription>{t("replayPage.placeholderBody")}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
-                {`bodyKind: ${blob.request_body_kind}\nlength: ${form.bodyText.length}`}
-              </p>
-            </CardContent>
-          </Card>
+          <ReplayBodyEditor
+            value={form.bodyText}
+            kind={blob.request_body_kind}
+            originalValue={blob.request_body ?? ""}
+            onChange={(bodyText) => {
+              setForm({ ...form, bodyText })
+            }}
+          />
         </div>
 
         <Card>
           <CardHeader>
             <CardTitle className="text-base">{t("replayPage.placeholderResponse")}</CardTitle>
-            <CardDescription>{t("replayPage.placeholderResponse")}</CardDescription>
+            <CardDescription>
+              {bodyValidation.ok
+                ? t("replayPage.placeholderResponse")
+                : `${t("replayPage.body.invalid")}: ${bodyValidation.message}`}
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <p className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
-              {`mode: ${form.mode}\nresponseStatus: ${blob.response_status}`}
+              {`mode: ${form.mode}\nresponseStatus: ${blob.response_status}\ncanSend: ${String(bodyValidation.ok)}`}
             </p>
           </CardContent>
         </Card>

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -776,7 +776,16 @@ export function RequestsPage(): React.JSX.Element {
                             {devModeEnabled && r.has_outbound ? (
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <PlayIcon className="size-3 shrink-0 text-muted-foreground" />
+                                  <span
+                                    tabIndex={0}
+                                    aria-label={t("requestsPage.replayAvailable")}
+                                    className="inline-flex"
+                                  >
+                                    <PlayIcon
+                                      aria-hidden="true"
+                                      className="size-3 shrink-0 text-muted-foreground"
+                                    />
+                                  </span>
                                 </TooltipTrigger>
                                 <TooltipContent>{t("requestsPage.replayAvailable")}</TooltipContent>
                               </Tooltip>

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link, useSearchParams } from "react-router-dom"
-import { LoaderCircleIcon } from "lucide-react"
+import { LoaderCircleIcon, PlayIcon } from "lucide-react"
 import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
 
 import {
   AdminApiError,
   type AdminRequestItem,
+  getDevMode,
   queryAdminRequests,
 } from "@/lib/admin-api"
 import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
@@ -219,6 +220,11 @@ export function RequestsPage(): React.JSX.Element {
   const [hasMore, setHasMore] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [devModeEnabled, setDevModeEnabled] = useState(false)
+
+  useEffect(() => {
+    getDevMode().then((dm) => setDevModeEnabled(dm.enabled)).catch(() => {})
+  }, [])
 
   const activeFilters = useMemo(() => getFiltersFromSearch(searchParams), [searchParams])
 
@@ -766,7 +772,17 @@ export function RequestsPage(): React.JSX.Element {
                     return (
                       <TableRow key={r.request_id}>
                         <TableCell className="font-mono text-xs">
-                          {fmtLocalDateTime(r.started_at_ms)}
+                          <span className="flex items-center gap-1">
+                            {devModeEnabled && r.has_outbound ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <PlayIcon className="size-3 shrink-0 text-muted-foreground" />
+                                </TooltipTrigger>
+                                <TooltipContent>{t("requestsPage.replayAvailable")}</TooltipContent>
+                              </Tooltip>
+                            ) : null}
+                            {fmtLocalDateTime(r.started_at_ms)}
+                          </span>
                         </TableCell>
                         <TableCell className="font-mono text-sm whitespace-normal break-words">
                           <Link

--- a/admin-ui/src/pages/requests-page.tsx
+++ b/admin-ui/src/pages/requests-page.tsx
@@ -223,7 +223,15 @@ export function RequestsPage(): React.JSX.Element {
   const [devModeEnabled, setDevModeEnabled] = useState(false)
 
   useEffect(() => {
-    getDevMode().then((dm) => setDevModeEnabled(dm.enabled)).catch(() => {})
+    let cancelled = false
+    getDevMode()
+      .then((dm) => {
+        if (!cancelled) setDevModeEnabled(dm.enabled)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const activeFilters = useMemo(() => getFiltersFromSearch(searchParams), [searchParams])

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -1832,16 +1832,18 @@ type DeveloperModeCardProps = {
   devMode: DevModeState
   saving: boolean
   onToggleEnabled: (value: boolean) => void
-  onToggleCapture4xx: (value: boolean) => void
+  onCaptureChange: (field: "capture4xx" | "capture5xx" | "captureOther", value: boolean) => void
 }
 
 function DeveloperModeCard({
   devMode,
   saving,
   onToggleEnabled,
-  onToggleCapture4xx,
+  onCaptureChange,
 }: DeveloperModeCardProps): React.JSX.Element {
   const { t } = useTranslation()
+
+  const anyCaptureEnabled = devMode.capture4xx || devMode.capture5xx || devMode.captureOther
 
   return (
     <Card className="gap-4 py-4">
@@ -1868,30 +1870,54 @@ function DeveloperModeCard({
           />
         </div>
 
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
+        {devMode.enabled ? (
+          <div className="space-y-2">
             <div className="text-sm font-medium">
-              {t("settingsPage.devMode.capture")}
+              {t("settingsPage.devMode.captureLabel")}
+            </div>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-1.5 text-sm">
+                <Switch
+                  checked={devMode.capture4xx}
+                  disabled={saving}
+                  onCheckedChange={(v) => onCaptureChange("capture4xx", v)}
+                  className="scale-75"
+                />
+                {t("settingsPage.devMode.capture4xx")}
+              </label>
+              <label className="flex items-center gap-1.5 text-sm">
+                <Switch
+                  checked={devMode.capture5xx}
+                  disabled={saving}
+                  onCheckedChange={(v) => onCaptureChange("capture5xx", v)}
+                  className="scale-75"
+                />
+                {t("settingsPage.devMode.capture5xx")}
+              </label>
+              <label className="flex items-center gap-1.5 text-sm">
+                <Switch
+                  checked={devMode.captureOther}
+                  disabled={saving}
+                  onCheckedChange={(v) => onCaptureChange("captureOther", v)}
+                  className="scale-75"
+                />
+                {t("settingsPage.devMode.captureOther")}
+              </label>
             </div>
             <div className="text-muted-foreground text-xs">
-              {t(
-                devMode.enabled
-                  ? "settingsPage.devMode.captureHint"
-                  : "settingsPage.devMode.captureDisabled",
-              )}
+              {t("settingsPage.devMode.captureHint")}
             </div>
           </div>
-          <Switch
-            checked={devMode.capture4xx}
-            disabled={!devMode.enabled || saving}
-            onCheckedChange={onToggleCapture4xx}
-          />
-        </div>
+        ) : (
+          <div className="text-muted-foreground text-xs">
+            {t("settingsPage.devMode.captureDisabled")}
+          </div>
+        )}
 
-        {devMode.enabled && devMode.capture4xx ? (
+        {devMode.enabled && anyCaptureEnabled ? (
           <InlineAlert
             variant="warning"
-            title={t("settingsPage.devMode.capture")}
+            title={t("settingsPage.devMode.captureLabel")}
             description={t("settingsPage.devMode.captureHint")}
           />
         ) : null}
@@ -2521,7 +2547,7 @@ type SettingsPageViewProps = {
   onSave: () => void
   devMode: DevModeState
   onDevModeEnabledToggle: (value: boolean) => void
-  onDevModeCapture4xxToggle: (value: boolean) => void
+  onDevModeCaptureChange: (field: "capture4xx" | "capture5xx" | "captureOther", value: boolean) => void
   hasModels: boolean
   smallModelLabel: string
   smallModelValue: string
@@ -2612,6 +2638,8 @@ function useSettingsPageState(): SettingsPageViewProps {
   const [devMode, setDevModeState] = useState<DevModeState>({
     enabled: false,
     capture4xx: false,
+    capture5xx: false,
+    captureOther: false,
   })
   const [draft, setDraft] = useState<AdminConfig>({})
   const [initialDraftJson, setInitialDraftJson] = useState<string>("{}")
@@ -3011,21 +3039,26 @@ function useSettingsPageState(): SettingsPageViewProps {
       const next = {
         enabled: value,
         capture4xx: value ? devMode.capture4xx : false,
+        capture5xx: value ? devMode.capture5xx : false,
+        captureOther: value ? devMode.captureOther : false,
       }
       void persistDevMode(next)
     },
-    [devMode.capture4xx, persistDevMode],
+    [devMode.capture4xx, devMode.capture5xx, devMode.captureOther, persistDevMode],
   )
 
-  const handleDevModeCapture4xxToggle = useCallback(
-    (value: boolean) => {
+  const handleDevModeCaptureChange = useCallback(
+    (field: "capture4xx" | "capture5xx" | "captureOther", value: boolean) => {
       const next = {
         enabled: devMode.enabled,
-        capture4xx: value,
+        capture4xx: devMode.capture4xx,
+        capture5xx: devMode.capture5xx,
+        captureOther: devMode.captureOther,
+        [field]: value,
       }
       void persistDevMode(next)
     },
-    [devMode.enabled, persistDevMode],
+    [devMode.enabled, devMode.capture4xx, devMode.capture5xx, devMode.captureOther, persistDevMode],
   )
   const useFunctionApplyPatch = draft.useFunctionApplyPatch ?? true
   const forceAgent = draft.forceAgent ?? false
@@ -3046,7 +3079,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     onSave,
     devMode,
     onDevModeEnabledToggle: handleDevModeEnabledToggle,
-    onDevModeCapture4xxToggle: handleDevModeCapture4xxToggle,
+    onDevModeCaptureChange: handleDevModeCaptureChange,
     hasModels,
     smallModelLabel,
     smallModelValue,
@@ -3136,7 +3169,7 @@ function SettingsPageView({
   onSave,
   devMode,
   onDevModeEnabledToggle,
-  onDevModeCapture4xxToggle,
+  onDevModeCaptureChange,
   hasModels,
   smallModelLabel,
   smallModelValue,
@@ -3491,7 +3524,7 @@ function SettingsPageView({
               devMode={devMode}
               saving={saving}
               onToggleEnabled={onDevModeEnabledToggle}
-              onToggleCapture4xx={onDevModeCapture4xxToggle}
+              onCaptureChange={onDevModeCaptureChange}
             />
           </SettingsSectionCard>
         </main>

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -14,12 +14,15 @@ import {
   AdminApiError,
   type AdminConfig,
   type AdminConfigResponse,
+  type DevModeState,
   type ModelAliasSpec,
   type ProviderConfig,
   type ProviderModelConfig,
   type ReasoningEffort,
   getAdminConfig,
   getAdminModels,
+  getDevMode,
+  setDevMode,
   updateAdminConfig,
 } from "@/lib/admin-api"
 import { i18n } from "@/lib/i18n"
@@ -57,6 +60,7 @@ const SETTINGS_SECTION_IDS = [
   "aliases",
   "prompts",
   "advanced",
+  "devMode",
   "providers",
 ] as const
 
@@ -1824,6 +1828,78 @@ function ModelAliasesCard({
   )
 }
 
+type DeveloperModeCardProps = {
+  devMode: DevModeState
+  saving: boolean
+  onToggleEnabled: (value: boolean) => void
+  onToggleCapture4xx: (value: boolean) => void
+}
+
+function DeveloperModeCard({
+  devMode,
+  saving,
+  onToggleEnabled,
+  onToggleCapture4xx,
+}: DeveloperModeCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>{t("settingsPage.devMode.title")}</CardTitle>
+        <CardDescription className="hidden sm:block">
+          {t("settingsPage.devMode.description")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 px-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.devMode.enable")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.devMode.enableHint")}
+            </div>
+          </div>
+          <Switch
+            checked={devMode.enabled}
+            disabled={saving}
+            onCheckedChange={onToggleEnabled}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.devMode.capture")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t(
+                devMode.enabled
+                  ? "settingsPage.devMode.captureHint"
+                  : "settingsPage.devMode.captureDisabled",
+              )}
+            </div>
+          </div>
+          <Switch
+            checked={devMode.capture4xx}
+            disabled={!devMode.enabled || saving}
+            onCheckedChange={onToggleCapture4xx}
+          />
+        </div>
+
+        {devMode.enabled && devMode.capture4xx ? (
+          <InlineAlert
+            variant="warning"
+            title={t("settingsPage.devMode.capture")}
+            description={t("settingsPage.devMode.captureHint")}
+          />
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
 type AdvancedSettingsCardProps = {
   accountAffinityEnabled: boolean
   modelRefreshIntervalInput: string
@@ -2443,6 +2519,9 @@ type SettingsPageViewProps = {
   isDirty: boolean
   onReload: () => void
   onSave: () => void
+  devMode: DevModeState
+  onDevModeEnabledToggle: (value: boolean) => void
+  onDevModeCapture4xxToggle: (value: boolean) => void
   hasModels: boolean
   smallModelLabel: string
   smallModelValue: string
@@ -2530,6 +2609,10 @@ function useSettingsPageState(): SettingsPageViewProps {
   const [configPath, setConfigPath] = useState<string | null>(null)
 
   const [models, setModels] = useState<Array<string>>([])
+  const [devMode, setDevModeState] = useState<DevModeState>({
+    enabled: false,
+    capture4xx: false,
+  })
   const [draft, setDraft] = useState<AdminConfig>({})
   const [initialDraftJson, setInitialDraftJson] = useState<string>("{}")
   const [modelRefreshIntervalInput, setModelRefreshIntervalInput] =
@@ -2661,9 +2744,10 @@ function useSettingsPageState(): SettingsPageViewProps {
     setError(null)
 
     try {
-      const [configRes, modelsRes] = await Promise.allSettled([
+      const [configRes, modelsRes, devModeRes] = await Promise.allSettled([
         getAdminConfig(),
         getAdminModels(),
+        getDevMode(),
       ])
 
       if (configRes.status === "fulfilled") {
@@ -2680,6 +2764,12 @@ function useSettingsPageState(): SettingsPageViewProps {
           description:
             modelsRes.reason instanceof Error ? modelsRes.reason.message : String(modelsRes.reason),
         })
+      }
+
+      if (devModeRes.status === "fulfilled") {
+        setDevModeState(devModeRes.value)
+      } else {
+        throw devModeRes.reason
       }
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
@@ -2893,6 +2983,50 @@ function useSettingsPageState(): SettingsPageViewProps {
   const accountAffinityEnabled = draft.accountAffinity ?? true
   const allowOriginalModelNamesForAliases =
     draft.allowOriginalModelNamesForAliases ?? false
+
+  const persistDevMode = useCallback(
+    async (next: DevModeState) => {
+      setSaving(true)
+      setError(null)
+
+      try {
+        const updated = await setDevMode(next)
+        setDevModeState(updated)
+        toast.success(i18n.t("settingsPage.toast.devModeSaved"))
+      } catch (err) {
+        const msg = err instanceof AdminApiError ? err.message : String(err)
+        setError(msg)
+        toast.error(i18n.t("settingsPage.toast.saveDevModeFailed"), {
+          description: msg,
+        })
+      } finally {
+        setSaving(false)
+      }
+    },
+    [],
+  )
+
+  const handleDevModeEnabledToggle = useCallback(
+    (value: boolean) => {
+      const next = {
+        enabled: value,
+        capture4xx: value ? devMode.capture4xx : false,
+      }
+      void persistDevMode(next)
+    },
+    [devMode.capture4xx, persistDevMode],
+  )
+
+  const handleDevModeCapture4xxToggle = useCallback(
+    (value: boolean) => {
+      const next = {
+        enabled: devMode.enabled,
+        capture4xx: value,
+      }
+      void persistDevMode(next)
+    },
+    [devMode.enabled, persistDevMode],
+  )
   const useFunctionApplyPatch = draft.useFunctionApplyPatch ?? true
   const forceAgent = draft.forceAgent ?? false
   const compactUseSmallModel = draft.compactUseSmallModel ?? true
@@ -2910,6 +3044,9 @@ function useSettingsPageState(): SettingsPageViewProps {
     isDirty,
     onReload,
     onSave,
+    devMode,
+    onDevModeEnabledToggle: handleDevModeEnabledToggle,
+    onDevModeCapture4xxToggle: handleDevModeCapture4xxToggle,
     hasModels,
     smallModelLabel,
     smallModelValue,
@@ -2997,6 +3134,9 @@ function SettingsPageView({
   isDirty,
   onReload,
   onSave,
+  devMode,
+  onDevModeEnabledToggle,
+  onDevModeCapture4xxToggle,
   hasModels,
   smallModelLabel,
   smallModelValue,
@@ -3079,6 +3219,7 @@ function SettingsPageView({
       { id: "aliases", label: t("settingsPage.sections.aliases") },
       { id: "prompts", label: t("settingsPage.sections.prompts") },
       { id: "advanced", label: t("settingsPage.sections.advanced") },
+      { id: "devMode", label: t("settingsPage.sections.devMode") },
       { id: "providers", label: t("settingsPage.sections.providers") },
     ]
   }, [t])
@@ -3320,12 +3461,27 @@ function SettingsPageView({
             />
           </SettingsSectionCard>
 
+          {/* Developer Mode */}
+          <SettingsSectionCard
+            id="devMode"
+            isActive={activeSection === "devMode"}
+            ref={(el) => registerSection("devMode", el)}
+            style={{ animationDelay: "300ms" }}
+          >
+            <DeveloperModeCard
+              devMode={devMode}
+              saving={saving}
+              onToggleEnabled={onDevModeEnabledToggle}
+              onToggleCapture4xx={onDevModeCapture4xxToggle}
+            />
+          </SettingsSectionCard>
+
           {/* Providers */}
           <SettingsSectionCard
             id="providers"
             isActive={activeSection === "providers"}
             ref={(el) => registerSection("providers", el)}
-            style={{ animationDelay: "300ms" }}
+            style={{ animationDelay: "360ms" }}
           >
             <ProvidersSettingsCard
               items={providersItems}

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -2797,7 +2797,13 @@ function useSettingsPageState(): SettingsPageViewProps {
       if (devModeRes.status === "fulfilled") {
         setDevModeState(devModeRes.value)
       } else {
-        throw devModeRes.reason
+        setDevModeState({ enabled: false, capture4xx: false, capture5xx: false, captureOther: false })
+        toast.error(i18n.t("settingsPage.toast.loadDevModeFailed"), {
+          description:
+            devModeRes.reason instanceof Error
+              ? devModeRes.reason.message
+              : String(devModeRes.reason),
+        })
       }
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -60,8 +60,8 @@ const SETTINGS_SECTION_IDS = [
   "aliases",
   "prompts",
   "advanced",
-  "devMode",
   "providers",
+  "devMode",
 ] as const
 
 const REASONING_EFFORTS: Array<ReasoningEffort> = [
@@ -3219,8 +3219,8 @@ function SettingsPageView({
       { id: "aliases", label: t("settingsPage.sections.aliases") },
       { id: "prompts", label: t("settingsPage.sections.prompts") },
       { id: "advanced", label: t("settingsPage.sections.advanced") },
-      { id: "devMode", label: t("settingsPage.sections.devMode") },
       { id: "providers", label: t("settingsPage.sections.providers") },
+      { id: "devMode", label: t("settingsPage.sections.devMode") },
     ]
   }, [t])
 
@@ -3461,27 +3461,12 @@ function SettingsPageView({
             />
           </SettingsSectionCard>
 
-          {/* Developer Mode */}
-          <SettingsSectionCard
-            id="devMode"
-            isActive={activeSection === "devMode"}
-            ref={(el) => registerSection("devMode", el)}
-            style={{ animationDelay: "300ms" }}
-          >
-            <DeveloperModeCard
-              devMode={devMode}
-              saving={saving}
-              onToggleEnabled={onDevModeEnabledToggle}
-              onToggleCapture4xx={onDevModeCapture4xxToggle}
-            />
-          </SettingsSectionCard>
-
           {/* Providers */}
           <SettingsSectionCard
             id="providers"
             isActive={activeSection === "providers"}
             ref={(el) => registerSection("providers", el)}
-            style={{ animationDelay: "360ms" }}
+            style={{ animationDelay: "300ms" }}
           >
             <ProvidersSettingsCard
               items={providersItems}
@@ -3492,6 +3477,21 @@ function SettingsPageView({
               onAddModel={onProvidersAddModel}
               onRemoveModel={onProvidersRemoveModel}
               onUpdateModel={onProvidersUpdateModel}
+            />
+          </SettingsSectionCard>
+
+          {/* Developer Mode */}
+          <SettingsSectionCard
+            id="devMode"
+            isActive={activeSection === "devMode"}
+            ref={(el) => registerSection("devMode", el)}
+            style={{ animationDelay: "360ms" }}
+          >
+            <DeveloperModeCard
+              devMode={devMode}
+              saving={saving}
+              onToggleEnabled={onDevModeEnabledToggle}
+              onToggleCapture4xx={onDevModeCapture4xxToggle}
             />
           </SettingsSectionCard>
         </main>

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+root = "./tests"

--- a/docs/developer-mode.md
+++ b/docs/developer-mode.md
@@ -1,0 +1,198 @@
+# Developer Mode（Request Replay）
+
+## 1. 功能简介
+
+Developer Mode 是 Admin-UI 中的调试工具，用于对请求历史里返回 4xx 的上游请求进行重放。它适合在排查上游报错时使用：你可以基于系统捕获到的真实出站请求，直接在页面中修改内容后重新发送，而不需要离开管理后台。
+
+核心能力包括：
+
+- 修改请求体（request body）
+- 修改业务头（business headers）
+- 切换上游账号进行重放
+- 查看上游原始响应
+- 查看经过本系统 translation 层转换后的响应
+
+Developer Mode 提供两种响应模式：
+
+- **Collect**：等待上游完整返回后，一次性展示完整响应
+- **Live**：以 SSE 方式实时展示上游返回的每个 chunk
+
+## 2. 开启方法
+
+### 2.1 通过 Admin-UI 开启
+
+1. 访问 Admin-UI 的 Settings 页面。
+2. 找到 **Developer Mode** 区块。
+3. 开启 **Enable Developer Mode** 主开关。
+4. 开启 **Capture 4xx upstream payloads** 捕获开关。
+
+这两个开关是独立的：
+
+- 你可以只开启捕获，不开启重放
+- 你也可以只开启重放，不开启捕获
+
+也就是说，`enabled` 和 `capture4xx` 不互相强绑定，分别控制不同能力。
+
+### 2.2 通过 API 开启
+
+查看当前状态：
+
+```http
+GET /api/admin/dev-mode
+```
+
+示例响应：
+
+```json
+{
+  "enabled": true,
+  "capture4xx": true
+}
+```
+
+修改状态：
+
+```http
+POST /api/admin/dev-mode
+Content-Type: application/json
+
+{
+  "enabled": true,
+  "capture4xx": true
+}
+```
+
+你也可以只修改其中一个字段，未提供的字段会保留当前值。
+
+### 2.3 通过 config.json 开启
+
+也可以直接编辑本地配置文件：
+
+```text
+~/.local/share/copilot-api/config.json
+```
+
+添加或修改如下配置：
+
+```json
+{
+  "devMode": {
+    "enabled": true,
+    "capture4xx": true
+  }
+}
+```
+
+## 3. 使用方法
+
+### 3.1 等待 4xx 请求被捕获
+
+开启 `capture4xx` 后，系统会自动捕获所有返回 4xx 的上游请求。
+
+捕获内容包括：
+
+- 完整的出站请求体
+- 脱敏后的请求头
+- 上游响应体
+- 上游响应头
+
+其中敏感头会被替换为 `***`，例如：
+
+- `Authorization`
+- 各类 `token` 相关请求头
+- 其他敏感认证类请求头
+
+这意味着你可以安全地查看捕获记录中的请求结构，但不能直接从中恢复认证信息。
+
+### 3.2 进入重放页面
+
+1. 在请求历史列表中找到一条 4xx 请求。
+2. 点击进入请求详情页。
+3. 点击工具栏中的 **Replay** 按钮。
+4. 进入 `/requests/:id/replay` 页面。
+
+只有当该请求存在捕获数据时，**Replay** 按钮才可用。
+
+### 3.3 编辑与发送
+
+#### 账号选择
+
+- 默认会选中原始请求使用的账号
+- 原始账号会标记为 **original**
+- 你可以切换到其他可用账号进行重放
+
+#### 请求头编辑
+
+- 业务头可以自由编辑、添加、删除
+- 认证头会显示为 `***`，并且是只读的
+- 实际发送时，系统会根据当前所选账号自动注入真实认证头
+
+#### 请求体编辑
+
+- JSON 模式支持格式化
+- JSON 模式支持语法校验
+- 可以随时重置为原始捕获值
+
+#### 发送模式
+
+- **Collect**：等待上游完整响应后统一展示
+- **Live**：实时流式展示上游返回的每个 chunk
+
+编辑完成后，点击 **Send** 发送重放请求。
+
+### 3.4 查看响应
+
+发送完成后，可以在响应面板中查看以下内容：
+
+- **Raw 标签**：查看上游原始响应，可能是 JSON、SSE 或纯文本
+- **Translated 标签**：查看经过本系统 translation 层转换后的 Anthropic 格式响应，仅 `/v1/messages` 请求可用
+- **Headers 标签**：查看上游响应头
+
+如果原始请求不是 `/v1/messages`，则通常只有 Raw 和 Headers 视图具有实际意义。
+
+## 4. 注意事项
+
+- 重放会向 GitHub 发送真实请求，并消耗上游账号的真实配额
+- 重放请求不会写入主请求历史
+- 重放请求不会影响 premium 统计
+- 重放请求不会写入 session affinity
+- 捕获的数据会随主请求历史一起清理，保留期为 35 天
+- 请求体中可能包含用户 prompt 等敏感内容，请注意数据安全
+- `devMode.enabled` 是后端硬门闩；关闭后，所有重放相关端点都会返回 `403`，即使请求携带了合法的 `ADMIN_TOKEN`
+
+## 5. 故障排查
+
+### “Replay” 按钮不显示
+
+请先检查 Developer Mode 是否已开启。
+
+重点确认：
+
+- Settings 页面中的 **Enable Developer Mode** 是否已开启
+- 或 `devMode.enabled` 是否为 `true`
+
+### “Replay” 按钮灰色不可点
+
+这通常表示该请求没有捕获数据，常见原因包括：
+
+- 该请求发生在 `capture4xx` 开启之前
+- 该请求不是 4xx
+- 该请求未被捕获成功
+
+### 重放返回 403
+
+表示 Developer Mode 未开启。
+
+请检查：
+
+- `GET /api/admin/dev-mode` 返回的 `enabled` 是否为 `true`
+- 或 `config.json` 中的 `devMode.enabled` 是否已开启
+
+### 重放返回 404
+
+通常表示以下两种情况之一：
+
+- 捕获数据已经过期并被清理
+- 原始请求记录已经不存在
+
+如果是历史较久的请求，优先考虑数据已随请求历史一起清理。

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1605,6 +1605,23 @@ export class AccountsManager {
   }
 
   /**
+   * Get account context by account ID.
+   * Returns null if no account with the given ID exists.
+   */
+  getAccountContextById(id: string): AccountContext | null {
+    if (this.temporaryAccount && this.temporaryAccount.id === id) {
+      return this.toAccountContext(this.temporaryAccount)
+    }
+
+    const account = this.accounts.get(id)
+    if (account) {
+      return this.toAccountContext(account)
+    }
+
+    return null
+  }
+
+  /**
    * Get account context by index.
    * Index 0 is the temporary account (if exists), otherwise the first registered account.
    * Returns null if index is out of bounds.

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -284,7 +284,32 @@ function migrateV11(db: Database): void {
     }
   }
 
-  db.run("PRAGMA user_version = 11;")
+  db.run(`
+    CREATE TABLE IF NOT EXISTS request_outbound (
+      request_id         TEXT PRIMARY KEY,
+      captured_at_ms     INTEGER NOT NULL,
+      http_status        INTEGER NOT NULL,
+
+      upstream_url       TEXT NOT NULL,
+      upstream_method    TEXT NOT NULL,
+
+      request_headers    TEXT NOT NULL,
+      request_body       TEXT,
+      request_body_kind  TEXT NOT NULL,
+
+      response_status    INTEGER NOT NULL,
+      response_headers   TEXT NOT NULL,
+      response_body      TEXT,
+      response_body_kind TEXT NOT NULL,
+
+      FOREIGN KEY (request_id) REFERENCES request_log(request_id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_request_outbound_captured_at
+      ON request_outbound(captured_at_ms DESC);
+
+    PRAGMA user_version = 11;
+  `)
 }
 
 function migrateV8ToV11(db: Database, current: number): void {
@@ -312,6 +337,7 @@ function migrateAdminDb(db: Database): void {
   const current = row?.user_version ?? 0
 
   if (current >= 11) {
+    migrateV11(db)
     return
   }
 

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -330,6 +330,7 @@ function migrateV8ToV11(db: Database, current: number): void {
   }
 }
 
+// eslint-disable-next-line complexity -- migration chain grows with each version
 function migrateAdminDb(db: Database): void {
   const row = db.query("PRAGMA user_version;").get() as {
     user_version?: number
@@ -337,7 +338,7 @@ function migrateAdminDb(db: Database): void {
   const current = row?.user_version ?? 0
 
   if (current >= 11) {
-    migrateV11(db)
+    if (current === 11) migrateV11(db)
     return
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,6 +5,11 @@ import { PATHS } from "./paths"
 
 export type LogLevel = "error" | "warn" | "info" | "debug"
 
+export interface DevModeConfig {
+  enabled: boolean
+  capture4xx: boolean
+}
+
 export interface AppConfig {
   auth?: {
     apiKeys?: Array<string>
@@ -33,6 +38,7 @@ export interface AppConfig {
   useResponsesApiWebSearch?: boolean
   claudeTokenMultiplier?: number
   logLevel?: LogLevel
+  devMode?: DevModeConfig
 }
 
 export interface ModelConfig {
@@ -124,6 +130,10 @@ const defaultConfig: AppConfig = {
   useMessagesApi: true,
   useResponsesApiWebSearch: true,
   logLevel: "info",
+  devMode: {
+    enabled: false,
+    capture4xx: false,
+  },
 }
 
 let cachedConfig: AppConfig | null = null
@@ -367,6 +377,28 @@ function mergeDefaultLogLevel(config: AppConfig): {
   }
 }
 
+function mergeDefaultDevMode(config: AppConfig): ConfigMergeResult {
+  const current = config.devMode
+  if (
+    current
+    && typeof current.enabled === "boolean"
+    && typeof current.capture4xx === "boolean"
+  ) {
+    return { mergedConfig: config, changed: false }
+  }
+
+  return {
+    mergedConfig: {
+      ...config,
+      devMode: {
+        enabled: current?.enabled === true,
+        capture4xx: current?.capture4xx === true,
+      },
+    },
+    changed: true,
+  }
+}
+
 type ConfigMergeResult = {
   mergedConfig: AppConfig
   changed: boolean
@@ -400,6 +432,7 @@ export function mergeConfigWithDefaults(): AppConfig {
     mergeDefaultModelRefreshInterval,
     mergeDefaultSessionAffinityRetention,
     mergeDefaultLogLevel,
+    mergeDefaultDevMode,
   ])
 
   if (changed) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,8 @@ export type LogLevel = "error" | "warn" | "info" | "debug"
 export interface DevModeConfig {
   enabled: boolean
   capture4xx: boolean
+  capture5xx: boolean
+  captureOther: boolean
 }
 
 export interface AppConfig {
@@ -133,6 +135,8 @@ const defaultConfig: AppConfig = {
   devMode: {
     enabled: false,
     capture4xx: false,
+    capture5xx: false,
+    captureOther: false,
   },
 }
 
@@ -383,6 +387,8 @@ function mergeDefaultDevMode(config: AppConfig): ConfigMergeResult {
     current
     && typeof current.enabled === "boolean"
     && typeof current.capture4xx === "boolean"
+    && typeof current.capture5xx === "boolean"
+    && typeof current.captureOther === "boolean"
   ) {
     return { mergedConfig: config, changed: false }
   }
@@ -393,6 +399,8 @@ function mergeDefaultDevMode(config: AppConfig): ConfigMergeResult {
       devMode: {
         enabled: current?.enabled === true,
         capture4xx: current?.capture4xx === true,
+        capture5xx: current?.capture5xx === true,
+        captureOther: current?.captureOther === true,
       },
     },
     changed: true,

--- a/src/lib/dev-mode.ts
+++ b/src/lib/dev-mode.ts
@@ -7,3 +7,11 @@ export function isDevModeEnabled(): boolean {
 export function isCapture4xxEnabled(): boolean {
   return getConfig().devMode?.capture4xx === true
 }
+
+export function isCapture5xxEnabled(): boolean {
+  return getConfig().devMode?.capture5xx === true
+}
+
+export function isCaptureOtherEnabled(): boolean {
+  return getConfig().devMode?.captureOther === true
+}

--- a/src/lib/dev-mode.ts
+++ b/src/lib/dev-mode.ts
@@ -1,0 +1,9 @@
+import { getConfig } from "./config"
+
+export function isDevModeEnabled(): boolean {
+  return getConfig().devMode?.enabled === true
+}
+
+export function isCapture4xxEnabled(): boolean {
+  return getConfig().devMode?.capture4xx === true
+}

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -744,6 +744,10 @@ export class RequestHistoryStore {
     } catch (error) {
       consola.debug("Failed to cleanup request_log retention", error)
     }
+
+    import("./request-outbound")
+      .then((m) => m.getRequestOutboundStore().cleanupOrphans())
+      .catch(() => {})
   }
 
   meta(): {

--- a/src/lib/request-outbound.ts
+++ b/src/lib/request-outbound.ts
@@ -100,6 +100,7 @@ export type OutboundCaptureRow = OutboundCaptureInput & {
 export type RequestOutboundStoreApi = {
   insert(input: OutboundCaptureInput): void
   getByRequestId(requestId: string): OutboundCaptureRow | null
+  hasOutboundForIds(requestIds: Array<string>): Set<string>
   cleanupOrphans(): void
   meta(): {
     dbPath: string
@@ -224,6 +225,21 @@ class RequestOutboundStore implements RequestOutboundStoreApi {
     }
   }
 
+  hasOutboundForIds(requestIds: Array<string>): Set<string> {
+    if (requestIds.length === 0) return new Set()
+    try {
+      const placeholders = requestIds.map(() => "?").join(", ")
+      const stmt = this.db.query(
+        `SELECT request_id FROM request_outbound WHERE request_id IN (${placeholders})`,
+      )
+      const rows = stmt.all(...requestIds) as Array<{ request_id: string }>
+      return new Set(rows.map((r) => r.request_id))
+    } catch (error) {
+      consola.debug("Failed to batch-check request outbound ids", error)
+      return new Set()
+    }
+  }
+
   cleanupOrphans(): void {
     try {
       this.cleanupOrphansStmt.run()
@@ -249,6 +265,7 @@ export function createRequestOutboundStore(
 const disabledStore: RequestOutboundStoreApi = {
   insert: () => {},
   getByRequestId: () => null,
+  hasOutboundForIds: () => new Set(),
   cleanupOrphans: () => {},
   meta: () => ({
     dbPath: getAdminDbPath(),

--- a/src/lib/request-outbound.ts
+++ b/src/lib/request-outbound.ts
@@ -1,0 +1,279 @@
+import type { Database } from "bun:sqlite"
+
+import consola from "consola"
+
+import { getAdminDb, getAdminDbPath, getAdminDbUserVersion } from "./admin-db"
+
+const INSERT_WARN_THROTTLE_MS = 30_000
+const STORE_INIT_WARN_THROTTLE_MS = 30_000
+const STORE_INIT_RETRY_DELAY_MS = 30_000
+
+let lastInsertWarnAtMs = 0
+let suppressedInsertWarnCount = 0
+let lastStoreInitWarnAtMs = 0
+let suppressedStoreInitWarnCount = 0
+let nextStoreRetryAtMs = 0
+
+export const SENSITIVE_HEADER_PATTERNS = [
+  /^authorization$/i,
+  /^x-github-token$/i,
+  /^cookie$/i,
+  /^set-cookie$/i,
+  /^proxy-authorization$/i,
+  /^x-api-key$/i,
+  /-token$/i,
+  /-secret$/i,
+] as const
+
+function warnInsertFailure(error: unknown): void {
+  const now = Date.now()
+
+  if (now - lastInsertWarnAtMs < INSERT_WARN_THROTTLE_MS) {
+    suppressedInsertWarnCount++
+    return
+  }
+
+  const suppressed = suppressedInsertWarnCount
+  suppressedInsertWarnCount = 0
+  lastInsertWarnAtMs = now
+
+  const suffix =
+    suppressed > 0 ? ` (suppressed ${suppressed} similar errors)` : ""
+  consola.warn(`Failed to insert request outbound${suffix}`, error)
+}
+
+function warnStoreInitFailure(error: unknown): void {
+  const now = Date.now()
+
+  if (now - lastStoreInitWarnAtMs < STORE_INIT_WARN_THROTTLE_MS) {
+    suppressedStoreInitWarnCount++
+    return
+  }
+
+  const suppressed = suppressedStoreInitWarnCount
+  suppressedStoreInitWarnCount = 0
+  lastStoreInitWarnAtMs = now
+
+  const suffix =
+    suppressed > 0 ? ` (suppressed ${suppressed} similar errors)` : ""
+  consola.warn(`Request outbound store is disabled${suffix}`, error)
+}
+
+type HeaderMap = Record<string, string>
+
+function shouldRedactHeader(key: string): boolean {
+  return SENSITIVE_HEADER_PATTERNS.some((pattern) => pattern.test(key))
+}
+
+export function getRedactedHeaderKeys(headers: HeaderMap): Array<string> {
+  return Object.keys(headers).filter((key) => shouldRedactHeader(key))
+}
+
+export function redactHeaders(headers: HeaderMap): HeaderMap {
+  const redacted: HeaderMap = {}
+
+  for (const [key, value] of Object.entries(headers)) {
+    redacted[key] = shouldRedactHeader(key) ? "***" : value
+  }
+
+  return redacted
+}
+
+export type OutboundCaptureInput = {
+  requestId: string
+  httpStatus: number
+  upstreamUrl: string
+  upstreamMethod: string
+  requestHeaders: HeaderMap
+  requestBody: string | null
+  requestBodyKind: string
+  responseStatus: number
+  responseHeaders: HeaderMap
+  responseBody: string | null
+  responseBodyKind: string
+}
+
+export type OutboundCaptureRow = OutboundCaptureInput & {
+  capturedAtMs: number
+}
+
+export type RequestOutboundStoreApi = {
+  insert(input: OutboundCaptureInput): void
+  getByRequestId(requestId: string): OutboundCaptureRow | null
+  cleanupOrphans(): void
+  meta(): {
+    dbPath: string
+    userVersion: number
+  }
+}
+
+class RequestOutboundStore implements RequestOutboundStoreApi {
+  private readonly db: Database
+  private readonly insertStmt: ReturnType<Database["query"]>
+  private readonly getByRequestIdStmt: ReturnType<Database["query"]>
+  private readonly cleanupOrphansStmt: ReturnType<Database["query"]>
+
+  constructor(db: Database) {
+    this.db = db
+    this.insertStmt = db.query(`
+      INSERT OR REPLACE INTO request_outbound (
+        request_id,
+        captured_at_ms,
+        http_status,
+        upstream_url,
+        upstream_method,
+        request_headers,
+        request_body,
+        request_body_kind,
+        response_status,
+        response_headers,
+        response_body,
+        response_body_kind
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    `)
+    this.getByRequestIdStmt = db.query(`
+      SELECT
+        request_id,
+        captured_at_ms,
+        http_status,
+        upstream_url,
+        upstream_method,
+        request_headers,
+        request_body,
+        request_body_kind,
+        response_status,
+        response_headers,
+        response_body,
+        response_body_kind
+      FROM request_outbound
+      WHERE request_id = ?
+      LIMIT 1;
+    `)
+    this.cleanupOrphansStmt = db.query(`
+      DELETE FROM request_outbound
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM request_log
+        WHERE request_log.request_id = request_outbound.request_id
+      );
+    `)
+  }
+
+  insert(input: OutboundCaptureInput): void {
+    try {
+      this.insertStmt.run(
+        input.requestId,
+        Date.now(),
+        input.httpStatus,
+        input.upstreamUrl,
+        input.upstreamMethod,
+        JSON.stringify(redactHeaders(input.requestHeaders)),
+        input.requestBody,
+        input.requestBodyKind,
+        input.responseStatus,
+        JSON.stringify(input.responseHeaders),
+        input.responseBody,
+        input.responseBodyKind,
+      )
+    } catch (error) {
+      warnInsertFailure(error)
+    }
+  }
+
+  getByRequestId(requestId: string): OutboundCaptureRow | null {
+    try {
+      const row = this.getByRequestIdStmt.get(requestId) as
+        | {
+            request_id: string
+            captured_at_ms: number
+            http_status: number
+            upstream_url: string
+            upstream_method: string
+            request_headers: string
+            request_body: string | null
+            request_body_kind: string
+            response_status: number
+            response_headers: string
+            response_body: string | null
+            response_body_kind: string
+          }
+        | null
+        | undefined
+
+      if (!row) {
+        return null
+      }
+
+      return {
+        requestId: row.request_id,
+        capturedAtMs: row.captured_at_ms,
+        httpStatus: row.http_status,
+        upstreamUrl: row.upstream_url,
+        upstreamMethod: row.upstream_method,
+        requestHeaders: JSON.parse(row.request_headers) as HeaderMap,
+        requestBody: row.request_body,
+        requestBodyKind: row.request_body_kind,
+        responseStatus: row.response_status,
+        responseHeaders: JSON.parse(row.response_headers) as HeaderMap,
+        responseBody: row.response_body,
+        responseBodyKind: row.response_body_kind,
+      }
+    } catch (error) {
+      consola.debug("Failed to fetch request outbound by request_id", error)
+      return null
+    }
+  }
+
+  cleanupOrphans(): void {
+    try {
+      this.cleanupOrphansStmt.run()
+    } catch (error) {
+      consola.debug("Failed to cleanup request_outbound orphans", error)
+    }
+  }
+
+  meta(): { dbPath: string; userVersion: number } {
+    return {
+      dbPath: getAdminDbPath(),
+      userVersion: getAdminDbUserVersion(this.db),
+    }
+  }
+}
+
+export function createRequestOutboundStore(
+  db: Database,
+): RequestOutboundStoreApi {
+  return new RequestOutboundStore(db)
+}
+
+const disabledStore: RequestOutboundStoreApi = {
+  insert: () => {},
+  getByRequestId: () => null,
+  cleanupOrphans: () => {},
+  meta: () => ({
+    dbPath: getAdminDbPath(),
+    userVersion: 0,
+  }),
+}
+
+let sharedStore: RequestOutboundStoreApi | null = null
+
+export function getRequestOutboundStore(): RequestOutboundStoreApi {
+  if (sharedStore) {
+    return sharedStore
+  }
+
+  const now = Date.now()
+  if (now < nextStoreRetryAtMs) {
+    return disabledStore
+  }
+
+  try {
+    sharedStore = createRequestOutboundStore(getAdminDb())
+    return sharedStore
+  } catch (error) {
+    nextStoreRetryAtMs = now + STORE_INIT_RETRY_DELAY_MS
+    warnStoreInitFailure(error)
+    return disabledStore
+  }
+}

--- a/src/routes/admin-api/config-writer.ts
+++ b/src/routes/admin-api/config-writer.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from "node:crypto"
+import fs from "node:fs/promises"
+
+import type { AppConfig } from "~/lib/config"
+
+import { PATHS } from "~/lib/paths"
+
+export async function writeConfigFile(config: AppConfig): Promise<void> {
+  await fs.mkdir(PATHS.APP_DIR, { recursive: true })
+
+  const content = `${JSON.stringify(config, null, 2)}\n`
+  const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${randomUUID()}`
+
+  try {
+    await fs.writeFile(tmpPath, content, "utf8")
+    try {
+      await fs.chmod(tmpPath, 0o600)
+    } catch {
+      // Ignore chmod errors (e.g. unsupported filesystem).
+    }
+    await fs.rename(tmpPath, PATHS.CONFIG_PATH)
+  } catch (error) {
+    await fs.rm(tmpPath, { force: true }).catch(() => {})
+    throw error
+  }
+}

--- a/src/routes/admin-api/config-writer.ts
+++ b/src/routes/admin-api/config-writer.ts
@@ -12,7 +12,7 @@ export async function writeConfigFile(config: AppConfig): Promise<void> {
   const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${randomUUID()}`
 
   try {
-    await fs.writeFile(tmpPath, content, "utf8")
+    await fs.writeFile(tmpPath, content, { encoding: "utf8", mode: 0o600 })
     try {
       await fs.chmod(tmpPath, 0o600)
     } catch {

--- a/src/routes/admin-api/replay-translation.ts
+++ b/src/routes/admin-api/replay-translation.ts
@@ -1,0 +1,39 @@
+import type { ChatCompletionResponse } from "~/services/copilot/create-chat-completions"
+
+import { translateToAnthropic } from "~/routes/messages/non-stream-translation"
+
+export type TranslateForReplayInput = {
+  upstreamEndpoint: string
+  rawText: string
+  rawKind: "json" | "sse" | "text"
+}
+
+export function translateForReplay(input: TranslateForReplayInput): unknown {
+  const { upstreamEndpoint, rawText, rawKind } = input
+
+  // /chat/completions + json → translate OpenAI → Anthropic
+  if (upstreamEndpoint.includes("/chat/completions") && rawKind === "json") {
+    const parsed = JSON.parse(rawText) as ChatCompletionResponse
+    return translateToAnthropic(parsed)
+  }
+
+  // /chat/completions + sse → return raw (full SSE translation is complex, defer)
+  if (upstreamEndpoint.includes("/chat/completions") && rawKind === "sse") {
+    return rawText
+  }
+
+  // /v1/messages → identity (raw IS anthropic format)
+  if (upstreamEndpoint.includes("/v1/messages")) {
+    if (rawKind === "json") {
+      return JSON.parse(rawText) as unknown
+    }
+    return rawText
+  }
+
+  // /responses → return raw (responses translation is complex, defer)
+  if (upstreamEndpoint.includes("/responses")) {
+    return rawText
+  }
+
+  return null
+}

--- a/src/routes/admin-api/replay-translation.ts
+++ b/src/routes/admin-api/replay-translation.ts
@@ -13,8 +13,11 @@ export function translateForReplay(input: TranslateForReplayInput): unknown {
 
   // /chat/completions + json → translate OpenAI → Anthropic
   if (upstreamEndpoint.includes("/chat/completions") && rawKind === "json") {
-    const parsed = JSON.parse(rawText) as ChatCompletionResponse
-    return translateToAnthropic(parsed)
+    const parsed = JSON.parse(rawText) as Partial<ChatCompletionResponse>
+    if (!Array.isArray(parsed.choices)) {
+      return parsed
+    }
+    return translateToAnthropic(parsed as ChatCompletionResponse)
   }
 
   // /chat/completions + sse → return raw (full SSE translation is complex, defer)

--- a/src/routes/admin-api/replay.ts
+++ b/src/routes/admin-api/replay.ts
@@ -4,6 +4,11 @@ import type { AppConfig, DevModeConfig } from "~/lib/config"
 
 import { getConfig, mergeConfigWithDefaults } from "~/lib/config"
 import { isDevModeEnabled } from "~/lib/dev-mode"
+import { getRequestHistoryStore } from "~/lib/request-history"
+import {
+  getRedactedHeaderKeys,
+  getRequestOutboundStore,
+} from "~/lib/request-outbound"
 
 import { writeConfigFile } from "./config-writer"
 
@@ -55,6 +60,53 @@ replayRoutes.post("/dev-mode", async (c) => {
   mergeConfigWithDefaults()
 
   return c.json(next)
+})
+
+replayRoutes.get("/requests/:requestId/outbound", (c) => {
+  const gate = requireDevMode(c)
+  if (gate) return gate
+
+  const requestId = c.req.param("requestId")
+  const blob = getRequestOutboundStore().getByRequestId(requestId)
+  if (!blob) {
+    return c.json(
+      {
+        error: {
+          message: "No outbound captured for this request",
+          type: "not_found",
+        },
+      },
+      404,
+    )
+  }
+
+  const logRow = getRequestHistoryStore().getByRequestId(requestId)
+
+  return c.json({
+    request_id: blob.requestId,
+    captured_at_ms: blob.capturedAtMs,
+    http_status: blob.httpStatus,
+    upstream_url: blob.upstreamUrl,
+    upstream_method: blob.upstreamMethod,
+    request_headers: blob.requestHeaders,
+    request_body: blob.requestBody,
+    request_body_kind: blob.requestBodyKind,
+    response_status: blob.responseStatus,
+    response_headers: blob.responseHeaders,
+    response_body: blob.responseBody,
+    response_body_kind: blob.responseBodyKind,
+    redacted_header_keys: getRedactedHeaderKeys(blob.requestHeaders),
+    original:
+      logRow ?
+        {
+          path: logRow.path,
+          upstream_endpoint: logRow.upstream_endpoint,
+          upstream_model: logRow.upstream_model,
+          account_id: logRow.account_id,
+          client_model: logRow.client_model,
+        }
+      : null,
+  })
 })
 
 export function requireDevMode(c: Context): Response | null {

--- a/src/routes/admin-api/replay.ts
+++ b/src/routes/admin-api/replay.ts
@@ -1,6 +1,8 @@
 import { Hono, type Context } from "hono"
+import { streamSSE } from "hono/streaming"
 
 import type { AppConfig, DevModeConfig } from "~/lib/config"
+import type { RequestLogRow } from "~/lib/request-history"
 import type { OutboundCaptureRow } from "~/lib/request-outbound"
 import type { AccountContext } from "~/lib/types/account"
 
@@ -127,6 +129,12 @@ type ReplayError = {
   status: number
 }
 
+function isReplayError(
+  value: string | null | ReplayError,
+): value is ReplayError {
+  return value !== null && typeof value === "object" && "json" in value
+}
+
 function resolveRequestBody(
   blob: OutboundCaptureRow,
   bodyOverride: unknown,
@@ -190,6 +198,29 @@ function headersToRecord(headers: Headers): Record<string, string> {
   return out
 }
 
+async function readReplayChunks(
+  body: ReadableStream<Uint8Array> | null,
+): Promise<Array<string>> {
+  if (!body) {
+    return []
+  }
+
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  const rawChunks: Array<string> = []
+
+  for (;;) {
+    const readResult = await reader.read()
+    if (readResult.done) {
+      break
+    }
+
+    rawChunks.push(decoder.decode(readResult.value, { stream: true }))
+  }
+
+  return rawChunks
+}
+
 function tryTranslate(
   upstreamEndpoint: string,
   rawText: string,
@@ -207,7 +238,6 @@ replayRoutes.post("/requests/:requestId/replay", async (c) => {
   if (gate) return gate
 
   const requestId = c.req.param("requestId")
-
   const blob = getRequestOutboundStore().getByRequestId(requestId)
   if (!blob) {
     return c.json(
@@ -244,6 +274,19 @@ replayRoutes.post("/requests/:requestId/replay", async (c) => {
     )
   }
 
+  return handleReplayRequest(c, { blob, logRow, payload })
+})
+
+async function handleReplayRequest(
+  c: Context,
+  input: {
+    blob: OutboundCaptureRow
+    logRow: RequestLogRow
+    payload: ReplayPayload
+  },
+) {
+  const { blob, logRow, payload } = input
+
   if (!payload.accountId || typeof payload.accountId !== "string") {
     return c.json(
       { error: { message: "accountId is required", type: "bad_request" } },
@@ -265,28 +308,34 @@ replayRoutes.post("/requests/:requestId/replay", async (c) => {
   }
 
   const bodyResult = resolveRequestBody(blob, payload.body)
-  if (
-    bodyResult !== null
-    && typeof bodyResult === "object"
-    && "json" in bodyResult
-  ) {
+  if (isReplayError(bodyResult)) {
     return c.json(bodyResult.json, bodyResult.status as 400)
   }
-  const requestBody = bodyResult
 
+  const requestBody = bodyResult
   const mergedHeaders = buildReplayHeaders(blob, payload.headers, account)
   const mode = payload.mode ?? "collect"
 
   if (mode === "live") {
-    return c.json(
-      {
-        error: {
-          message: "Live SSE mode is not yet implemented",
-          type: "not_implemented",
-        },
-      },
-      501,
-    )
+    const startMs = Date.now()
+    let upstreamResponse: Response
+    try {
+      upstreamResponse = await fetchReplayUpstream({
+        blob,
+        headers: mergedHeaders,
+        body: requestBody,
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Upstream fetch failed"
+      return c.json({ error: { message, type: "upstream_error" } }, 502)
+    }
+
+    return streamAndRespond(c, {
+      upstreamRes: upstreamResponse,
+      logRow,
+      startMs,
+    })
   }
 
   return collectAndRespond(c, {
@@ -295,13 +344,33 @@ replayRoutes.post("/requests/:requestId/replay", async (c) => {
     headers: mergedHeaders,
     body: requestBody,
   })
-})
+}
 
-type CollectInput = {
+type ReplayUpstreamInput = {
   blob: OutboundCaptureRow
-  upstreamEndpoint: string
   headers: Record<string, string>
   body: string | null
+}
+
+type CollectInput = ReplayUpstreamInput & {
+  upstreamEndpoint: string
+}
+
+type StreamInput = {
+  upstreamRes: Response
+  logRow: RequestLogRow | null
+  startMs: number
+}
+
+async function fetchReplayUpstream(
+  input: ReplayUpstreamInput,
+): Promise<Response> {
+  const { blob, headers, body } = input
+  return copilotFetch(
+    blob.upstreamUrl,
+    { method: blob.upstreamMethod, headers, body },
+    { callSite: "replay", capturable: false },
+  )
 }
 
 async function collectAndRespond(c: Context, input: CollectInput) {
@@ -309,11 +378,7 @@ async function collectAndRespond(c: Context, input: CollectInput) {
   const startMs = Date.now()
   let upstreamResponse: Response
   try {
-    upstreamResponse = await copilotFetch(
-      blob.upstreamUrl,
-      { method: blob.upstreamMethod, headers, body },
-      { callSite: "replay", capturable: false },
-    )
+    upstreamResponse = await fetchReplayUpstream({ blob, headers, body })
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Upstream fetch failed"
@@ -333,6 +398,59 @@ async function collectAndRespond(c: Context, input: CollectInput) {
     translated: tryTranslate(upstreamEndpoint, responseText, rawKind),
     durationMs,
     replayedAt: Date.now(),
+  })
+}
+
+function streamAndRespond(c: Context, input: StreamInput): Response {
+  const { upstreamRes, logRow, startMs } = input
+
+  return streamSSE(c, async (sse) => {
+    const responseHeaders = headersToRecord(upstreamRes.headers)
+
+    await sse.writeSSE({
+      event: "upstream-start",
+      data: JSON.stringify({
+        status: upstreamRes.status,
+        statusText: upstreamRes.statusText,
+        headers: responseHeaders,
+      }),
+    })
+
+    const rawChunks = await readReplayChunks(upstreamRes.body)
+    for (const chunk of rawChunks) {
+      await sse.writeSSE({
+        event: "upstream-chunk",
+        data: JSON.stringify({ raw: chunk }),
+      })
+    }
+
+    await sse.writeSSE({
+      event: "upstream-done",
+      data: JSON.stringify({ durationMs: Date.now() - startMs }),
+    })
+
+    if (logRow?.path === "/v1/messages") {
+      const contentType = upstreamRes.headers.get("content-type") ?? ""
+      const rawText = rawChunks.join("")
+      const rawKind = detectRawKind(contentType)
+
+      try {
+        const translated = translateForReplay({
+          upstreamEndpoint: logRow.upstream_endpoint ?? "",
+          rawText,
+          rawKind,
+        })
+        await sse.writeSSE({
+          event: "translated",
+          data: JSON.stringify(translated),
+        })
+      } catch (err) {
+        await sse.writeSSE({
+          event: "translated",
+          data: JSON.stringify({ error: (err as Error).message }),
+        })
+      }
+    }
   })
 }
 

--- a/src/routes/admin-api/replay.ts
+++ b/src/routes/admin-api/replay.ts
@@ -1,7 +1,11 @@
 import { Hono, type Context } from "hono"
 
 import type { AppConfig, DevModeConfig } from "~/lib/config"
+import type { OutboundCaptureRow } from "~/lib/request-outbound"
+import type { AccountContext } from "~/lib/types/account"
 
+import { accountsManager } from "~/lib/accounts-manager"
+import { copilotHeaders } from "~/lib/api-config"
 import { getConfig, mergeConfigWithDefaults } from "~/lib/config"
 import { isDevModeEnabled } from "~/lib/dev-mode"
 import { getRequestHistoryStore } from "~/lib/request-history"
@@ -9,8 +13,10 @@ import {
   getRedactedHeaderKeys,
   getRequestOutboundStore,
 } from "~/lib/request-outbound"
+import { copilotFetch } from "~/services/copilot/copilot-fetch"
 
 import { writeConfigFile } from "./config-writer"
+import { translateForReplay } from "./replay-translation"
 
 export const replayRoutes = new Hono()
 
@@ -108,6 +114,227 @@ replayRoutes.get("/requests/:requestId/outbound", (c) => {
       : null,
   })
 })
+
+type ReplayPayload = {
+  mode?: "collect" | "live"
+  accountId: string
+  headers?: Record<string, string>
+  body?: unknown
+}
+
+type ReplayError = {
+  json: { error: { message: string; type: string } }
+  status: number
+}
+
+function resolveRequestBody(
+  blob: OutboundCaptureRow,
+  bodyOverride: unknown,
+): string | null | ReplayError {
+  if (bodyOverride === undefined) {
+    return blob.requestBody
+  }
+
+  if (blob.requestBodyKind === "json" && typeof bodyOverride === "string") {
+    try {
+      JSON.parse(bodyOverride)
+      return bodyOverride
+    } catch {
+      return {
+        json: {
+          error: {
+            message: "body override is not valid JSON",
+            type: "bad_request",
+          },
+        },
+        status: 400,
+      }
+    }
+  }
+
+  if (blob.requestBodyKind === "json") {
+    return JSON.stringify(bodyOverride)
+  }
+
+  return typeof bodyOverride === "string" ? bodyOverride : (
+      JSON.stringify(bodyOverride)
+    )
+}
+
+function buildReplayHeaders(
+  blob: OutboundCaptureRow,
+  headerOverrides: Record<string, string> | undefined,
+  account: AccountContext,
+): Record<string, string> {
+  const base = { ...blob.requestHeaders }
+  if (headerOverrides) {
+    Object.assign(base, headerOverrides)
+  }
+  const cleaned = Object.fromEntries(
+    Object.entries(base).filter(([, v]) => v !== "***"),
+  )
+  return { ...cleaned, ...copilotHeaders(account) }
+}
+
+function detectRawKind(contentType: string): "json" | "sse" | "text" {
+  if (contentType.includes("text/event-stream")) return "sse"
+  if (contentType.includes("application/json")) return "json"
+  return "text"
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of headers.entries()) {
+    out[key] = value
+  }
+  return out
+}
+
+function tryTranslate(
+  upstreamEndpoint: string,
+  rawText: string,
+  rawKind: "json" | "sse" | "text",
+): unknown {
+  try {
+    return translateForReplay({ upstreamEndpoint, rawText, rawKind })
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Translation failed" }
+  }
+}
+
+replayRoutes.post("/requests/:requestId/replay", async (c) => {
+  const gate = requireDevMode(c)
+  if (gate) return gate
+
+  const requestId = c.req.param("requestId")
+
+  const blob = getRequestOutboundStore().getByRequestId(requestId)
+  if (!blob) {
+    return c.json(
+      {
+        error: {
+          message: "No outbound captured for this request",
+          type: "not_found",
+        },
+      },
+      404,
+    )
+  }
+
+  const logRow = getRequestHistoryStore().getByRequestId(requestId)
+  if (!logRow) {
+    return c.json(
+      {
+        error: {
+          message: "No request log found for this request",
+          type: "not_found",
+        },
+      },
+      404,
+    )
+  }
+
+  let payload: ReplayPayload
+  try {
+    payload = await c.req.json()
+  } catch {
+    return c.json(
+      { error: { message: "Body must be valid JSON", type: "bad_request" } },
+      400,
+    )
+  }
+
+  if (!payload.accountId || typeof payload.accountId !== "string") {
+    return c.json(
+      { error: { message: "accountId is required", type: "bad_request" } },
+      400,
+    )
+  }
+
+  const account = accountsManager.getAccountContextById(payload.accountId)
+  if (!account?.copilotToken) {
+    return c.json(
+      {
+        error: {
+          message: `Account "${payload.accountId}" not found or has no valid token`,
+          type: "bad_request",
+        },
+      },
+      400,
+    )
+  }
+
+  const bodyResult = resolveRequestBody(blob, payload.body)
+  if (
+    bodyResult !== null
+    && typeof bodyResult === "object"
+    && "json" in bodyResult
+  ) {
+    return c.json(bodyResult.json, bodyResult.status as 400)
+  }
+  const requestBody = bodyResult
+
+  const mergedHeaders = buildReplayHeaders(blob, payload.headers, account)
+  const mode = payload.mode ?? "collect"
+
+  if (mode === "live") {
+    return c.json(
+      {
+        error: {
+          message: "Live SSE mode is not yet implemented",
+          type: "not_implemented",
+        },
+      },
+      501,
+    )
+  }
+
+  return collectAndRespond(c, {
+    blob,
+    upstreamEndpoint: logRow.upstream_endpoint ?? "",
+    headers: mergedHeaders,
+    body: requestBody,
+  })
+})
+
+type CollectInput = {
+  blob: OutboundCaptureRow
+  upstreamEndpoint: string
+  headers: Record<string, string>
+  body: string | null
+}
+
+async function collectAndRespond(c: Context, input: CollectInput) {
+  const { blob, upstreamEndpoint, headers, body } = input
+  const startMs = Date.now()
+  let upstreamResponse: Response
+  try {
+    upstreamResponse = await copilotFetch(
+      blob.upstreamUrl,
+      { method: blob.upstreamMethod, headers, body },
+      { callSite: "replay", capturable: false },
+    )
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Upstream fetch failed"
+    return c.json({ error: { message, type: "upstream_error" } }, 502)
+  }
+  const durationMs = Date.now() - startMs
+
+  const responseText = await upstreamResponse.text()
+  const contentType = upstreamResponse.headers.get("content-type") ?? ""
+  const rawKind = detectRawKind(contentType)
+
+  return c.json({
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: headersToRecord(upstreamResponse.headers),
+    raw: { body: responseText, kind: rawKind },
+    translated: tryTranslate(upstreamEndpoint, responseText, rawKind),
+    durationMs,
+    replayedAt: Date.now(),
+  })
+}
 
 export function requireDevMode(c: Context): Response | null {
   if (!isDevModeEnabled()) {

--- a/src/routes/admin-api/replay.ts
+++ b/src/routes/admin-api/replay.ts
@@ -1,0 +1,73 @@
+import { Hono, type Context } from "hono"
+
+import type { AppConfig, DevModeConfig } from "~/lib/config"
+
+import { getConfig, mergeConfigWithDefaults } from "~/lib/config"
+import { isDevModeEnabled } from "~/lib/dev-mode"
+
+import { writeConfigFile } from "./config-writer"
+
+export const replayRoutes = new Hono()
+
+replayRoutes.get("/dev-mode", (c) => {
+  const dev = getConfig().devMode ?? { enabled: false, capture4xx: false }
+  return c.json({
+    enabled: dev.enabled,
+    capture4xx: dev.capture4xx,
+  })
+})
+
+replayRoutes.post("/dev-mode", async (c) => {
+  let payload: unknown
+  try {
+    payload = await c.req.json()
+  } catch {
+    return c.json(
+      { error: { message: "Body must be valid JSON", type: "bad_request" } },
+      400,
+    )
+  }
+
+  if (
+    typeof payload !== "object"
+    || payload === null
+    || Array.isArray(payload)
+  ) {
+    return c.json(
+      { error: { message: "Body must be an object", type: "bad_request" } },
+      400,
+    )
+  }
+
+  const patch = payload as Partial<DevModeConfig>
+  const current = getConfig().devMode ?? { enabled: false, capture4xx: false }
+  const next: DevModeConfig = {
+    enabled:
+      typeof patch.enabled === "boolean" ? patch.enabled : current.enabled,
+    capture4xx:
+      typeof patch.capture4xx === "boolean" ?
+        patch.capture4xx
+      : current.capture4xx,
+  }
+
+  const config: AppConfig = { ...getConfig(), devMode: next }
+  await writeConfigFile(config)
+  mergeConfigWithDefaults()
+
+  return c.json(next)
+})
+
+export function requireDevMode(c: Context): Response | null {
+  if (!isDevModeEnabled()) {
+    return c.json(
+      {
+        error: {
+          message: "Developer mode disabled",
+          type: "forbidden",
+        },
+      },
+      403,
+    )
+  }
+  return null
+}

--- a/src/routes/admin-api/replay.ts
+++ b/src/routes/admin-api/replay.ts
@@ -198,29 +198,6 @@ function headersToRecord(headers: Headers): Record<string, string> {
   return out
 }
 
-async function readReplayChunks(
-  body: ReadableStream<Uint8Array> | null,
-): Promise<Array<string>> {
-  if (!body) {
-    return []
-  }
-
-  const reader = body.getReader()
-  const decoder = new TextDecoder()
-  const rawChunks: Array<string> = []
-
-  for (;;) {
-    const readResult = await reader.read()
-    if (readResult.done) {
-      break
-    }
-
-    rawChunks.push(decoder.decode(readResult.value, { stream: true }))
-  }
-
-  return rawChunks
-}
-
 function tryTranslate(
   upstreamEndpoint: string,
   rawText: string,
@@ -416,12 +393,34 @@ function streamAndRespond(c: Context, input: StreamInput): Response {
       }),
     })
 
-    const rawChunks = await readReplayChunks(upstreamRes.body)
-    for (const chunk of rawChunks) {
-      await sse.writeSSE({
-        event: "upstream-chunk",
-        data: JSON.stringify({ raw: chunk }),
-      })
+    const rawChunks: Array<string> = []
+
+    if (upstreamRes.body) {
+      const reader = (
+        upstreamRes.body as ReadableStream<Uint8Array>
+      ).getReader()
+      const decoder = new TextDecoder()
+
+      for (;;) {
+        const readResult = await reader.read()
+        if (readResult.done) break
+
+        const chunk = decoder.decode(readResult.value, { stream: true })
+        rawChunks.push(chunk)
+        await sse.writeSSE({
+          event: "upstream-chunk",
+          data: JSON.stringify({ raw: chunk }),
+        })
+      }
+
+      const trailing = decoder.decode()
+      if (trailing) {
+        rawChunks.push(trailing)
+        await sse.writeSSE({
+          event: "upstream-chunk",
+          data: JSON.stringify({ raw: trailing }),
+        })
+      }
     }
 
     await sse.writeSSE({

--- a/src/routes/admin-api/replay.ts
+++ b/src/routes/admin-api/replay.ts
@@ -23,10 +23,17 @@ import { translateForReplay } from "./replay-translation"
 export const replayRoutes = new Hono()
 
 replayRoutes.get("/dev-mode", (c) => {
-  const dev = getConfig().devMode ?? { enabled: false, capture4xx: false }
+  const dev = getConfig().devMode ?? {
+    enabled: false,
+    capture4xx: false,
+    capture5xx: false,
+    captureOther: false,
+  }
   return c.json({
     enabled: dev.enabled,
     capture4xx: dev.capture4xx,
+    capture5xx: dev.capture5xx,
+    captureOther: dev.captureOther,
   })
 })
 
@@ -53,7 +60,12 @@ replayRoutes.post("/dev-mode", async (c) => {
   }
 
   const patch = payload as Partial<DevModeConfig>
-  const current = getConfig().devMode ?? { enabled: false, capture4xx: false }
+  const current = getConfig().devMode ?? {
+    enabled: false,
+    capture4xx: false,
+    capture5xx: false,
+    captureOther: false,
+  }
   const next: DevModeConfig = {
     enabled:
       typeof patch.enabled === "boolean" ? patch.enabled : current.enabled,
@@ -61,6 +73,14 @@ replayRoutes.post("/dev-mode", async (c) => {
       typeof patch.capture4xx === "boolean" ?
         patch.capture4xx
       : current.capture4xx,
+    capture5xx:
+      typeof patch.capture5xx === "boolean" ?
+        patch.capture5xx
+      : current.capture5xx,
+    captureOther:
+      typeof patch.captureOther === "boolean" ?
+        patch.captureOther
+      : current.captureOther,
   }
 
   const config: AppConfig = { ...getConfig(), devMode: next }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -994,29 +994,36 @@ function applyProvidersConfig(
   return undefined
 }
 
+const DEV_MODE_KEYS = new Set([
+  "enabled",
+  "capture4xx",
+  "capture5xx",
+  "captureOther",
+])
+
 function parseDevModeConfig(value: unknown): ParseFieldResult<DevModeConfig> {
   if (value === null || value === undefined) return { clear: true }
   if (!isPlainObject(value)) return { error: "devMode must be an object" }
 
   for (const key of Object.keys(value)) {
-    if (key !== "enabled" && key !== "capture4xx") {
+    if (!DEV_MODE_KEYS.has(key)) {
       return { error: `devMode.${key} is not supported` }
     }
   }
 
-  const enabled = value.enabled
-  const capture4xx = value.capture4xx
-  if (enabled !== undefined && typeof enabled !== "boolean") {
-    return { error: "devMode.enabled must be a boolean" }
-  }
-  if (capture4xx !== undefined && typeof capture4xx !== "boolean") {
-    return { error: "devMode.capture4xx must be a boolean" }
+  for (const key of DEV_MODE_KEYS) {
+    const v = value[key]
+    if (v !== undefined && typeof v !== "boolean") {
+      return { error: `devMode.${key} must be a boolean` }
+    }
   }
 
   return {
     value: {
-      enabled: enabled === true,
-      capture4xx: capture4xx === true,
+      enabled: value.enabled === true,
+      capture4xx: value.capture4xx === true,
+      capture5xx: value.capture5xx === true,
+      captureOther: value.captureOther === true,
     },
   }
 }
@@ -1028,7 +1035,12 @@ function applyDevModeConfig(
   const parsed = parseDevModeConfig(value)
   if ("error" in parsed) return parsed.error
   if ("clear" in parsed) {
-    next.devMode = { enabled: false, capture4xx: false }
+    next.devMode = {
+      enabled: false,
+      capture4xx: false,
+      capture5xx: false,
+      captureOther: false,
+    }
     return undefined
   }
   next.devMode = parsed.value
@@ -1450,8 +1462,16 @@ adminApiRoutes.get("/requests", (c) => {
     toMs,
   })
 
+  const outboundIds = getRequestOutboundStore().hasOutboundForIds(
+    result.items.map((i) => i.request_id),
+  )
+  const itemsWithOutbound = result.items.map((item) => ({
+    ...item,
+    has_outbound: outboundIds.has(item.request_id),
+  }))
+
   return c.json({
-    items: result.items,
+    items: itemsWithOutbound,
     next_cursor_id: result.nextCursorId,
     has_more: result.hasMore,
   })

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1,7 +1,5 @@
 /* eslint-disable max-lines */
 import { Hono, type Context } from "hono"
-import { randomUUID } from "node:crypto"
-import fs from "node:fs/promises"
 
 import {
   DEFAULT_IDENTITY_ENTERPRISE_DOMAIN,
@@ -41,7 +39,8 @@ import { toLocalDateString } from "~/lib/stats-store"
 import { isAccountType } from "~/lib/types/account"
 
 import { authSessionManager } from "./auth-sessions"
-
+import { writeConfigFile } from "./config-writer"
+import { replayRoutes } from "./replay"
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN?.trim() || undefined
 
 type AdminAccessDecision =
@@ -1098,26 +1097,6 @@ function applyConfigPatch(
   return { config: next }
 }
 
-async function writeConfigFile(config: AppConfig): Promise<void> {
-  await fs.mkdir(PATHS.APP_DIR, { recursive: true })
-
-  const content = `${JSON.stringify(config, null, 2)}\n`
-  const tmpPath = `${PATHS.CONFIG_PATH}.tmp-${randomUUID()}`
-
-  try {
-    await fs.writeFile(tmpPath, content, "utf8")
-    try {
-      await fs.chmod(tmpPath, 0o600)
-    } catch {
-      // Ignore chmod errors (e.g. unsupported filesystem).
-    }
-    await fs.rename(tmpPath, PATHS.CONFIG_PATH)
-  } catch (error) {
-    await fs.rm(tmpPath, { force: true }).catch(() => {})
-    throw error
-  }
-}
-
 export const adminApiRoutes = new Hono()
 
 adminApiRoutes.use("*", async (c, next) => {
@@ -1788,3 +1767,5 @@ adminApiRoutes.get("/stats/premium-daily", (c) => {
     range: { from: resolvedFrom, to: resolvedTo, granularity },
   })
 })
+
+adminApiRoutes.route("/", replayRoutes)

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -25,6 +25,7 @@ import {
   mergeConfigWithDefaults,
   PROVIDER_TYPE_ANTHROPIC,
   type AppConfig,
+  type DevModeConfig,
   type LogLevel,
   type ModelConfig,
   type ProviderConfig,
@@ -193,6 +194,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "sessionAffinityRetentionDays",
   "useMessagesApi",
   "useResponsesApiWebSearch",
+  "devMode",
 ])
 
 const REASONING_EFFORTS = new Set<ReasoningEffort>([
@@ -992,6 +994,49 @@ function applyProvidersConfig(
   return undefined
 }
 
+function parseDevModeConfig(
+  value: unknown,
+): ParseFieldResult<DevModeConfig> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) return { error: "devMode must be an object" }
+
+  for (const key of Object.keys(value)) {
+    if (key !== "enabled" && key !== "capture4xx") {
+      return { error: `devMode.${key} is not supported` }
+    }
+  }
+
+  const enabled = value.enabled
+  const capture4xx = value.capture4xx
+  if (enabled !== undefined && typeof enabled !== "boolean") {
+    return { error: "devMode.enabled must be a boolean" }
+  }
+  if (capture4xx !== undefined && typeof capture4xx !== "boolean") {
+    return { error: "devMode.capture4xx must be a boolean" }
+  }
+
+  return {
+    value: {
+      enabled: enabled === true,
+      capture4xx: capture4xx === true,
+    },
+  }
+}
+
+function applyDevModeConfig(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseDevModeConfig(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    next.devMode = { enabled: false, capture4xx: false }
+    return undefined
+  }
+  next.devMode = parsed.value
+  return undefined
+}
+
 type ConfigPatchHandler = (
   next: AppConfig,
   value: unknown,
@@ -1028,6 +1073,7 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
     applyOptionalBoolean(next, "useMessagesApi", value),
   useResponsesApiWebSearch: (next, value) =>
     applyOptionalBoolean(next, "useResponsesApiWebSearch", value),
+  devMode: applyDevModeConfig,
 }
 
 function applyConfigPatch(

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -994,9 +994,7 @@ function applyProvidersConfig(
   return undefined
 }
 
-function parseDevModeConfig(
-  value: unknown,
-): ParseFieldResult<DevModeConfig> {
+function parseDevModeConfig(value: unknown): ParseFieldResult<DevModeConfig> {
   if (value === null || value === undefined) return { clear: true }
   if (!isPlainObject(value)) return { error: "devMode must be an object" }
 

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -34,6 +34,7 @@ import {
   getStatsStore,
   type AccountStatsRow,
 } from "~/lib/request-history"
+import { getRequestOutboundStore } from "~/lib/request-outbound"
 import { applySharedSessionAffinityRetention } from "~/lib/session-affinity-store"
 import { toLocalDateString } from "~/lib/stats-store"
 import { isAccountType } from "~/lib/types/account"
@@ -1460,7 +1461,10 @@ adminApiRoutes.get("/requests/:requestId", (c) => {
   const requestId = c.req.param("requestId")
   const store = getRequestHistoryStore()
   const item = store.getByRequestId(requestId)
-  return c.json({ item })
+  const hasOutbound =
+    item !== null
+    && getRequestOutboundStore().getByRequestId(requestId) !== null
+  return c.json({ item, has_outbound: hasOutbound })
 })
 
 adminApiRoutes.post("/accounts/auth/start", async (c) => {

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -389,6 +389,7 @@ async function handleStreamingRequest(params: {
     response = await createChatCompletions(payload, accountCtx, {
       upstreamRequestId: request.upstreamRequestId,
       sessionId: request.upstreamSessionId,
+      requestId: request.requestId,
     })
     selection.confirmAffinity?.()
   } catch (error) {
@@ -738,6 +739,7 @@ async function handleNonStreamingRequest(params: {
     const response = await createChatCompletions(payload, accountCtx, {
       upstreamRequestId: request.upstreamRequestId,
       sessionId: request.upstreamSessionId,
+      requestId: request.requestId,
     })
     if (!isNonStreaming(response)) {
       throw new Error("Upstream returned a stream unexpectedly")

--- a/src/routes/chat-completions/support.ts
+++ b/src/routes/chat-completions/support.ts
@@ -102,7 +102,7 @@ export function insertRequestLog(
     affinityCacheKey: request.affinityCacheKey,
     ...record,
   })
-  flushPendingCapture(request.requestId)
+  void flushPendingCapture(request.requestId)
 }
 
 export function recordUnsupportedChatCompletionsModel(

--- a/src/routes/chat-completions/support.ts
+++ b/src/routes/chat-completions/support.ts
@@ -9,6 +9,7 @@ import type {
 import type { AffinityKeySource } from "~/lib/utils"
 
 import { getClientIpInfo, getRequestHistoryStore } from "~/lib/request-history"
+import { flushPendingCapture } from "~/services/copilot/copilot-fetch"
 
 export const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
 export const GPT_5_4_MODEL_ID = "gpt-5.4"
@@ -101,6 +102,7 @@ export function insertRequestLog(
     affinityCacheKey: request.affinityCacheKey,
     ...record,
   })
+  flushPendingCapture(request.requestId)
 }
 
 export function recordUnsupportedChatCompletionsModel(

--- a/src/routes/embeddings/route.ts
+++ b/src/routes/embeddings/route.ts
@@ -203,7 +203,9 @@ async function runEmbeddingsWithAccount({
   try {
     const accountCtx = toAccountContext(account)
 
-    const response = await createEmbeddings(payload, accountCtx)
+    const response = await createEmbeddings(payload, accountCtx, {
+      requestId: ctx.requestId,
+    })
 
     usage = normalizeEmbeddingsUsage(response.usage)
 

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -76,6 +76,7 @@ export const handleWithChatCompletions = async (
     upstreamRequestId: requestId,
     sessionId,
     compactType,
+    requestId,
   })
 
   if (isNonStreaming(response)) {
@@ -154,6 +155,7 @@ export const handleWithResponsesApi = async (
     upstreamRequestId: requestId,
     sessionId,
     compactType,
+    requestId,
   })
 
   if (responsesPayload.stream && isAsyncIterable(response)) {
@@ -245,6 +247,7 @@ export const handleWithMessagesApi = async (
     upstreamRequestId: requestId,
     sessionId,
     compactType,
+    requestId,
   })
 
   if (isAsyncIterable(response)) {

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -690,7 +690,7 @@ function insertRequestLog(
     premiumUnlimitedBefore,
     ...record,
   })
-  flushPendingCapture(requestId)
+  void flushPendingCapture(requestId)
 }
 
 async function finalizeQuotaAndGetPremiumSnapshot(

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -448,6 +448,7 @@ const handleWithChatCompletions = async (params: {
       subagentMarker,
       sessionId,
       compactType,
+      requestId: instr.requestId,
     })
     instr.confirmAffinity?.()
     instr.confirmOwnership?.()
@@ -551,6 +552,7 @@ const handleWithResponsesApi = async (params: {
         subagentMarker,
         sessionId,
         compactType,
+        requestId: instr.requestId,
       },
       ctx,
     )
@@ -1412,6 +1414,7 @@ const handleWithMessagesApi = async (params: {
       subagentMarker,
       sessionId,
       compactType,
+      requestId: instr.requestId,
     })
     instr.confirmAffinity?.()
     instr.confirmOwnership?.()

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -63,6 +63,7 @@ import {
   compactInputByLatestCompaction,
   getResponsesRequestOptions,
 } from "~/routes/responses/utils"
+import { flushPendingCapture } from "~/services/copilot/copilot-fetch"
 import {
   createChatCompletions,
   getChatInitiator,
@@ -689,6 +690,7 @@ function insertRequestLog(
     premiumUnlimitedBefore,
     ...record,
   })
+  flushPendingCapture(requestId)
 }
 
 async function finalizeQuotaAndGetPremiumSnapshot(

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -464,6 +464,7 @@ async function handleStreamingResponses(params: {
         initiator,
         upstreamRequestId: request.upstreamRequestId,
         sessionId: request.upstreamSessionId,
+        requestId: request.requestId,
       },
       accountCtx,
     )
@@ -794,6 +795,7 @@ async function handleNonStreamingResponses(params: {
         initiator,
         upstreamRequestId: request.upstreamRequestId,
         sessionId: request.upstreamSessionId,
+        requestId: request.requestId,
       },
       accountCtx,
     )

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -353,7 +353,7 @@ function insertRequestLog(
     affinityCacheKey: request.affinityCacheKey,
     ...record,
   })
-  flushPendingCapture(request.requestId)
+  void flushPendingCapture(request.requestId)
 }
 
 function recordSelectionFailure(

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -33,6 +33,7 @@ import {
   resolveAffinityKey,
   type AffinityKeySource,
 } from "~/lib/utils"
+import { flushPendingCapture } from "~/services/copilot/copilot-fetch"
 import {
   createResponses,
   type ResponsesPayload,
@@ -352,6 +353,7 @@ function insertRequestLog(
     affinityCacheKey: request.affinityCacheKey,
     ...record,
   })
+  flushPendingCapture(request.requestId)
 }
 
 function recordSelectionFailure(

--- a/src/services/copilot/copilot-fetch.ts
+++ b/src/services/copilot/copilot-fetch.ts
@@ -16,7 +16,7 @@ export type CopilotFetchCtx = {
 const pendingCaptures = new Map<string, PersistInput>()
 const pendingCapturePromises = new Map<string, Promise<void>>()
 
-export function flushPendingCapture(requestId: string): void {
+export async function flushPendingCapture(requestId: string): Promise<void> {
   const pending = pendingCaptures.get(requestId)
   if (pending) {
     pendingCaptures.delete(requestId)
@@ -26,14 +26,13 @@ export function flushPendingCapture(requestId: string): void {
   }
   const promise = pendingCapturePromises.get(requestId)
   if (promise) {
-    void promise.then(() => {
-      const deferred = pendingCaptures.get(requestId)
-      if (deferred) {
-        pendingCaptures.delete(requestId)
-        persistNow(deferred)
-      }
-      pendingCapturePromises.delete(requestId)
-    })
+    await promise
+    const deferred = pendingCaptures.get(requestId)
+    if (deferred) {
+      pendingCaptures.delete(requestId)
+      persistNow(deferred)
+    }
+    pendingCapturePromises.delete(requestId)
   }
 }
 

--- a/src/services/copilot/copilot-fetch.ts
+++ b/src/services/copilot/copilot-fetch.ts
@@ -1,6 +1,10 @@
 import consola from "consola"
 
-import { isCapture4xxEnabled } from "~/lib/dev-mode"
+import {
+  isCapture4xxEnabled,
+  isCapture5xxEnabled,
+  isCaptureOtherEnabled,
+} from "~/lib/dev-mode"
 import { getRequestOutboundStore } from "~/lib/request-outbound"
 
 export type CopilotFetchCtx = {
@@ -76,6 +80,12 @@ function snapshotBody(init: RequestInit): {
   return { body: null, bodyKind: "text" }
 }
 
+function shouldCaptureStatus(status: number): boolean {
+  if (status >= 400 && status < 500) return isCapture4xxEnabled()
+  if (status >= 500) return isCapture5xxEnabled()
+  return isCaptureOtherEnabled()
+}
+
 export async function copilotFetch(
   input: string | URL,
   init: RequestInit,
@@ -95,9 +105,7 @@ export async function copilotFetch(
   const shouldCapture =
     ctx.requestId !== undefined
     && ctx.capturable !== false
-    && isCapture4xxEnabled()
-    && response.status >= 400
-    && response.status < 500
+    && shouldCaptureStatus(response.status)
 
   if (!shouldCapture) {
     return response

--- a/src/services/copilot/copilot-fetch.ts
+++ b/src/services/copilot/copilot-fetch.ts
@@ -1,0 +1,213 @@
+import consola from "consola"
+
+import { isCapture4xxEnabled } from "~/lib/dev-mode"
+import { getRequestOutboundStore } from "~/lib/request-outbound"
+
+export type CopilotFetchCtx = {
+  requestId?: string
+  capturable?: boolean
+  callSite: string
+}
+
+type RequestSnapshot = {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body: string | null
+  bodyKind: "json" | "text" | "binary"
+}
+
+function snapshotHeaders(init: RequestInit): Record<string, string> {
+  const headers = init.headers
+  if (headers instanceof Headers) {
+    const out: Record<string, string> = {}
+    for (const [key, value] of headers.entries()) {
+      out[key] = value
+    }
+    return out
+  }
+
+  if (Array.isArray(headers)) {
+    const out: Record<string, string> = {}
+    for (const [key, value] of headers) {
+      out[key] = value
+    }
+    return out
+  }
+
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(
+    (headers ?? {}) as Record<string, string>,
+  )) {
+    out[key] = value
+  }
+  return out
+}
+
+function snapshotBody(init: RequestInit): {
+  body: string | null
+  bodyKind: "json" | "text" | "binary"
+} {
+  const body = init.body
+  if (body === null || body === undefined) {
+    return { body: null, bodyKind: "text" }
+  }
+
+  if (typeof body === "string") {
+    try {
+      JSON.parse(body)
+      return { body, bodyKind: "json" }
+    } catch {
+      return { body, bodyKind: "text" }
+    }
+  }
+
+  if (body instanceof Uint8Array) {
+    return { body: Buffer.from(body).toString("base64"), bodyKind: "binary" }
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return {
+      body: Buffer.from(new Uint8Array(body)).toString("base64"),
+      bodyKind: "binary",
+    }
+  }
+
+  return { body: null, bodyKind: "text" }
+}
+
+export async function copilotFetch(
+  input: string | URL,
+  init: RequestInit,
+  ctx: CopilotFetchCtx,
+): Promise<Response> {
+  const urlString = typeof input === "string" ? input : input.toString()
+
+  const requestSnapshot: RequestSnapshot = {
+    url: urlString,
+    method: (init.method ?? "GET").toUpperCase(),
+    headers: snapshotHeaders(init),
+    ...snapshotBody(init),
+  }
+
+  const response = await fetch(input, init)
+
+  const shouldCapture =
+    ctx.requestId !== undefined
+    && ctx.capturable !== false
+    && isCapture4xxEnabled()
+    && response.status >= 400
+    && response.status < 500
+
+  if (!shouldCapture) {
+    return response
+  }
+
+  const contentType = response.headers.get("content-type") ?? ""
+  const isSSE = contentType.includes("text/event-stream")
+  const responseHeaders: Record<string, string> = {}
+  for (const [key, value] of response.headers.entries()) {
+    responseHeaders[key] = value
+  }
+
+  if (!response.body) {
+    persist({
+      requestSnapshot,
+      status: response.status,
+      responseBody: "",
+      responseBodyKind: isSSE ? "sse" : "json",
+      responseHeaders,
+      ctx,
+    })
+    return response
+  }
+
+  const [forClient, forCapture] = response.body.tee()
+
+  void (async () => {
+    const chunks: Array<Uint8Array> = []
+    const reader =
+      forCapture.getReader() as ReadableStreamDefaultReader<Uint8Array>
+
+    try {
+      for (;;) {
+        const result = await reader.read()
+        if (result.done) {
+          break
+        }
+
+        const value = result.value
+        if (value instanceof Uint8Array) {
+          chunks.push(value)
+        }
+      }
+
+      const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
+      const text = buffer.toString("utf8")
+      let responseBodyKind: "json" | "sse" | "text" = "text"
+
+      if (isSSE) {
+        responseBodyKind = "sse"
+      } else if (contentType.includes("application/json")) {
+        responseBodyKind = "json"
+      }
+
+      persist({
+        requestSnapshot,
+        status: response.status,
+        responseBody: text,
+        responseBodyKind,
+        responseHeaders,
+        ctx,
+      })
+    } catch (error) {
+      consola.debug("copilotFetch capture stream failed", error)
+    }
+  })()
+
+  return new Response(forClient, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}
+
+type PersistInput = {
+  requestSnapshot: RequestSnapshot
+  status: number
+  responseBody: string
+  responseBodyKind: "json" | "sse" | "text"
+  responseHeaders: Record<string, string>
+  ctx: CopilotFetchCtx
+}
+
+function persist({
+  requestSnapshot,
+  status,
+  responseBody,
+  responseBodyKind,
+  responseHeaders,
+  ctx,
+}: PersistInput): void {
+  if (!ctx.requestId) {
+    return
+  }
+
+  try {
+    getRequestOutboundStore().insert({
+      requestId: ctx.requestId,
+      httpStatus: status,
+      upstreamUrl: requestSnapshot.url,
+      upstreamMethod: requestSnapshot.method,
+      requestHeaders: requestSnapshot.headers,
+      requestBody: requestSnapshot.body,
+      requestBodyKind: requestSnapshot.bodyKind,
+      responseStatus: status,
+      responseHeaders,
+      responseBody,
+      responseBodyKind,
+    })
+  } catch (error) {
+    consola.debug("copilotFetch persist failed", error)
+  }
+}

--- a/src/services/copilot/copilot-fetch.ts
+++ b/src/services/copilot/copilot-fetch.ts
@@ -13,6 +13,30 @@ export type CopilotFetchCtx = {
   callSite: string
 }
 
+const pendingCaptures = new Map<string, PersistInput>()
+const pendingCapturePromises = new Map<string, Promise<void>>()
+
+export function flushPendingCapture(requestId: string): void {
+  const pending = pendingCaptures.get(requestId)
+  if (pending) {
+    pendingCaptures.delete(requestId)
+    pendingCapturePromises.delete(requestId)
+    persistNow(pending)
+    return
+  }
+  const promise = pendingCapturePromises.get(requestId)
+  if (promise) {
+    void promise.then(() => {
+      const deferred = pendingCaptures.get(requestId)
+      if (deferred) {
+        pendingCaptures.delete(requestId)
+        persistNow(deferred)
+      }
+      pendingCapturePromises.delete(requestId)
+    })
+  }
+}
+
 type RequestSnapshot = {
   url: string
   method: string
@@ -119,7 +143,7 @@ export async function copilotFetch(
   }
 
   if (!response.body) {
-    persist({
+    storePending({
       requestSnapshot,
       status: response.status,
       responseBody: "",
@@ -132,7 +156,7 @@ export async function copilotFetch(
 
   const [forClient, forCapture] = response.body.tee()
 
-  void (async () => {
+  const capturePromise = (async () => {
     const chunks: Array<Uint8Array> = []
     const reader =
       forCapture.getReader() as ReadableStreamDefaultReader<Uint8Array>
@@ -160,7 +184,7 @@ export async function copilotFetch(
         responseBodyKind = "json"
       }
 
-      persist({
+      storePending({
         requestSnapshot,
         status: response.status,
         responseBody: text,
@@ -172,6 +196,10 @@ export async function copilotFetch(
       consola.debug("copilotFetch capture stream failed", error)
     }
   })()
+
+  if (ctx.requestId) {
+    pendingCapturePromises.set(ctx.requestId, capturePromise)
+  }
 
   return new Response(forClient, {
     status: response.status,
@@ -189,7 +217,13 @@ type PersistInput = {
   ctx: CopilotFetchCtx
 }
 
-function persist({
+function storePending(input: PersistInput): void {
+  const id = input.ctx.requestId
+  if (!id) return
+  pendingCaptures.set(id, input)
+}
+
+function persistNow({
   requestSnapshot,
   status,
   responseBody,

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -17,6 +17,8 @@ import { captureOutboundHeadersSnapshot } from "~/lib/request-context"
 import { resolveEffectiveInitiator } from "~/lib/request-initiator"
 import { accountFromState } from "~/lib/state"
 
+import { copilotFetch } from "./copilot-fetch"
+
 function isGpt5MiniFamily(modelId: string): boolean {
   return modelId === "gpt-5-mini" || modelId.startsWith("gpt-5-mini-")
 }
@@ -64,6 +66,7 @@ export const createChatCompletions = async (
     subagentMarker?: SubagentMarker | null
     sessionId?: string
     compactType?: CompactType
+    requestId?: string
   },
 ) => {
   const ctx = account ?? accountFromState()
@@ -100,11 +103,18 @@ export const createChatCompletions = async (
   prepareForCompact(headers, options?.compactType)
   captureOutboundHeadersSnapshot(headers)
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/chat/completions`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(upstreamPayload),
-  })
+  const response = await copilotFetch(
+    `${copilotBaseUrl(ctx)}/chat/completions`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(upstreamPayload),
+    },
+    {
+      requestId: options?.requestId,
+      callSite: "chat-completions",
+    },
+  )
 
   if (!response.ok) {
     consola.error("Failed to create chat completions", response)

--- a/src/services/copilot/create-embeddings.ts
+++ b/src/services/copilot/create-embeddings.ts
@@ -5,9 +5,14 @@ import { HTTPError } from "~/lib/error"
 import { captureOutboundHeadersSnapshot } from "~/lib/request-context"
 import { accountFromState } from "~/lib/state"
 
+import { copilotFetch } from "./copilot-fetch"
+
 export const createEmbeddings = async (
   payload: EmbeddingRequest,
   account?: AccountContext,
+  options?: {
+    requestId?: string
+  },
 ) => {
   const ctx = account ?? accountFromState()
   if (!ctx.copilotToken) throw new Error("Copilot token not found")
@@ -15,11 +20,19 @@ export const createEmbeddings = async (
   const headers = copilotHeaders(ctx)
   captureOutboundHeadersSnapshot(headers)
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/embeddings`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  const response = await copilotFetch(
+    `${copilotBaseUrl(ctx)}/embeddings`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+    {
+      requestId: options?.requestId,
+      callSite: "embeddings",
+      capturable: false,
+    },
+  )
 
   if (!response.ok) throw new HTTPError("Failed to create embeddings", response)
 

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -23,6 +23,8 @@ import { resolveEffectiveInitiator } from "~/lib/request-initiator"
 import { accountFromState } from "~/lib/state"
 import { parseUserIdMetadata } from "~/lib/utils"
 
+import { copilotFetch } from "./copilot-fetch"
+
 const isAgentMessage = (
   msg: AnthropicMessagesPayload["messages"][number],
 ): boolean => {
@@ -152,6 +154,7 @@ const buildMessagesHeaders = ({
         subagentMarker?: SubagentMarker | null
         sessionId?: string
         compactType?: CompactType
+        requestId?: string
       }
     | undefined
   payload: AnthropicMessagesPayload
@@ -200,6 +203,7 @@ export const createMessages = async (
     subagentMarker?: SubagentMarker | null
     sessionId?: string
     compactType?: CompactType
+    requestId?: string
   },
 ): Promise<CreateMessagesReturn> => {
   const ctx = account ?? accountFromState()
@@ -217,11 +221,18 @@ export const createMessages = async (
 
   captureOutboundHeadersSnapshot(headers)
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/v1/messages`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  const response = await copilotFetch(
+    `${copilotBaseUrl(ctx)}/v1/messages`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+    {
+      requestId: options?.requestId,
+      callSite: "messages",
+    },
+  )
 
   if (!response.ok) {
     consola.error("Failed to create messages", response)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -16,6 +16,8 @@ import { captureOutboundHeadersSnapshot } from "~/lib/request-context"
 import { resolveEffectiveInitiator } from "~/lib/request-initiator"
 import { accountFromState } from "~/lib/state"
 
+import { copilotFetch } from "./copilot-fetch"
+
 export interface ResponsesPayload {
   model: string
   instructions?: string | null
@@ -363,6 +365,7 @@ interface ResponsesRequestOptions {
   subagentMarker?: SubagentMarker | null
   sessionId?: string
   compactType?: CompactType
+  requestId?: string
 }
 
 export const createResponses = async (
@@ -374,6 +377,7 @@ export const createResponses = async (
     subagentMarker,
     sessionId,
     compactType,
+    requestId,
   }: ResponsesRequestOptions,
   account?: AccountContext,
 ): Promise<CreateResponsesReturn> => {
@@ -399,11 +403,18 @@ export const createResponses = async (
   payload.service_tier = null
   captureOutboundHeadersSnapshot(headers)
 
-  const response = await fetch(`${copilotBaseUrl(ctx)}/responses`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  const response = await copilotFetch(
+    `${copilotBaseUrl(ctx)}/responses`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+    {
+      requestId,
+      callSite: "responses",
+    },
+  )
 
   if (!response.ok) {
     consola.error("Failed to create responses", response)

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -8,11 +8,26 @@ import { HTTPError } from "~/lib/error"
 import { PATHS } from "~/lib/paths"
 import { accountFromState } from "~/lib/state"
 
-export const getModels = async (account?: AccountContext) => {
+import { copilotFetch } from "./copilot-fetch"
+
+export const getModels = async (
+  account?: AccountContext,
+  options?: {
+    requestId?: string
+  },
+) => {
   const ctx = account ?? accountFromState()
-  const response = await fetch(`${copilotBaseUrl(ctx)}/models`, {
-    headers: copilotModelsHeaders(ctx),
-  })
+  const response = await copilotFetch(
+    `${copilotBaseUrl(ctx)}/models`,
+    {
+      headers: copilotModelsHeaders(ctx),
+    },
+    {
+      requestId: options?.requestId,
+      callSite: "models",
+      capturable: false,
+    },
+  )
 
   if (!response.ok) {
     const errorText = await response.clone().text()

--- a/tests/admin-api-dev-mode.test.ts
+++ b/tests/admin-api-dev-mode.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+
+type TestConfig = Record<string, unknown>
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+
+  try {
+    await run()
+  } finally {
+    const restoreConfig =
+      original === null ?
+        fs.rm(PATHS.CONFIG_PATH, { force: true })
+      : fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    await restoreConfig
+    mergeConfigWithDefaults()
+  }
+}
+
+test("GET /api/admin/dev-mode returns disabled state by default", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const response = await server.fetch(
+      new Request("http://localhost/api/admin/dev-mode"),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      enabled: false,
+      capture4xx: false,
+    })
+  })
+})
+
+test("POST /api/admin/dev-mode updates enabled and preserves capture4xx", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const postResponse = await server.fetch(
+      new Request("http://localhost/api/admin/dev-mode", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ enabled: true }),
+      }),
+    )
+
+    expect(postResponse.status).toBe(200)
+    expect(await postResponse.json()).toEqual({
+      enabled: true,
+      capture4xx: false,
+    })
+
+    const getResponse = await server.fetch(
+      new Request("http://localhost/api/admin/dev-mode"),
+    )
+
+    expect(getResponse.status).toBe(200)
+    expect(await getResponse.json()).toEqual({
+      enabled: true,
+      capture4xx: false,
+    })
+  })
+})

--- a/tests/admin-api-dev-mode.test.ts
+++ b/tests/admin-api-dev-mode.test.ts
@@ -44,6 +44,8 @@ test("GET /api/admin/dev-mode returns disabled state by default", async () => {
     expect(await response.json()).toEqual({
       enabled: false,
       capture4xx: false,
+      capture5xx: false,
+      captureOther: false,
     })
   })
 })
@@ -66,6 +68,8 @@ test("POST /api/admin/dev-mode updates enabled and preserves capture4xx", async 
     expect(await postResponse.json()).toEqual({
       enabled: true,
       capture4xx: false,
+      capture5xx: false,
+      captureOther: false,
     })
 
     const getResponse = await server.fetch(
@@ -76,6 +80,8 @@ test("POST /api/admin/dev-mode updates enabled and preserves capture4xx", async 
     expect(await getResponse.json()).toEqual({
       enabled: true,
       capture4xx: false,
+      capture5xx: false,
+      captureOther: false,
     })
   })
 })

--- a/tests/admin-api-outbound.test.ts
+++ b/tests/admin-api-outbound.test.ts
@@ -3,29 +3,31 @@ import { Hono } from "hono"
 import fs from "node:fs/promises"
 import path from "node:path"
 
-import type { RequestLogRow } from "~/lib/request-history"
+import "./shared-admin-db-test-home"
+
 import type { OutboundCaptureRow } from "~/lib/request-outbound"
 
+import { getAdminDb } from "~/lib/admin-db"
 import { mergeConfigWithDefaults } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
+import { getRequestHistoryStore } from "~/lib/request-history"
 
 type TestConfig = Record<string, unknown>
 
 let outboundRow: OutboundCaptureRow | null = null
-let historyRow: RequestLogRow | null = null
+
+const realOutbound = await import("~/lib/request-outbound")
 
 await mock.module("~/lib/request-outbound", () => ({
+  ...realOutbound,
   getRequestOutboundStore: () => ({
+    insert: () => {},
     getByRequestId: () => outboundRow,
+    cleanupOrphans: () => {},
+    meta: () => ({ dbPath: "", userVersion: 0 }),
   }),
   getRedactedHeaderKeys: (headers: Record<string, string>) =>
     Object.keys(headers).filter((key) => key.toLowerCase() === "authorization"),
-}))
-
-await mock.module("~/lib/request-history", () => ({
-  getRequestHistoryStore: () => ({
-    getByRequestId: () => historyRow,
-  }),
 }))
 
 const { replayRoutes } = await import("../src/routes/admin-api/replay")
@@ -63,7 +65,7 @@ function createApp() {
 
 afterEach(() => {
   outboundRow = null
-  historyRow = null
+  getAdminDb().run("DELETE FROM request_log;")
 })
 
 test("GET /requests/:id/outbound returns 403 when dev mode is disabled", async () => {
@@ -127,68 +129,19 @@ test("GET /requests/:id/outbound returns blob data, redacted headers, and origin
     responseBodyKind: "json",
   }
 
-  historyRow = {
-    id: 1,
-    request_id: "req-blob",
-    started_at_ms: 1,
-    finished_at_ms: null,
+  // Insert a real request_log row so getRequestHistoryStore().getByRequestId works
+  getRequestHistoryStore().insert({
+    requestId: "req-blob",
+    startedAtMs: 1,
     method: "POST",
     path: "/v1/messages",
-    upstream_endpoint: "/v1/messages",
-    stream: 0,
-    account_id: "acc-1",
-    account_type: null,
-    cost_units: 0,
-    client_model: "claude-3-7-sonnet",
-    upstream_model: "claude-sonnet-4.5",
-    client_ip: null,
-    client_ip_source: null,
-    user_agent: null,
-    user_id: null,
-    safety_identifier: null,
-    prompt_cache_key: null,
-    initiator: null,
-    is_subagent: null,
-    upstream_request_id: null,
-    outbound_x_request_id: null,
-    outbound_x_agent_task_id: null,
-    outbound_x_interaction_type: null,
-    outbound_openai_intent: null,
-    outbound_user_agent: null,
-    affinity_key_used: null,
-    affinity_key_source: null,
-    selection_reason: null,
-    tokens_input: null,
-    tokens_output: null,
-    tokens_total: null,
-    tokens_cached_input: null,
-    usage_json: null,
-    premium_remaining_before: null,
-    premium_remaining_after: null,
-    premium_remaining_diff: null,
-    premium_unlimited_before: null,
-    premium_unlimited_after: null,
-    status: "error",
-    http_status: 400,
-    duration_ms: null,
-    ttfb_ms: null,
-    model: null,
-    provider: null,
-    service_tier: null,
-    endpoint: null,
-    error_name: null,
-    error_status: null,
-    error_message: null,
-    upstream_error_message_raw: null,
-    selection_failure_reason: null,
-    affinity_hit: null,
-    affinity_cache_key: null,
-    input_tokens: null,
-    output_tokens: null,
-    cache_creation_input_tokens: null,
-    cache_read_input_tokens: null,
-    account_label: null,
-  } as RequestLogRow
+    upstreamEndpoint: "/v1/messages",
+    stream: false,
+    accountId: "acc-1",
+    clientModel: "claude-3-7-sonnet",
+    upstreamModel: "claude-sonnet-4.5",
+    httpStatus: 400,
+  })
 
   await withConfig(
     { devMode: { enabled: true, capture4xx: false } },

--- a/tests/admin-api-outbound.test.ts
+++ b/tests/admin-api-outbound.test.ts
@@ -23,6 +23,7 @@ await mock.module("~/lib/request-outbound", () => ({
   getRequestOutboundStore: () => ({
     insert: () => {},
     getByRequestId: () => outboundRow,
+    hasOutboundForIds: () => new Set(),
     cleanupOrphans: () => {},
     meta: () => ({ dbPath: "", userVersion: 0 }),
   }),

--- a/tests/admin-api-outbound.test.ts
+++ b/tests/admin-api-outbound.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { RequestLogRow } from "~/lib/request-history"
+import type { OutboundCaptureRow } from "~/lib/request-outbound"
+
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+
+type TestConfig = Record<string, unknown>
+
+let outboundRow: OutboundCaptureRow | null = null
+let historyRow: RequestLogRow | null = null
+
+await mock.module("~/lib/request-outbound", () => ({
+  getRequestOutboundStore: () => ({
+    getByRequestId: () => outboundRow,
+  }),
+  getRedactedHeaderKeys: (headers: Record<string, string>) =>
+    Object.keys(headers).filter((key) => key.toLowerCase() === "authorization"),
+}))
+
+await mock.module("~/lib/request-history", () => ({
+  getRequestHistoryStore: () => ({
+    getByRequestId: () => historyRow,
+  }),
+}))
+
+const { replayRoutes } = await import("../src/routes/admin-api/replay")
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+
+  try {
+    await run()
+  } finally {
+    const restoreConfig =
+      original === null ?
+        fs.rm(PATHS.CONFIG_PATH, { force: true })
+      : fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    await restoreConfig
+    mergeConfigWithDefaults()
+  }
+}
+
+function createApp() {
+  const app = new Hono()
+  app.route("/", replayRoutes)
+  return app
+}
+
+afterEach(() => {
+  outboundRow = null
+  historyRow = null
+})
+
+test("GET /requests/:id/outbound returns 403 when dev mode is disabled", async () => {
+  await withConfig({}, async () => {
+    const app = createApp()
+
+    const response = await app.request(
+      "http://localhost/requests/req-disabled/outbound",
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({
+      error: {
+        message: "Developer mode disabled",
+        type: "forbidden",
+      },
+    })
+  })
+})
+
+test("GET /requests/:id/outbound returns 404 when no outbound capture exists", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      const app = createApp()
+
+      const response = await app.request(
+        "http://localhost/requests/req-missing/outbound",
+      )
+
+      expect(response.status).toBe(404)
+      expect(await response.json()).toEqual({
+        error: {
+          message: "No outbound captured for this request",
+          type: "not_found",
+        },
+      })
+    },
+  )
+})
+
+test("GET /requests/:id/outbound returns blob data, redacted headers, and original request context", async () => {
+  outboundRow = {
+    requestId: "req-blob",
+    capturedAtMs: 123456789,
+    httpStatus: 400,
+    upstreamUrl: "https://api.githubcopilot.com/v1/messages",
+    upstreamMethod: "POST",
+    requestHeaders: {
+      Authorization: "***",
+      "content-type": "application/json",
+      "x-request-id": "abc-123",
+    },
+    requestBody: '{"model":"claude-sonnet-4.5"}',
+    requestBodyKind: "json",
+    responseStatus: 400,
+    responseHeaders: {
+      "content-type": "application/json",
+    },
+    responseBody: '{"error":"bad request"}',
+    responseBodyKind: "json",
+  }
+
+  historyRow = {
+    id: 1,
+    request_id: "req-blob",
+    started_at_ms: 1,
+    finished_at_ms: null,
+    method: "POST",
+    path: "/v1/messages",
+    upstream_endpoint: "/v1/messages",
+    stream: 0,
+    account_id: "acc-1",
+    account_type: null,
+    cost_units: 0,
+    client_model: "claude-3-7-sonnet",
+    upstream_model: "claude-sonnet-4.5",
+    client_ip: null,
+    client_ip_source: null,
+    user_agent: null,
+    user_id: null,
+    safety_identifier: null,
+    prompt_cache_key: null,
+    initiator: null,
+    is_subagent: null,
+    upstream_request_id: null,
+    outbound_x_request_id: null,
+    outbound_x_agent_task_id: null,
+    outbound_x_interaction_type: null,
+    outbound_openai_intent: null,
+    outbound_user_agent: null,
+    affinity_key_used: null,
+    affinity_key_source: null,
+    selection_reason: null,
+    tokens_input: null,
+    tokens_output: null,
+    tokens_total: null,
+    tokens_cached_input: null,
+    usage_json: null,
+    premium_remaining_before: null,
+    premium_remaining_after: null,
+    premium_remaining_diff: null,
+    premium_unlimited_before: null,
+    premium_unlimited_after: null,
+    status: "error",
+    http_status: 400,
+    duration_ms: null,
+    ttfb_ms: null,
+    model: null,
+    provider: null,
+    service_tier: null,
+    endpoint: null,
+    error_name: null,
+    error_status: null,
+    error_message: null,
+    upstream_error_message_raw: null,
+    selection_failure_reason: null,
+    affinity_hit: null,
+    affinity_cache_key: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: null,
+    account_label: null,
+  } as RequestLogRow
+
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      const app = createApp()
+
+      const response = await app.request(
+        "http://localhost/requests/req-blob/outbound",
+      )
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({
+        request_id: "req-blob",
+        captured_at_ms: 123456789,
+        http_status: 400,
+        upstream_url: "https://api.githubcopilot.com/v1/messages",
+        upstream_method: "POST",
+        request_headers: {
+          Authorization: "***",
+          "content-type": "application/json",
+          "x-request-id": "abc-123",
+        },
+        request_body: '{"model":"claude-sonnet-4.5"}',
+        request_body_kind: "json",
+        response_status: 400,
+        response_headers: {
+          "content-type": "application/json",
+        },
+        response_body: '{"error":"bad request"}',
+        response_body_kind: "json",
+        redacted_header_keys: ["Authorization"],
+        original: {
+          path: "/v1/messages",
+          upstream_endpoint: "/v1/messages",
+          upstream_model: "claude-sonnet-4.5",
+          account_id: "acc-1",
+          client_model: "claude-3-7-sonnet",
+        },
+      })
+    },
+  )
+})

--- a/tests/admin-db-migrations.test.ts
+++ b/tests/admin-db-migrations.test.ts
@@ -1,0 +1,56 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+
+import { initAdminDb } from "~/lib/admin-db"
+
+function countTable(db: Database, name: string): number {
+  const row = db
+    .query(
+      `SELECT count(*) AS c FROM sqlite_master WHERE type='table' AND name=?;`,
+    )
+    .get(name) as { c: number }
+  return row.c
+}
+
+test("migrateV11 creates request_outbound with FK cascade", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  expect(countTable(db, "request_outbound")).toBe(1)
+
+  const version = (
+    db.query("PRAGMA user_version;").get() as { user_version: number }
+  ).user_version
+  expect(version).toBeGreaterThanOrEqual(11)
+
+  db.run(
+    `INSERT INTO request_log (request_id, started_at_ms, method, path, stream)
+     VALUES ('req-1', 1, 'POST', '/v1/messages', 0);`,
+  )
+  db.run(
+    `INSERT INTO request_outbound (
+       request_id, captured_at_ms, http_status,
+       upstream_url, upstream_method,
+       request_headers, request_body, request_body_kind,
+       response_status, response_headers, response_body, response_body_kind
+     ) VALUES ('req-1', 1, 400, 'https://x', 'POST', '{}', null, 'json', 400, '{}', null, 'json');`,
+  )
+
+  expect(
+    (
+      db.query("SELECT count(*) AS c FROM request_outbound;").get() as {
+        c: number
+      }
+    ).c,
+  ).toBe(1)
+
+  db.run("DELETE FROM request_log WHERE request_id = 'req-1';")
+
+  expect(
+    (
+      db.query("SELECT count(*) AS c FROM request_outbound;").get() as {
+        c: number
+      }
+    ).c,
+  ).toBe(0)
+})

--- a/tests/copilot-fetch.test.ts
+++ b/tests/copilot-fetch.test.ts
@@ -82,7 +82,8 @@ test("4xx JSON response is captured", async () => {
     }),
   )
 
-  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
+  const { copilotFetch, flushPendingCapture } =
+    await import("~/services/copilot/copilot-fetch")
 
   const response = await copilotFetch(
     "https://example.com/v1/messages",
@@ -99,6 +100,7 @@ test("4xx JSON response is captured", async () => {
 
   expect(response.status).toBe(400)
   await new Promise((resolve) => setTimeout(resolve, 50))
+  flushPendingCapture("req-4xx")
   expect(insertSpy).toHaveBeenCalledTimes(1)
   expect(insertSpy).toHaveBeenCalledWith({
     requestId: "req-4xx",
@@ -225,7 +227,8 @@ test("tee() does not corrupt the caller-facing body", async () => {
     }),
   )
 
-  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
+  const { copilotFetch, flushPendingCapture } =
+    await import("~/services/copilot/copilot-fetch")
 
   const response = await copilotFetch(
     "https://example.com/v1/messages",
@@ -242,6 +245,7 @@ test("tee() does not corrupt the caller-facing body", async () => {
   )
 
   await new Promise((resolve) => setTimeout(resolve, 50))
+  flushPendingCapture("req-tee")
   expect(insertSpy).toHaveBeenCalledTimes(1)
   expect(insertSpy).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/tests/copilot-fetch.test.ts
+++ b/tests/copilot-fetch.test.ts
@@ -4,6 +4,7 @@ import * as devMode from "~/lib/dev-mode"
 import * as outbound from "~/lib/request-outbound"
 
 const insertSpy = mock(() => {})
+const originalFetch = globalThis.fetch
 
 let devModeSpy: ReturnType<typeof spyOn<typeof devMode, "isCapture4xxEnabled">>
 let devMode5xxSpy: ReturnType<
@@ -42,6 +43,7 @@ afterEach(() => {
   devMode5xxSpy.mockRestore()
   devModeOtherSpy.mockRestore()
   outboundSpy.mockRestore()
+  globalThis.fetch = originalFetch
 })
 
 function setFetchResponse(response: Response): void {
@@ -99,8 +101,7 @@ test("4xx JSON response is captured", async () => {
   )
 
   expect(response.status).toBe(400)
-  await new Promise((resolve) => setTimeout(resolve, 50))
-  flushPendingCapture("req-4xx")
+  await flushPendingCapture("req-4xx")
   expect(insertSpy).toHaveBeenCalledTimes(1)
   expect(insertSpy).toHaveBeenCalledWith({
     requestId: "req-4xx",
@@ -244,8 +245,7 @@ test("tee() does not corrupt the caller-facing body", async () => {
     JSON.stringify({ error: "full body preserved" }),
   )
 
-  await new Promise((resolve) => setTimeout(resolve, 50))
-  flushPendingCapture("req-tee")
+  await flushPendingCapture("req-tee")
   expect(insertSpy).toHaveBeenCalledTimes(1)
   expect(insertSpy).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/tests/copilot-fetch.test.ts
+++ b/tests/copilot-fetch.test.ts
@@ -1,35 +1,35 @@
-import { afterEach, expect, mock, test } from "bun:test"
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test"
 
-let capture4xxEnabled = true
+import * as devMode from "~/lib/dev-mode"
+import * as outbound from "~/lib/request-outbound"
+
 const insertSpy = mock(() => {})
 
-const realDevMode = await import("~/lib/dev-mode")
-const realOutbound = await import("~/lib/request-outbound")
+let devModeSpy: ReturnType<typeof spyOn<typeof devMode, "isCapture4xxEnabled">>
+let outboundSpy: ReturnType<
+  typeof spyOn<typeof outbound, "getRequestOutboundStore">
+>
 
-await mock.module("~/lib/dev-mode", () => ({
-  ...realDevMode,
-  isCapture4xxEnabled: () => capture4xxEnabled,
-}))
-
-await mock.module("~/lib/request-outbound", () => ({
-  ...realOutbound,
-  getRequestOutboundStore: () => ({
+beforeEach(() => {
+  insertSpy.mockClear()
+  devModeSpy = spyOn(devMode, "isCapture4xxEnabled").mockReturnValue(true)
+  outboundSpy = spyOn(outbound, "getRequestOutboundStore").mockReturnValue({
     insert: insertSpy,
     getByRequestId: () => null,
     cleanupOrphans: () => {},
-    meta: () => ({ dbPath: "", userVersion: 0 }),
-  }),
-}))
-
-afterEach(() => {
-  capture4xxEnabled = true
-  insertSpy.mockClear()
-  mock.restore()
+    meta: () => ({
+      dbPath: "",
+      userVersion: 0,
+      retentionDays: 35,
+      maxRows: 200000,
+    }),
+  } as unknown as ReturnType<typeof outbound.getRequestOutboundStore>)
 })
 
-async function loadCopilotFetch() {
-  return import("../src/services/copilot/copilot-fetch")
-}
+afterEach(() => {
+  devModeSpy.mockRestore()
+  outboundSpy.mockRestore()
+})
 
 function setFetchResponse(response: Response): void {
   // @ts-expect-error test mock only implements fetch call signature
@@ -44,7 +44,7 @@ test("2xx response is not captured", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   const response = await copilotFetch(
     "https://example.com/v1/messages",
@@ -53,16 +53,11 @@ test("2xx response is not captured", async () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      requestId: "req-2xx",
-      callSite: "test",
-    },
+    { requestId: "req-2xx", callSite: "test" },
   )
 
   expect(response.status).toBe(200)
-
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).not.toHaveBeenCalled()
 })
 
@@ -74,7 +69,7 @@ test("4xx JSON response is captured", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   const response = await copilotFetch(
     "https://example.com/v1/messages",
@@ -86,16 +81,11 @@ test("4xx JSON response is captured", async () => {
       },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      requestId: "req-4xx",
-      callSite: "test",
-    },
+    { requestId: "req-4xx", callSite: "test" },
   )
 
   expect(response.status).toBe(400)
-
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).toHaveBeenCalledTimes(1)
   expect(insertSpy).toHaveBeenCalledWith({
     requestId: "req-4xx",
@@ -109,9 +99,7 @@ test("4xx JSON response is captured", async () => {
     requestBody: JSON.stringify({ hello: "world" }),
     requestBodyKind: "json",
     responseStatus: 400,
-    responseHeaders: {
-      "content-type": "application/json",
-    },
+    responseHeaders: { "content-type": "application/json" },
     responseBody: JSON.stringify({ error: "bad request" }),
     responseBodyKind: "json",
   })
@@ -125,7 +113,7 @@ test("5xx response is NOT captured", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   const response = await copilotFetch(
     "https://example.com/v1/messages",
@@ -134,16 +122,11 @@ test("5xx response is NOT captured", async () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      requestId: "req-5xx",
-      callSite: "test",
-    },
+    { requestId: "req-5xx", callSite: "test" },
   )
 
   expect(response.status).toBe(502)
-
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).not.toHaveBeenCalled()
 })
 
@@ -155,7 +138,7 @@ test("capturable:false disables capture for 4xx", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   await copilotFetch(
     "https://example.com/v1/messages",
@@ -164,20 +147,16 @@ test("capturable:false disables capture for 4xx", async () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      requestId: "req-no-capture",
-      capturable: false,
-      callSite: "test",
-    },
+    { requestId: "req-no-capture", capturable: false, callSite: "test" },
   )
 
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).not.toHaveBeenCalled()
 })
 
 test("capture4xx config=false disables capture", async () => {
-  capture4xxEnabled = false
+  devModeSpy.mockReturnValue(false)
+
   setFetchResponse(
     new Response(JSON.stringify({ error: "bad request" }), {
       status: 400,
@@ -185,7 +164,7 @@ test("capture4xx config=false disables capture", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   await copilotFetch(
     "https://example.com/v1/messages",
@@ -194,14 +173,10 @@ test("capture4xx config=false disables capture", async () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      requestId: "req-config-off",
-      callSite: "test",
-    },
+    { requestId: "req-config-off", callSite: "test" },
   )
 
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).not.toHaveBeenCalled()
 })
 
@@ -213,7 +188,7 @@ test("missing requestId disables capture", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   await copilotFetch(
     "https://example.com/v1/messages",
@@ -222,13 +197,10 @@ test("missing requestId disables capture", async () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      callSite: "test",
-    },
+    { callSite: "test" },
   )
 
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).not.toHaveBeenCalled()
 })
 
@@ -240,7 +212,7 @@ test("tee() does not corrupt the caller-facing body", async () => {
     }),
   )
 
-  const { copilotFetch } = await loadCopilotFetch()
+  const { copilotFetch } = await import("~/services/copilot/copilot-fetch")
 
   const response = await copilotFetch(
     "https://example.com/v1/messages",
@@ -249,10 +221,7 @@ test("tee() does not corrupt the caller-facing body", async () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hello: "world" }),
     },
-    {
-      requestId: "req-tee",
-      callSite: "test",
-    },
+    { requestId: "req-tee", callSite: "test" },
   )
 
   expect(await response.text()).toBe(
@@ -260,7 +229,6 @@ test("tee() does not corrupt the caller-facing body", async () => {
   )
 
   await new Promise((resolve) => setTimeout(resolve, 50))
-
   expect(insertSpy).toHaveBeenCalledTimes(1)
   expect(insertSpy).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/tests/copilot-fetch.test.ts
+++ b/tests/copilot-fetch.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, expect, mock, test } from "bun:test"
+
+let capture4xxEnabled = true
+const insertSpy = mock(() => {})
+
+await mock.module("~/lib/dev-mode", () => ({
+  isCapture4xxEnabled: () => capture4xxEnabled,
+}))
+
+await mock.module("~/lib/request-outbound", () => ({
+  getRequestOutboundStore: () => ({
+    insert: insertSpy,
+  }),
+}))
+
+afterEach(() => {
+  capture4xxEnabled = true
+  insertSpy.mockClear()
+  mock.restore()
+})
+
+async function loadCopilotFetch() {
+  return import("../src/services/copilot/copilot-fetch")
+}
+
+function setFetchResponse(response: Response): void {
+  // @ts-expect-error test mock only implements fetch call signature
+  globalThis.fetch = mock(() => Promise.resolve(response))
+}
+
+test("2xx response is not captured", async () => {
+  setFetchResponse(
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  const response = await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      requestId: "req-2xx",
+      callSite: "test",
+    },
+  )
+
+  expect(response.status).toBe(200)
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).not.toHaveBeenCalled()
+})
+
+test("4xx JSON response is captured", async () => {
+  setFetchResponse(
+    new Response(JSON.stringify({ error: "bad request" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  const response = await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer SECRET",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      requestId: "req-4xx",
+      callSite: "test",
+    },
+  )
+
+  expect(response.status).toBe(400)
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).toHaveBeenCalledTimes(1)
+  expect(insertSpy).toHaveBeenCalledWith({
+    requestId: "req-4xx",
+    httpStatus: 400,
+    upstreamUrl: "https://example.com/v1/messages",
+    upstreamMethod: "POST",
+    requestHeaders: {
+      authorization: "Bearer SECRET",
+      "content-type": "application/json",
+    },
+    requestBody: JSON.stringify({ hello: "world" }),
+    requestBodyKind: "json",
+    responseStatus: 400,
+    responseHeaders: {
+      "content-type": "application/json",
+    },
+    responseBody: JSON.stringify({ error: "bad request" }),
+    responseBodyKind: "json",
+  })
+})
+
+test("5xx response is NOT captured", async () => {
+  setFetchResponse(
+    new Response("bad gateway", {
+      status: 502,
+      headers: { "content-type": "text/plain" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  const response = await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      requestId: "req-5xx",
+      callSite: "test",
+    },
+  )
+
+  expect(response.status).toBe(502)
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).not.toHaveBeenCalled()
+})
+
+test("capturable:false disables capture for 4xx", async () => {
+  setFetchResponse(
+    new Response(JSON.stringify({ error: "bad request" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      requestId: "req-no-capture",
+      capturable: false,
+      callSite: "test",
+    },
+  )
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).not.toHaveBeenCalled()
+})
+
+test("capture4xx config=false disables capture", async () => {
+  capture4xxEnabled = false
+  setFetchResponse(
+    new Response(JSON.stringify({ error: "bad request" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      requestId: "req-config-off",
+      callSite: "test",
+    },
+  )
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).not.toHaveBeenCalled()
+})
+
+test("missing requestId disables capture", async () => {
+  setFetchResponse(
+    new Response(JSON.stringify({ error: "bad request" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      callSite: "test",
+    },
+  )
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).not.toHaveBeenCalled()
+})
+
+test("tee() does not corrupt the caller-facing body", async () => {
+  setFetchResponse(
+    new Response(JSON.stringify({ error: "full body preserved" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  const { copilotFetch } = await loadCopilotFetch()
+
+  const response = await copilotFetch(
+    "https://example.com/v1/messages",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    },
+    {
+      requestId: "req-tee",
+      callSite: "test",
+    },
+  )
+
+  expect(await response.text()).toBe(
+    JSON.stringify({ error: "full body preserved" }),
+  )
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(insertSpy).toHaveBeenCalledTimes(1)
+  expect(insertSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      responseBody: JSON.stringify({ error: "full body preserved" }),
+    }),
+  )
+})

--- a/tests/copilot-fetch.test.ts
+++ b/tests/copilot-fetch.test.ts
@@ -6,6 +6,12 @@ import * as outbound from "~/lib/request-outbound"
 const insertSpy = mock(() => {})
 
 let devModeSpy: ReturnType<typeof spyOn<typeof devMode, "isCapture4xxEnabled">>
+let devMode5xxSpy: ReturnType<
+  typeof spyOn<typeof devMode, "isCapture5xxEnabled">
+>
+let devModeOtherSpy: ReturnType<
+  typeof spyOn<typeof devMode, "isCaptureOtherEnabled">
+>
 let outboundSpy: ReturnType<
   typeof spyOn<typeof outbound, "getRequestOutboundStore">
 >
@@ -13,9 +19,14 @@ let outboundSpy: ReturnType<
 beforeEach(() => {
   insertSpy.mockClear()
   devModeSpy = spyOn(devMode, "isCapture4xxEnabled").mockReturnValue(true)
+  devMode5xxSpy = spyOn(devMode, "isCapture5xxEnabled").mockReturnValue(false)
+  devModeOtherSpy = spyOn(devMode, "isCaptureOtherEnabled").mockReturnValue(
+    false,
+  )
   outboundSpy = spyOn(outbound, "getRequestOutboundStore").mockReturnValue({
     insert: insertSpy,
     getByRequestId: () => null,
+    hasOutboundForIds: () => new Set(),
     cleanupOrphans: () => {},
     meta: () => ({
       dbPath: "",
@@ -28,6 +39,8 @@ beforeEach(() => {
 
 afterEach(() => {
   devModeSpy.mockRestore()
+  devMode5xxSpy.mockRestore()
+  devModeOtherSpy.mockRestore()
   outboundSpy.mockRestore()
 })
 

--- a/tests/copilot-fetch.test.ts
+++ b/tests/copilot-fetch.test.ts
@@ -3,13 +3,21 @@ import { afterEach, expect, mock, test } from "bun:test"
 let capture4xxEnabled = true
 const insertSpy = mock(() => {})
 
+const realDevMode = await import("~/lib/dev-mode")
+const realOutbound = await import("~/lib/request-outbound")
+
 await mock.module("~/lib/dev-mode", () => ({
+  ...realDevMode,
   isCapture4xxEnabled: () => capture4xxEnabled,
 }))
 
 await mock.module("~/lib/request-outbound", () => ({
+  ...realOutbound,
   getRequestOutboundStore: () => ({
     insert: insertSpy,
+    getByRequestId: () => null,
+    cleanupOrphans: () => {},
+    meta: () => ({ dbPath: "", userVersion: 0 }),
   }),
 }))
 

--- a/tests/dev-mode-config.test.ts
+++ b/tests/dev-mode-config.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, expect, spyOn, test } from "bun:test"
 
 import * as config from "~/lib/config"
-import { isCapture4xxEnabled, isDevModeEnabled } from "~/lib/dev-mode"
+import {
+  isCapture4xxEnabled,
+  isCapture5xxEnabled,
+  isCaptureOtherEnabled,
+  isDevModeEnabled,
+} from "~/lib/dev-mode"
 
 let configSpy: ReturnType<typeof spyOn<typeof config, "getConfig">> | null =
   null
@@ -23,14 +28,58 @@ test("isCapture4xxEnabled returns false when devMode is undefined", () => {
 
 test("isDevModeEnabled returns true when enabled", () => {
   configSpy = spyOn(config, "getConfig").mockReturnValue({
-    devMode: { enabled: true, capture4xx: false },
+    devMode: {
+      enabled: true,
+      capture4xx: false,
+      capture5xx: false,
+      captureOther: false,
+    },
   } as config.AppConfig)
   expect(isDevModeEnabled()).toBe(true)
 })
 
 test("isCapture4xxEnabled returns true when capture4xx is true", () => {
   configSpy = spyOn(config, "getConfig").mockReturnValue({
-    devMode: { enabled: false, capture4xx: true },
+    devMode: {
+      enabled: false,
+      capture4xx: true,
+      capture5xx: false,
+      captureOther: false,
+    },
   } as config.AppConfig)
   expect(isCapture4xxEnabled()).toBe(true)
+})
+
+test("isCapture5xxEnabled returns false when devMode is undefined", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({} as config.AppConfig)
+  expect(isCapture5xxEnabled()).toBe(false)
+})
+
+test("isCapture5xxEnabled returns true when capture5xx is true", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({
+    devMode: {
+      enabled: true,
+      capture4xx: false,
+      capture5xx: true,
+      captureOther: false,
+    },
+  } as config.AppConfig)
+  expect(isCapture5xxEnabled()).toBe(true)
+})
+
+test("isCaptureOtherEnabled returns false when devMode is undefined", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({} as config.AppConfig)
+  expect(isCaptureOtherEnabled()).toBe(false)
+})
+
+test("isCaptureOtherEnabled returns true when captureOther is true", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({
+    devMode: {
+      enabled: true,
+      capture4xx: false,
+      capture5xx: false,
+      captureOther: true,
+    },
+  } as config.AppConfig)
+  expect(isCaptureOtherEnabled()).toBe(true)
 })

--- a/tests/dev-mode-config.test.ts
+++ b/tests/dev-mode-config.test.ts
@@ -1,12 +1,36 @@
-import { expect, test } from "bun:test"
+import { afterEach, expect, spyOn, test } from "bun:test"
 
+import * as config from "~/lib/config"
 import { isCapture4xxEnabled, isDevModeEnabled } from "~/lib/dev-mode"
 
-test("isDevModeEnabled defaults to false", () => {
-  // getConfig() reads from disk; default config has devMode.enabled = false
+let configSpy: ReturnType<typeof spyOn<typeof config, "getConfig">> | null =
+  null
+
+afterEach(() => {
+  configSpy?.mockRestore()
+  configSpy = null
+})
+
+test("isDevModeEnabled returns false when devMode is undefined", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({} as config.AppConfig)
   expect(isDevModeEnabled()).toBe(false)
 })
 
-test("isCapture4xxEnabled defaults to false", () => {
+test("isCapture4xxEnabled returns false when devMode is undefined", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({} as config.AppConfig)
   expect(isCapture4xxEnabled()).toBe(false)
+})
+
+test("isDevModeEnabled returns true when enabled", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({
+    devMode: { enabled: true, capture4xx: false },
+  } as config.AppConfig)
+  expect(isDevModeEnabled()).toBe(true)
+})
+
+test("isCapture4xxEnabled returns true when capture4xx is true", () => {
+  configSpy = spyOn(config, "getConfig").mockReturnValue({
+    devMode: { enabled: false, capture4xx: true },
+  } as config.AppConfig)
+  expect(isCapture4xxEnabled()).toBe(true)
 })

--- a/tests/dev-mode-config.test.ts
+++ b/tests/dev-mode-config.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+
+import { isCapture4xxEnabled, isDevModeEnabled } from "~/lib/dev-mode"
+
+test("isDevModeEnabled defaults to false", () => {
+  // getConfig() reads from disk; default config has devMode.enabled = false
+  expect(isDevModeEnabled()).toBe(false)
+})
+
+test("isCapture4xxEnabled defaults to false", () => {
+  expect(isCapture4xxEnabled()).toBe(false)
+})

--- a/tests/outbound-redaction.test.ts
+++ b/tests/outbound-redaction.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+
+import { redactHeaders } from "~/lib/request-outbound"
+
+test("redacts authorization, token, secret, cookie, x-api-key", () => {
+  const redacted = redactHeaders({
+    Authorization: "Bearer x",
+    authorization: "Bearer y",
+    "x-github-token": "gh_z",
+    "X-Api-Key": "secret",
+    "my-custom-token": "t",
+    "my-custom-secret": "s",
+    cookie: "a=b",
+    "set-cookie": "a=b",
+    "proxy-authorization": "Basic foo",
+    "x-request-id": "keep",
+    "user-agent": "keep",
+    "content-type": "keep",
+  })
+
+  for (const key of [
+    "Authorization",
+    "authorization",
+    "x-github-token",
+    "X-Api-Key",
+    "my-custom-token",
+    "my-custom-secret",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+  ]) {
+    expect(redacted[key]).toBe("***")
+  }
+
+  expect(redacted["x-request-id"]).toBe("keep")
+  expect(redacted["user-agent"]).toBe("keep")
+  expect(redacted["content-type"]).toBe("keep")
+})

--- a/tests/replay-handler.test.ts
+++ b/tests/replay-handler.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import "./shared-admin-db-test-home"
+
+import type { OutboundCaptureRow } from "~/lib/request-outbound"
+import type { AccountContext } from "~/lib/types/account"
+
+import { getAdminDb } from "~/lib/admin-db"
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+import { getRequestHistoryStore } from "~/lib/request-history"
+
+type TestConfig = Record<string, unknown>
+
+let outboundRow: OutboundCaptureRow | null = null
+let mockAccount: AccountContext | null = null
+let lastFetchInit: RequestInit | null = null
+let mockFetchResponse: Response = new Response('{"ok":true}', {
+  status: 200,
+  headers: { "content-type": "application/json" },
+})
+
+const realOutbound = await import("~/lib/request-outbound")
+await mock.module("~/lib/request-outbound", () => ({
+  ...realOutbound,
+  getRequestOutboundStore: () => ({
+    insert: () => {},
+    getByRequestId: () => outboundRow,
+    cleanupOrphans: () => {},
+    meta: () => ({ dbPath: "", userVersion: 0 }),
+  }),
+  getRedactedHeaderKeys: (headers: Record<string, string>) =>
+    Object.keys(headers).filter((k) => k.toLowerCase() === "authorization"),
+}))
+
+const realAccountsManager = await import("~/lib/accounts-manager")
+await mock.module("~/lib/accounts-manager", () => ({
+  ...realAccountsManager,
+  accountsManager: new Proxy(realAccountsManager.accountsManager, {
+    get(target, prop) {
+      if (prop === "getAccountContextById") {
+        return (_id: string) => mockAccount
+      }
+      return Reflect.get(target, prop) as unknown
+    },
+  }),
+}))
+
+const realCopilotFetch = await import("~/services/copilot/copilot-fetch")
+await mock.module("~/services/copilot/copilot-fetch", () => ({
+  ...realCopilotFetch,
+  copilotFetch: (_url: string | URL, init: RequestInit) => {
+    lastFetchInit = init
+    return Promise.resolve(mockFetchResponse)
+  },
+}))
+
+const { replayRoutes } = await import("../src/routes/admin-api/replay")
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+  try {
+    await run()
+  } finally {
+    const restoreConfig =
+      original === null ?
+        fs.rm(PATHS.CONFIG_PATH, { force: true })
+      : fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    await restoreConfig
+    mergeConfigWithDefaults()
+  }
+}
+
+function createApp() {
+  const app = new Hono()
+  app.route("/", replayRoutes)
+  return app
+}
+
+const VALID_BLOB: OutboundCaptureRow = {
+  requestId: "req-replay",
+  capturedAtMs: 100000,
+  httpStatus: 400,
+  upstreamUrl: "https://api.githubcopilot.com/chat/completions",
+  upstreamMethod: "POST",
+  requestHeaders: {
+    Authorization: "***",
+    "content-type": "application/json",
+    "x-request-id": "abc-123",
+  },
+  requestBody: '{"model":"claude-sonnet-4.5","messages":[]}',
+  requestBodyKind: "json",
+  responseStatus: 400,
+  responseHeaders: { "content-type": "application/json" },
+  responseBody: '{"error":"bad"}',
+  responseBodyKind: "json",
+}
+
+const VALID_ACCOUNT: AccountContext = {
+  accountLogin: "test-user",
+  githubToken: "gh-token",
+  copilotToken: "copilot-token-fresh",
+  accountType: "individual",
+  vsCodeVersion: "1.90.0",
+}
+
+function insertRequestLog(requestId: string) {
+  getRequestHistoryStore().insert({
+    requestId,
+    startedAtMs: 1,
+    method: "POST",
+    path: "/v1/messages",
+    upstreamEndpoint: "/chat/completions",
+    stream: false,
+    accountId: "acc-1",
+    clientModel: "claude-3-7-sonnet",
+    upstreamModel: "claude-sonnet-4.5",
+    httpStatus: 400,
+  })
+}
+
+afterEach(() => {
+  outboundRow = null
+  mockAccount = null
+  lastFetchInit = null
+  mockFetchResponse = new Response('{"ok":true}', {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+  try {
+    getAdminDb().run("DELETE FROM request_log;")
+  } catch {
+    // ignore
+  }
+})
+
+// PLACEHOLDER_FOR_TESTS
+
+test("POST replay returns 403 when dev mode is disabled", async () => {
+  await withConfig({}, async () => {
+    const app = createApp()
+    const response = await app.request(
+      "http://localhost/requests/req-1/replay",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accountId: "acc-1" }),
+      },
+    )
+    expect(response.status).toBe(403)
+    const json = (await response.json()) as { error: { type: string } }
+    expect(json.error.type).toBe("forbidden")
+  })
+})
+
+test("POST replay returns 404 when blob is missing", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = null
+      const app = createApp()
+      const response = await app.request(
+        "http://localhost/requests/req-missing/replay",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ accountId: "acc-1" }),
+        },
+      )
+      expect(response.status).toBe(404)
+      const json = (await response.json()) as { error: { type: string } }
+      expect(json.error.type).toBe("not_found")
+    },
+  )
+})
+
+test("POST replay returns 404 when request_log is missing", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = { ...VALID_BLOB }
+      // Don't insert request_log
+      const app = createApp()
+      const response = await app.request(
+        "http://localhost/requests/req-replay/replay",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ accountId: "acc-1" }),
+        },
+      )
+      expect(response.status).toBe(404)
+    },
+  )
+})
+
+test("POST replay returns 400 when account is invalid", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = { ...VALID_BLOB }
+      insertRequestLog("req-replay")
+      mockAccount = null
+      const app = createApp()
+      const response = await app.request(
+        "http://localhost/requests/req-replay/replay",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ accountId: "bad-acc" }),
+        },
+      )
+      expect(response.status).toBe(400)
+      const json = (await response.json()) as { error: { type: string } }
+      expect(json.error.type).toBe("bad_request")
+    },
+  )
+})
+
+test("POST replay returns 400 when body override is invalid JSON for json kind", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = { ...VALID_BLOB }
+      insertRequestLog("req-replay")
+      mockAccount = { ...VALID_ACCOUNT }
+      const app = createApp()
+      const response = await app.request(
+        "http://localhost/requests/req-replay/replay",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ accountId: "acc-1", body: "not{json" }),
+        },
+      )
+      expect(response.status).toBe(400)
+      const json = (await response.json()) as {
+        error: { message: string; type: string }
+      }
+      expect(json.error.type).toBe("bad_request")
+      expect(json.error.message).toContain("not valid JSON")
+    },
+  )
+})
+
+test("POST replay collect mode returns upstream response with raw body and durationMs", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = { ...VALID_BLOB }
+      insertRequestLog("req-replay")
+      mockAccount = { ...VALID_ACCOUNT }
+      mockFetchResponse = new Response(
+        '{"error":"bad request from upstream"}',
+        {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { "content-type": "application/json" },
+        },
+      )
+      const app = createApp()
+      const response = await app.request(
+        "http://localhost/requests/req-replay/replay",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ accountId: "acc-1", mode: "collect" }),
+        },
+      )
+      expect(response.status).toBe(200)
+      const json = (await response.json()) as {
+        status: number
+        raw: { body: string; kind: string }
+        durationMs: number
+        replayedAt: number
+      }
+      expect(json.status).toBe(400)
+      expect(json.raw.body).toBe('{"error":"bad request from upstream"}')
+      expect(json.raw.kind).toBe("json")
+      expect(typeof json.durationMs).toBe("number")
+      expect(typeof json.replayedAt).toBe("number")
+    },
+  )
+})
+
+test("POST replay outgoing headers do NOT contain *** values", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = {
+        ...VALID_BLOB,
+        requestHeaders: {
+          Authorization: "***",
+          "x-github-token": "***",
+          "content-type": "application/json",
+          "x-custom": "keep-me",
+        },
+      }
+      insertRequestLog("req-replay")
+      mockAccount = { ...VALID_ACCOUNT }
+      const app = createApp()
+      await app.request("http://localhost/requests/req-replay/replay", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accountId: "acc-1" }),
+      })
+      expect(lastFetchInit).not.toBeNull()
+      const sentHeaders = (lastFetchInit ?? {}).headers as Record<
+        string,
+        string
+      >
+      const starValues = Object.entries(sentHeaders).filter(
+        ([, v]) => v === "***",
+      )
+      expect(starValues).toHaveLength(0)
+      // Auth header should be injected fresh
+      expect(
+        sentHeaders["Authorization"] ?? sentHeaders["authorization"],
+      ).toBeTruthy()
+      // Custom header should be preserved
+      expect(sentHeaders["x-custom"]).toBe("keep-me")
+    },
+  )
+})

--- a/tests/replay-handler.test.ts
+++ b/tests/replay-handler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, mock, test } from "bun:test"
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test"
 import { Hono } from "hono"
 import fs from "node:fs/promises"
 import path from "node:path"
@@ -8,10 +8,15 @@ import "./shared-admin-db-test-home"
 import type { OutboundCaptureRow } from "~/lib/request-outbound"
 import type { AccountContext } from "~/lib/types/account"
 
+import * as accountsMod from "~/lib/accounts-manager"
 import { getAdminDb } from "~/lib/admin-db"
 import { mergeConfigWithDefaults } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
 import { getRequestHistoryStore } from "~/lib/request-history"
+import * as outboundMod from "~/lib/request-outbound"
+import * as copilotFetchMod from "~/services/copilot/copilot-fetch"
+
+import { replayRoutes } from "../src/routes/admin-api/replay"
 
 type TestConfig = Record<string, unknown>
 
@@ -23,42 +28,50 @@ let mockFetchResponse: Response = new Response('{"ok":true}', {
   headers: { "content-type": "application/json" },
 })
 
-const realOutbound = await import("~/lib/request-outbound")
-await mock.module("~/lib/request-outbound", () => ({
-  ...realOutbound,
-  getRequestOutboundStore: () => ({
-    insert: () => {},
-    getByRequestId: () => outboundRow,
-    cleanupOrphans: () => {},
-    meta: () => ({ dbPath: "", userVersion: 0 }),
-  }),
-  getRedactedHeaderKeys: (headers: Record<string, string>) =>
-    Object.keys(headers).filter((k) => k.toLowerCase() === "authorization"),
-}))
+beforeEach(() => {
+  spyOn(outboundMod, "getRequestOutboundStore").mockImplementation(
+    () =>
+      ({
+        insert: () => {},
+        getByRequestId: () => outboundRow,
+        cleanupOrphans: () => {},
+        meta: () => ({ dbPath: "", userVersion: 0 }),
+      }) as ReturnType<typeof outboundMod.getRequestOutboundStore>,
+  )
 
-const realAccountsManager = await import("~/lib/accounts-manager")
-await mock.module("~/lib/accounts-manager", () => ({
-  ...realAccountsManager,
-  accountsManager: new Proxy(realAccountsManager.accountsManager, {
-    get(target, prop) {
-      if (prop === "getAccountContextById") {
-        return (_id: string) => mockAccount
-      }
-      return Reflect.get(target, prop) as unknown
+  spyOn(outboundMod, "getRedactedHeaderKeys").mockImplementation(
+    (headers: Record<string, string>) =>
+      Object.keys(headers).filter((k) => k.toLowerCase() === "authorization"),
+  )
+
+  spyOn(
+    accountsMod.accountsManager,
+    "getAccountContextById",
+  ).mockImplementation((_id: string) => mockAccount)
+
+  spyOn(copilotFetchMod, "copilotFetch").mockImplementation(
+    (_url: string | URL, init: RequestInit) => {
+      lastFetchInit = init
+      return Promise.resolve(mockFetchResponse)
     },
-  }),
-}))
+  )
+})
 
-const realCopilotFetch = await import("~/services/copilot/copilot-fetch")
-await mock.module("~/services/copilot/copilot-fetch", () => ({
-  ...realCopilotFetch,
-  copilotFetch: (_url: string | URL, init: RequestInit) => {
-    lastFetchInit = init
-    return Promise.resolve(mockFetchResponse)
-  },
-}))
-
-const { replayRoutes } = await import("../src/routes/admin-api/replay")
+afterEach(() => {
+  mock.restore()
+  outboundRow = null
+  mockAccount = null
+  lastFetchInit = null
+  mockFetchResponse = new Response('{"ok":true}', {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+  try {
+    getAdminDb().run("DELETE FROM request_log;")
+  } catch {
+    // ignore
+  }
+})
 
 const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
   const original = await fs
@@ -74,11 +87,11 @@ const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
   try {
     await run()
   } finally {
-    const restoreConfig =
+    const rc =
       original === null ?
         fs.rm(PATHS.CONFIG_PATH, { force: true })
       : fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
-    await restoreConfig
+    await rc
     mergeConfigWithDefaults()
   }
 }
@@ -131,23 +144,6 @@ function insertRequestLog(requestId: string) {
   })
 }
 
-afterEach(() => {
-  outboundRow = null
-  mockAccount = null
-  lastFetchInit = null
-  mockFetchResponse = new Response('{"ok":true}', {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  })
-  try {
-    getAdminDb().run("DELETE FROM request_log;")
-  } catch {
-    // ignore
-  }
-})
-
-// PLACEHOLDER_FOR_TESTS
-
 test("POST replay returns 403 when dev mode is disabled", async () => {
   await withConfig({}, async () => {
     const app = createApp()
@@ -191,7 +187,6 @@ test("POST replay returns 404 when request_log is missing", async () => {
     { devMode: { enabled: true, capture4xx: false } },
     async () => {
       outboundRow = { ...VALID_BLOB }
-      // Don't insert request_log
       const app = createApp()
       const response = await app.request(
         "http://localhost/requests/req-replay/replay",
@@ -325,11 +320,9 @@ test("POST replay outgoing headers do NOT contain *** values", async () => {
         ([, v]) => v === "***",
       )
       expect(starValues).toHaveLength(0)
-      // Auth header should be injected fresh
       expect(
         sentHeaders["Authorization"] ?? sentHeaders["authorization"],
       ).toBeTruthy()
-      // Custom header should be preserved
       expect(sentHeaders["x-custom"]).toBe("keep-me")
     },
   )

--- a/tests/replay-handler.test.ts
+++ b/tests/replay-handler.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
       ({
         insert: () => {},
         getByRequestId: () => outboundRow,
+        hasOutboundForIds: () => new Set(),
         cleanupOrphans: () => {},
         meta: () => ({ dbPath: "", userVersion: 0 }),
       }) as ReturnType<typeof outboundMod.getRequestOutboundStore>,

--- a/tests/replay-stream.test.ts
+++ b/tests/replay-stream.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import "./shared-admin-db-test-home"
+
+import type { OutboundCaptureRow } from "~/lib/request-outbound"
+import type { AccountContext } from "~/lib/types/account"
+
+import { getAdminDb } from "~/lib/admin-db"
+import { mergeConfigWithDefaults } from "~/lib/config"
+import { PATHS } from "~/lib/paths"
+import { getRequestHistoryStore } from "~/lib/request-history"
+
+type TestConfig = Record<string, unknown>
+
+type SseEvent = {
+  event?: string
+  data: string
+}
+
+let outboundRow: OutboundCaptureRow | null = null
+let mockAccount: AccountContext | null = null
+let mockFetchResponse: Response = new Response('{"ok":true}', {
+  status: 200,
+  headers: { "content-type": "application/json" },
+})
+
+const realOutbound = await import("~/lib/request-outbound")
+await mock.module("~/lib/request-outbound", () => ({
+  ...realOutbound,
+  getRequestOutboundStore: () => ({
+    insert: () => {},
+    getByRequestId: () => outboundRow,
+    cleanupOrphans: () => {},
+    meta: () => ({ dbPath: "", userVersion: 0 }),
+  }),
+  getRedactedHeaderKeys: (headers: Record<string, string>) =>
+    Object.keys(headers).filter((k) => k.toLowerCase() === "authorization"),
+}))
+
+const realAccountsManager = await import("~/lib/accounts-manager")
+await mock.module("~/lib/accounts-manager", () => ({
+  ...realAccountsManager,
+  accountsManager: new Proxy(realAccountsManager.accountsManager, {
+    get(target, prop) {
+      if (prop === "getAccountContextById") {
+        return (_id: string) => mockAccount
+      }
+      return Reflect.get(target, prop) as unknown
+    },
+  }),
+}))
+
+const realCopilotFetch = await import("~/services/copilot/copilot-fetch")
+await mock.module("~/services/copilot/copilot-fetch", () => ({
+  ...realCopilotFetch,
+  copilotFetch: () => Promise.resolve(mockFetchResponse),
+}))
+
+const { replayRoutes } = await import("../src/routes/admin-api/replay")
+
+const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
+  const original = await fs
+    .readFile(PATHS.CONFIG_PATH, "utf8")
+    .catch(() => null)
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+  try {
+    await run()
+  } finally {
+    const restoreConfig =
+      original === null ?
+        fs.rm(PATHS.CONFIG_PATH, { force: true })
+      : fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
+    await restoreConfig
+    mergeConfigWithDefaults()
+  }
+}
+
+function createApp() {
+  const app = new Hono()
+  app.route("/", replayRoutes)
+  return app
+}
+
+function parseSse(body: string): Array<SseEvent> {
+  const blocks = body
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+
+  return blocks.map((block) => {
+    const lines = block.split("\n")
+    let event: string | undefined
+    const dataLines: Array<string> = []
+
+    for (const line of lines) {
+      if (line.startsWith("event:")) {
+        event = line.slice("event:".length).trim() || undefined
+        continue
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice("data:".length).trim())
+      }
+    }
+
+    return {
+      event,
+      data: dataLines.join("\n"),
+    }
+  })
+}
+
+function createStreamingResponse(chunks: Array<string>): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(new TextEncoder().encode(chunk))
+        }
+        controller.close()
+      },
+    }),
+    {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "text/event-stream",
+        "x-upstream-test": "yes",
+      },
+    },
+  )
+}
+
+const VALID_BLOB: OutboundCaptureRow = {
+  requestId: "req-replay-stream",
+  capturedAtMs: 100000,
+  httpStatus: 400,
+  upstreamUrl: "https://api.githubcopilot.com/chat/completions",
+  upstreamMethod: "POST",
+  requestHeaders: {
+    Authorization: "***",
+    "content-type": "application/json",
+    "x-request-id": "abc-123",
+  },
+  requestBody: '{"model":"claude-sonnet-4.5","messages":[]}',
+  requestBodyKind: "json",
+  responseStatus: 400,
+  responseHeaders: { "content-type": "application/json" },
+  responseBody: '{"error":"bad"}',
+  responseBodyKind: "json",
+}
+
+const VALID_ACCOUNT: AccountContext = {
+  accountLogin: "test-user",
+  githubToken: "gh-token",
+  copilotToken: "copilot-token-fresh",
+  accountType: "individual",
+  vsCodeVersion: "1.90.0",
+}
+
+function insertRequestLog(requestId: string) {
+  getRequestHistoryStore().insert({
+    requestId,
+    startedAtMs: 1,
+    method: "POST",
+    path: "/v1/messages",
+    upstreamEndpoint: "/chat/completions",
+    stream: true,
+    accountId: "acc-1",
+    clientModel: "claude-3-7-sonnet",
+    upstreamModel: "claude-sonnet-4.5",
+    httpStatus: 200,
+  })
+}
+
+afterEach(() => {
+  outboundRow = null
+  mockAccount = null
+  mockFetchResponse = new Response('{"ok":true}', {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+  try {
+    getAdminDb().run("DELETE FROM request_log;")
+  } catch {
+    // ignore
+  }
+})
+
+test("POST replay live mode streams upstream SSE lifecycle events", async () => {
+  await withConfig(
+    { devMode: { enabled: true, capture4xx: false } },
+    async () => {
+      outboundRow = { ...VALID_BLOB }
+      insertRequestLog("req-replay-stream")
+      mockAccount = { ...VALID_ACCOUNT }
+      mockFetchResponse = createStreamingResponse([
+        'data: {"type":"delta-1"}\n\n',
+        'data: {"type":"delta-2"}\n\n',
+      ])
+
+      const app = createApp()
+      const response = await app.request(
+        "http://localhost/requests/req-replay-stream/replay",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ accountId: "acc-1", mode: "live" }),
+        },
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get("content-type")).toContain(
+        "text/event-stream",
+      )
+
+      const events = parseSse(await response.text())
+      const eventNames = events.map((event) => event.event)
+      const startIndex = eventNames.indexOf("upstream-start")
+      const firstChunkIndex = eventNames.indexOf("upstream-chunk")
+      const doneIndex = eventNames.indexOf("upstream-done")
+
+      expect(startIndex).toBeGreaterThanOrEqual(0)
+      expect(firstChunkIndex).toBeGreaterThan(startIndex)
+      expect(doneIndex).toBeGreaterThan(firstChunkIndex)
+
+      const startEvent = events[startIndex]
+      const startData = JSON.parse(startEvent.data) as {
+        status: number
+        headers: Record<string, string>
+      }
+      expect(startData.status).toBe(200)
+      expect(startData.headers["content-type"]).toBe("text/event-stream")
+      expect(startData.headers["x-upstream-test"]).toBe("yes")
+
+      const chunkEvents = events.filter(
+        (event) => event.event === "upstream-chunk",
+      )
+      expect(chunkEvents.length).toBeGreaterThanOrEqual(1)
+      expect(JSON.parse(chunkEvents[0].data)).toHaveProperty("raw")
+
+      const doneEvent = events[doneIndex]
+      const doneData = JSON.parse(doneEvent.data) as {
+        durationMs: number
+      }
+      expect(typeof doneData.durationMs).toBe("number")
+      expect(doneData.durationMs).toBeGreaterThanOrEqual(0)
+    },
+  )
+})

--- a/tests/replay-stream.test.ts
+++ b/tests/replay-stream.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, mock, test } from "bun:test"
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test"
 import { Hono } from "hono"
 import fs from "node:fs/promises"
 import path from "node:path"
@@ -8,17 +8,18 @@ import "./shared-admin-db-test-home"
 import type { OutboundCaptureRow } from "~/lib/request-outbound"
 import type { AccountContext } from "~/lib/types/account"
 
+import * as accountsMod from "~/lib/accounts-manager"
 import { getAdminDb } from "~/lib/admin-db"
 import { mergeConfigWithDefaults } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
 import { getRequestHistoryStore } from "~/lib/request-history"
+import * as outboundMod from "~/lib/request-outbound"
+import * as copilotFetchMod from "~/services/copilot/copilot-fetch"
+
+import { replayRoutes } from "../src/routes/admin-api/replay"
 
 type TestConfig = Record<string, unknown>
-
-type SseEvent = {
-  event?: string
-  data: string
-}
+type SseEvent = { event?: string; data: string }
 
 let outboundRow: OutboundCaptureRow | null = null
 let mockAccount: AccountContext | null = null
@@ -27,39 +28,46 @@ let mockFetchResponse: Response = new Response('{"ok":true}', {
   headers: { "content-type": "application/json" },
 })
 
-const realOutbound = await import("~/lib/request-outbound")
-await mock.module("~/lib/request-outbound", () => ({
-  ...realOutbound,
-  getRequestOutboundStore: () => ({
-    insert: () => {},
-    getByRequestId: () => outboundRow,
-    cleanupOrphans: () => {},
-    meta: () => ({ dbPath: "", userVersion: 0 }),
-  }),
-  getRedactedHeaderKeys: (headers: Record<string, string>) =>
-    Object.keys(headers).filter((k) => k.toLowerCase() === "authorization"),
-}))
+beforeEach(() => {
+  spyOn(outboundMod, "getRequestOutboundStore").mockImplementation(
+    () =>
+      ({
+        insert: () => {},
+        getByRequestId: () => outboundRow,
+        cleanupOrphans: () => {},
+        meta: () => ({ dbPath: "", userVersion: 0 }),
+      }) as ReturnType<typeof outboundMod.getRequestOutboundStore>,
+  )
 
-const realAccountsManager = await import("~/lib/accounts-manager")
-await mock.module("~/lib/accounts-manager", () => ({
-  ...realAccountsManager,
-  accountsManager: new Proxy(realAccountsManager.accountsManager, {
-    get(target, prop) {
-      if (prop === "getAccountContextById") {
-        return (_id: string) => mockAccount
-      }
-      return Reflect.get(target, prop) as unknown
-    },
-  }),
-}))
+  spyOn(outboundMod, "getRedactedHeaderKeys").mockImplementation(
+    (headers: Record<string, string>) =>
+      Object.keys(headers).filter((k) => k.toLowerCase() === "authorization"),
+  )
 
-const realCopilotFetch = await import("~/services/copilot/copilot-fetch")
-await mock.module("~/services/copilot/copilot-fetch", () => ({
-  ...realCopilotFetch,
-  copilotFetch: () => Promise.resolve(mockFetchResponse),
-}))
+  spyOn(
+    accountsMod.accountsManager,
+    "getAccountContextById",
+  ).mockImplementation((_id: string) => mockAccount)
 
-const { replayRoutes } = await import("../src/routes/admin-api/replay")
+  spyOn(copilotFetchMod, "copilotFetch").mockImplementation(() =>
+    Promise.resolve(mockFetchResponse),
+  )
+})
+
+afterEach(() => {
+  mock.restore()
+  outboundRow = null
+  mockAccount = null
+  mockFetchResponse = new Response('{"ok":true}', {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+  try {
+    getAdminDb().run("DELETE FROM request_log;")
+  } catch {
+    // ignore
+  }
+})
 
 const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
   const original = await fs
@@ -75,11 +83,11 @@ const withConfig = async (config: TestConfig, run: () => Promise<void>) => {
   try {
     await run()
   } finally {
-    const restoreConfig =
+    const rc =
       original === null ?
         fs.rm(PATHS.CONFIG_PATH, { force: true })
       : fs.writeFile(PATHS.CONFIG_PATH, original, "utf8")
-    await restoreConfig
+    await rc
     mergeConfigWithDefaults()
   }
 }
@@ -93,28 +101,20 @@ function createApp() {
 function parseSse(body: string): Array<SseEvent> {
   const blocks = body
     .split("\n\n")
-    .map((block) => block.trim())
-    .filter((block) => block.length > 0)
-
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0)
   return blocks.map((block) => {
     const lines = block.split("\n")
     let event: string | undefined
     const dataLines: Array<string> = []
-
     for (const line of lines) {
       if (line.startsWith("event:")) {
         event = line.slice("event:".length).trim() || undefined
-        continue
-      }
-      if (line.startsWith("data:")) {
+      } else if (line.startsWith("data:")) {
         dataLines.push(line.slice("data:".length).trim())
       }
     }
-
-    return {
-      event,
-      data: dataLines.join("\n"),
-    }
+    return { event, data: dataLines.join("\n") }
   })
 }
 
@@ -181,20 +181,6 @@ function insertRequestLog(requestId: string) {
   })
 }
 
-afterEach(() => {
-  outboundRow = null
-  mockAccount = null
-  mockFetchResponse = new Response('{"ok":true}', {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  })
-  try {
-    getAdminDb().run("DELETE FROM request_log;")
-  } catch {
-    // ignore
-  }
-})
-
 test("POST replay live mode streams upstream SSE lifecycle events", async () => {
   await withConfig(
     { devMode: { enabled: true, capture4xx: false } },
@@ -223,17 +209,16 @@ test("POST replay live mode streams upstream SSE lifecycle events", async () => 
       )
 
       const events = parseSse(await response.text())
-      const eventNames = events.map((event) => event.event)
-      const startIndex = eventNames.indexOf("upstream-start")
-      const firstChunkIndex = eventNames.indexOf("upstream-chunk")
-      const doneIndex = eventNames.indexOf("upstream-done")
+      const eventNames = events.map((e) => e.event)
+      const startIdx = eventNames.indexOf("upstream-start")
+      const chunkIdx = eventNames.indexOf("upstream-chunk")
+      const doneIdx = eventNames.indexOf("upstream-done")
 
-      expect(startIndex).toBeGreaterThanOrEqual(0)
-      expect(firstChunkIndex).toBeGreaterThan(startIndex)
-      expect(doneIndex).toBeGreaterThan(firstChunkIndex)
+      expect(startIdx).toBeGreaterThanOrEqual(0)
+      expect(chunkIdx).toBeGreaterThan(startIdx)
+      expect(doneIdx).toBeGreaterThan(chunkIdx)
 
-      const startEvent = events[startIndex]
-      const startData = JSON.parse(startEvent.data) as {
+      const startData = JSON.parse(events[startIdx].data) as {
         status: number
         headers: Record<string, string>
       }
@@ -241,14 +226,11 @@ test("POST replay live mode streams upstream SSE lifecycle events", async () => 
       expect(startData.headers["content-type"]).toBe("text/event-stream")
       expect(startData.headers["x-upstream-test"]).toBe("yes")
 
-      const chunkEvents = events.filter(
-        (event) => event.event === "upstream-chunk",
-      )
+      const chunkEvents = events.filter((e) => e.event === "upstream-chunk")
       expect(chunkEvents.length).toBeGreaterThanOrEqual(1)
       expect(JSON.parse(chunkEvents[0].data)).toHaveProperty("raw")
 
-      const doneEvent = events[doneIndex]
-      const doneData = JSON.parse(doneEvent.data) as {
+      const doneData = JSON.parse(events[doneIdx].data) as {
         durationMs: number
       }
       expect(typeof doneData.durationMs).toBe("number")

--- a/tests/replay-stream.test.ts
+++ b/tests/replay-stream.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
       ({
         insert: () => {},
         getByRequestId: () => outboundRow,
+        hasOutboundForIds: () => new Set(),
         cleanupOrphans: () => {},
         meta: () => ({ dbPath: "", userVersion: 0 }),
       }) as ReturnType<typeof outboundMod.getRequestOutboundStore>,

--- a/tests/request-outbound-store.test.ts
+++ b/tests/request-outbound-store.test.ts
@@ -1,0 +1,84 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+
+import { initAdminDb } from "~/lib/admin-db"
+import {
+  createRequestOutboundStore,
+  type OutboundCaptureInput,
+} from "~/lib/request-outbound"
+
+function seedLog(db: Database, requestId: string): void {
+  db.run(
+    `INSERT INTO request_log (request_id, started_at_ms, method, path, stream)
+     VALUES (?, 1, 'POST', '/v1/messages', 0);`,
+    [requestId],
+  )
+}
+
+function makeInput(
+  overrides: Partial<OutboundCaptureInput>,
+): OutboundCaptureInput {
+  return {
+    requestId: "req-1",
+    httpStatus: 400,
+    upstreamUrl: "https://api.githubcopilot.com/v1/messages",
+    upstreamMethod: "POST",
+    requestHeaders: {
+      Authorization: "Bearer REAL_TOKEN",
+      "x-request-id": "abc",
+    },
+    requestBody: '{"model":"x"}',
+    requestBodyKind: "json",
+    responseStatus: 400,
+    responseHeaders: { "content-type": "application/json" },
+    responseBody: '{"error":"bad request"}',
+    responseBodyKind: "json",
+    ...overrides,
+  }
+}
+
+test("insert + getByRequestId round-trips and redacts Authorization", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  seedLog(db, "req-1")
+
+  const store = createRequestOutboundStore(db)
+  store.insert(makeInput({}))
+
+  const row = store.getByRequestId("req-1")
+  expect(row).not.toBeNull()
+
+  if (!row) {
+    throw new Error("expected outbound row")
+  }
+
+  expect(row.requestHeaders["Authorization"]).toBe("***")
+  expect(row.requestHeaders["x-request-id"]).toBe("abc")
+  expect(row.requestBody).toBe('{"model":"x"}')
+  expect(row.responseStatus).toBe(400)
+})
+
+test("cleanupOrphans removes rows whose request_log entry is gone", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  seedLog(db, "req-orphan")
+
+  const store = createRequestOutboundStore(db)
+  store.insert(makeInput({ requestId: "req-orphan" }))
+
+  db.run("PRAGMA foreign_keys = OFF;")
+  db.run("DELETE FROM request_log WHERE request_id = 'req-orphan';")
+  db.run("PRAGMA foreign_keys = ON;")
+
+  expect(store.getByRequestId("req-orphan")).not.toBeNull()
+  store.cleanupOrphans()
+  expect(store.getByRequestId("req-orphan")).toBeNull()
+})
+
+test("getByRequestId returns null when missing", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  const store = createRequestOutboundStore(db)
+  expect(store.getByRequestId("does-not-exist")).toBeNull()
+})


### PR DESCRIPTION
## Summary

- Admin-UI 新增"开发者模式"，支持对历史 4xx 上游请求进行可交互重放调试
- 新增 `copilotFetch` 统一上游调用 helper，在 4xx 条件下自动捕获完整出站包体到 `request_outbound` blob 表
- 新增三组 Admin API 端点：`/dev-mode`（开关）、`/requests/:id/outbound`（读取 blob）、`/requests/:id/replay`（执行重放，支持 collect + live SSE）
- Admin-UI 新增独立 Replay 页面（`/requests/:id/replay`），包含账号选择、Header 编辑器、Body 编辑器（JSON/text/binary）、响应双视图（Raw / Translated / Headers）
- 重放为纯旁路：不写 request_log、不影响 premium 统计、不写 session affinity
- `devMode.enabled` 作为后端硬门闩，默认关闭；`devMode.capture4xx` 控制捕获，默认关闭
- 敏感头（Authorization / token 类）写入时自动脱敏为 `***`，重放时由后端按所选账号重新注入

## Test plan

- [x] `bun test` — 413 pass, 0 fail
- [x] `bun run lint` — pass
- [x] `bun run typecheck` — pass
- [x] `bun run build` — pass
- [ ] 手测：Settings 页开启 Developer Mode + Capture 4xx
- [ ] 手测：触发一次 4xx 上游错误，确认 request_outbound 表有记录
- [ ] 手测：请求详情页出现 Replay 按钮，进入 Replay 页
- [ ] 手测：修改 body / 业务头 → Send (collect) → 查看 Raw + Translated 响应
- [ ] 手测：切换 Live 模式 → Send → 增量 chunk 显示
- [ ] 手测：切换账号 → Send → 确认 Authorization 为新账号 token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增“请求重放”页面（/requests/:id/replay）：可选择目标账号、编辑请求体与业务头，支持 Collect 与 Live（SSE）两种重放模式并展示上游 Raw/Translated/Headers 视图。
  * 设置页新增“开发者模式”开关与捕获策略（可单独控制捕获 4xx/5xx/其他）。

* **文档**
  * 添加开发者模式与请求重放使用指南与故障排查说明。

* **测试**
  * 增加覆盖开发者模式、捕获、存储与重放（包括 SSE 流）相关的自动化测试。

* **本地化**
  * 完成中/英文界面文案更新，包含重放流程与设置文本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->