### PR TITLE
fix stale responses affinity after ownership mismatch

### DIFF
--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1202,6 +1202,15 @@ export class AccountsManager {
     return result
   }
 
+  invalidateAffinity(cacheKey: string): void {
+    const normalizedCacheKey = cacheKey.trim()
+    if (!normalizedCacheKey) {
+      return
+    }
+
+    this.affinityCache.delete(normalizedCacheKey)
+  }
+
   private attachConfirmOwnership(
     result: SelectAccountForRequestSuccess,
     ownershipWriteSessionId: string | undefined,

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -923,6 +923,15 @@ async function streamChatCompletionsAndLog(params: {
   }
 }
 
+function invalidateAffinityOnOwnershipMismatch(
+  ownershipMismatch: boolean,
+  instr: Pick<InstrumentationContext, "affinityHit" | "affinityCacheKey">,
+): void {
+  if (ownershipMismatch && instr.affinityHit && instr.affinityCacheKey) {
+    accountsManager.invalidateAffinity(instr.affinityCacheKey)
+  }
+}
+
 async function handleResponsesCreateError(params: {
   error: unknown
   instr: InstrumentationContext
@@ -932,6 +941,8 @@ async function handleResponsesCreateError(params: {
 
   const finishedAtMs = Date.now()
   const details = await extractErrorObservability(error)
+
+  invalidateAffinityOnOwnershipMismatch(details.ownershipMismatch, instr)
 
   if (shouldMarkAccountFailed(details)) {
     accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")
@@ -1146,6 +1157,8 @@ async function streamResponsesAndLog(params: {
     upstreamErrorMessageRaw = details.upstreamErrorMessageRaw
 
     logger.warn("Streaming error:", error)
+
+    invalidateAffinityOnOwnershipMismatch(details.ownershipMismatch, instr)
 
     if (shouldMarkAccountFailed(details)) {
       accountsManager.markAccountFailed(instr.account.id, "Unauthorized (401)")

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -258,8 +258,17 @@ type StreamSseStream = Parameters<Parameters<typeof streamSSE>[1]>[0]
 async function observeRequestError(
   accountId: string,
   error: unknown,
+  affinity?: { affinityHit?: boolean; affinityCacheKey?: string },
 ): Promise<ObservedErrorState> {
   const details = await extractErrorObservability(error)
+
+  if (
+    details.ownershipMismatch
+    && affinity?.affinityHit
+    && affinity.affinityCacheKey
+  ) {
+    accountsManager.invalidateAffinity(affinity.affinityCacheKey)
+  }
 
   if (shouldMarkAccountFailed(details)) {
     accountsManager.markAccountFailed(accountId, "Unauthorized (401)")
@@ -537,6 +546,14 @@ async function handleUpstreamCreateError(params: {
   const finishedAtMs = Date.now()
   const details = await extractErrorObservability(error)
 
+  if (
+    details.ownershipMismatch
+    && request.affinityHit
+    && request.affinityCacheKey
+  ) {
+    accountsManager.invalidateAffinity(request.affinityCacheKey)
+  }
+
   if (shouldMarkAccountFailed(details)) {
     accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
   }
@@ -718,6 +735,14 @@ async function streamResponsesAndLog(params: {
 
     logger.warn("Responses streaming error:", error)
 
+    if (
+      details.ownershipMismatch
+      && request.affinityHit
+      && request.affinityCacheKey
+    ) {
+      accountsManager.invalidateAffinity(request.affinityCacheKey)
+    }
+
     if (shouldMarkAccountFailed(details)) {
       accountsManager.markAccountFailed(account.id, "Unauthorized (401)")
     }
@@ -816,7 +841,10 @@ async function handleNonStreamingResponses(params: {
     return c.json(result)
   } catch (error) {
     finishedAtMs = Date.now()
-    errorState = await observeRequestError(account.id, error)
+    errorState = await observeRequestError(account.id, error, {
+      affinityHit: request.affinityHit,
+      affinityCacheKey: request.affinityCacheKey,
+    })
     throw error
   } finally {
     const finishedAtMsFinal = finishedAtMs ?? Date.now()

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -5,6 +5,7 @@ import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types
 import type { Model } from "~/services/copilot/get-models"
 
 import { accountsManager } from "~/lib/accounts-manager"
+import { getAdminDb } from "~/lib/admin-db"
 import { getSmallModel } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
@@ -184,6 +185,8 @@ function createPayload(
 beforeEach(() => {
   state.manualApprove = false
   state.verbose = false
+
+  getAdminDb().run("DELETE FROM session_affinity;")
 
   accountsManager.selectAccountForRequest = () =>
     Promise.resolve(buildSelection("/v1/messages", "messages-model"))
@@ -731,11 +734,29 @@ describe("messages handler ownership context", () => {
 })
 
 describe("messages handler unauthorized classification", () => {
-  test("ownership mismatch 401 does not trigger markAccountFailed", async () => {
+  test("ownership mismatch 401 invalidates stale affinity mapping and does not trigger markAccountFailed", async () => {
     const markFailedSpy = mock(() => {})
+    const cacheKey = "test-cache-key"
+
+    getAdminDb()
+      .query(
+        `INSERT INTO session_affinity (
+          cache_key,
+          account_id,
+          created_at_ms,
+          last_confirmed_at_ms,
+          last_used_at_ms
+        ) VALUES (?, ?, ?, ?, ?);`,
+      )
+      .run(cacheKey, "octocat", 1, 1, 1)
 
     accountsManager.selectAccountForRequest = () =>
-      Promise.resolve(buildSelection("/v1/messages", "messages-model"))
+      Promise.resolve({
+        ...buildSelection("/responses", "responses-model"),
+        affinityHit: true,
+        affinityCacheKey: cacheKey,
+        selectionReason: "affinity_hit",
+      })
     accountsManager.markAccountFailed = markFailedSpy
 
     const fetchMock = mock(() =>
@@ -758,8 +779,91 @@ describe("messages handler unauthorized classification", () => {
       }),
     )
 
+    const affinityRow = getAdminDb()
+      .query(
+        "SELECT account_id FROM session_affinity WHERE cache_key = ? LIMIT 1;",
+      )
+      .get(cacheKey) as { account_id?: string } | null
+
     expect(response.status).toBe(401)
     expect(markFailedSpy).not.toHaveBeenCalled()
+    expect(affinityRow).toBeNull()
+  })
+
+  test("ownership mismatch during responses stream invalidates stale affinity mapping and does not trigger markAccountFailed", async () => {
+    const markFailedSpy = mock(() => {})
+    const cacheKey = "test-stream-cache-key"
+    const encoder = new TextEncoder()
+
+    getAdminDb()
+      .query(
+        `INSERT INTO session_affinity (
+          cache_key,
+          account_id,
+          created_at_ms,
+          last_confirmed_at_ms,
+          last_used_at_ms
+        ) VALUES (?, ?, ?, ?, ?);`,
+      )
+      .run(cacheKey, "octocat", 1, 1, 1)
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve({
+        ...buildSelection("/responses", "responses-model"),
+        affinityHit: true,
+        affinityCacheKey: cacheKey,
+        selectionReason: "affinity_hit",
+      })
+    accountsManager.markAccountFailed = markFailedSpy
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode('event: ping\ndata: {"type":"ping"}\n\n'),
+              )
+              queueMicrotask(() => {
+                controller.error(
+                  new HTTPError(
+                    'input item ID "msg_abc" does not belong to this connection',
+                    new Response("ownership mismatch", { status: 401 }),
+                  ),
+                )
+              })
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload({ stream: true })),
+      }),
+    )
+
+    await response.text()
+
+    const affinityRow = getAdminDb()
+      .query(
+        "SELECT account_id FROM session_affinity WHERE cache_key = ? LIMIT 1;",
+      )
+      .get(cacheKey) as { account_id?: string } | null
+
+    expect(response.status).toBe(200)
+    expect(markFailedSpy).not.toHaveBeenCalled()
+    expect(affinityRow).toBeNull()
   })
 
   test("genuine unauthorized 401 does trigger markAccountFailed", async () => {

--- a/tests/responses-request-log-prompt-cache-key.test.ts
+++ b/tests/responses-request-log-prompt-cache-key.test.ts
@@ -5,6 +5,7 @@ import "./shared-admin-db-test-home"
 import type { AccountRuntime } from "~/lib/types/account"
 import type { Model } from "~/services/copilot/get-models"
 
+import { HTTPError } from "~/lib/error"
 import { getUUID } from "~/lib/utils"
 
 const [{ accountsManager }, { getAdminDb }, { state }, { responsesRoutes }] =
@@ -146,6 +147,7 @@ beforeEach(() => {
   state.verbose = false
 
   getAdminDb().run("DELETE FROM request_log;")
+  getAdminDb().run("DELETE FROM session_affinity;")
 
   accountsManager.finalizeQuota = () => Promise.resolve()
   accountsManager.markAccountFailed = () => {}
@@ -159,6 +161,65 @@ afterEach(() => {
 })
 
 describe("responses request log prompt_cache_key persistence", () => {
+  test("ownership mismatch 401 invalidates stale affinity mapping and does not trigger markAccountFailed", async () => {
+    const markFailedSpy = mock(() => {})
+    const cacheKey = "test-cache-key"
+
+    getAdminDb()
+      .query(
+        `INSERT INTO session_affinity (
+          cache_key,
+          account_id,
+          created_at_ms,
+          last_confirmed_at_ms,
+          last_used_at_ms
+        ) VALUES (?, ?, ?, ?, ?);`,
+      )
+      .run(cacheKey, "octocat", 1, 1, 1)
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve({
+        ...buildSelection("/responses", "responses-model"),
+        affinityHit: true,
+        affinityCacheKey: cacheKey,
+        selectionReason: "affinity_hit",
+      })
+    accountsManager.markAccountFailed = markFailedSpy
+
+    const fetchMock = mock(() =>
+      Promise.reject(
+        new HTTPError(
+          'input item ID "msg_abc" does not belong to this connection',
+          new Response("ownership mismatch", { status: 401 }),
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "original-model",
+          input: "hello",
+        }),
+      }),
+    )
+
+    const affinityRow = getAdminDb()
+      .query(
+        "SELECT account_id FROM session_affinity WHERE cache_key = ? LIMIT 1;",
+      )
+      .get(cacheKey) as { account_id?: string } | null
+
+    expect(response.status).toBe(401)
+    expect(markFailedSpy).not.toHaveBeenCalled()
+    expect(affinityRow).toBeNull()
+  })
+
   test("prefers payload.prompt_cache_key over metadata user_id session_id", async () => {
     let selectionRequestId: string | undefined
 


### PR DESCRIPTION
## Summary
- invalidate stale `session_affinity` mappings when Responses-related requests hit a 401 ownership-mismatch error
- avoid marking the upstream account as failed for connection-bound ownership mismatches
- add regression coverage for `/v1/messages -> /responses`, native `/responses`, and responses streaming error paths

## Test plan
- [x] `bun run lint`
- [x] `bun test "tests/messages-handler.test.ts" "tests/responses-request-log-prompt-cache-key.test.ts" "tests/embeddings-route.test.ts" "tests/handler-utils.test.ts"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了所有权不匹配错误的处理，现在会自动清除过期的缓存映射，防止后续请求使用陈旧数据。

* **测试**
  * 添加了针对所有权不匹配场景的测试覆盖，确保缓存失效机制正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->