### PR TITLE
Add background premium quota refresh

### DIFF
--- a/src/lib/accounts-manager-quota-scheduler.ts
+++ b/src/lib/accounts-manager-quota-scheduler.ts
@@ -65,6 +65,7 @@ export class QuotaRefreshScheduler {
   private readonly now: () => number
   private readonly random: () => number
   private readonly timer: SchedulerTimer
+  private generation = 0
   private pendingDelay?: PendingDelay
   private roundTimer?: TimerHandle
   private stopped = true
@@ -87,10 +88,14 @@ export class QuotaRefreshScheduler {
     }
 
     this.stopped = false
-    this.scheduleRound(secondsToMs(this.config.startupDelaySeconds))
+    this.scheduleRound(
+      secondsToMs(this.config.startupDelaySeconds),
+      this.generation,
+    )
   }
 
   stop(): void {
+    this.generation += 1
     this.stopped = true
     this.clearRoundTimer()
     this.clearPendingDelay()
@@ -100,24 +105,36 @@ export class QuotaRefreshScheduler {
     this.start(config)
   }
 
-  private scheduleRound(delayMs: number): void {
+  private isActiveGeneration(generation: number): boolean {
+    return !this.stopped && this.generation === generation
+  }
+
+  private scheduleRound(delayMs: number, generation: number): void {
     this.clearRoundTimer()
-    this.roundTimer = this.timer.setTimer(
+    const handle = this.timer.setTimer(
       () => {
-        this.roundTimer = undefined
-        void this.runRound()
+        if (this.roundTimer === handle) {
+          this.roundTimer = undefined
+        }
+        if (this.isActiveGeneration(generation)) {
+          void this.runRound(generation)
+        }
       },
       Math.max(0, delayMs),
     )
+    this.roundTimer = handle
   }
 
-  private scheduleNextRound(): void {
-    if (!isSchedulingEnabled(this.config)) {
+  private scheduleNextRound(generation: number): void {
+    if (
+      !this.isActiveGeneration(generation)
+      || !isSchedulingEnabled(this.config)
+    ) {
       return
     }
 
     const intervalMs = minutesToMs(this.config.intervalMinutes)
-    this.scheduleRound(this.withJitter(intervalMs))
+    this.scheduleRound(this.withJitter(intervalMs), generation)
   }
 
   private withJitter(intervalMs: number): number {
@@ -187,12 +204,12 @@ export class QuotaRefreshScheduler {
     resolve()
   }
 
-  private async runRound(): Promise<void> {
+  private async runRound(generation: number): Promise<void> {
     try {
       const accounts = this.manager.getQuotaRefreshAccounts()
 
       for (const [index, account] of accounts.entries()) {
-        if (this.stopped) {
+        if (!this.isActiveGeneration(generation)) {
           return
         }
         if (this.isFresh(account)) {
@@ -202,22 +219,31 @@ export class QuotaRefreshScheduler {
         try {
           await this.manager.refreshAccountQuota(account)
         } catch (error) {
-          this.logger.debug("Background quota refresh failed", {
-            accountId: account.id,
-            error,
-          })
+          if (this.isActiveGeneration(generation)) {
+            this.logger.debug("Background quota refresh failed", {
+              accountId: account.id,
+              error,
+            })
+          }
+        }
+
+        if (!this.isActiveGeneration(generation)) {
+          return
         }
 
         if (index < accounts.length - 1) {
           await this.schedulerDelay(this.getStaggerDelayMs())
+          if (!this.isActiveGeneration(generation)) {
+            return
+          }
         }
       }
     } catch (error) {
-      this.logger.error("Background quota refresh round failed", error)
-    } finally {
-      if (!this.stopped) {
-        this.scheduleNextRound()
+      if (this.isActiveGeneration(generation)) {
+        this.logger.error("Background quota refresh round failed", error)
       }
+    } finally {
+      this.scheduleNextRound(generation)
     }
   }
 }

--- a/src/lib/accounts-manager-quota-scheduler.ts
+++ b/src/lib/accounts-manager-quota-scheduler.ts
@@ -1,0 +1,223 @@
+import consola from "consola"
+
+import type { ResolvedQuotaRefreshConfig } from "~/lib/config"
+import type { AccountRuntime } from "~/lib/types/account"
+
+export const QUOTA_REFRESH_FRESHNESS_GUARD_MS = 5 * 60 * 1000
+export const QUOTA_REFRESH_INTERVAL_JITTER_RATIO = 0.1
+
+export interface QuotaRefreshManager {
+  getQuotaRefreshAccounts(): Array<AccountRuntime>
+  refreshAccountQuota(account: AccountRuntime): Promise<void>
+}
+
+type Logger = {
+  debug(...args: Array<unknown>): void
+  error(...args: Array<unknown>): void
+}
+
+type TimerHandle = unknown
+
+type SchedulerTimer = {
+  clearTimer(handle: TimerHandle): void
+  setTimer(callback: () => void, delayMs: number): TimerHandle
+}
+
+export interface QuotaRefreshSchedulerOptions {
+  config: ResolvedQuotaRefreshConfig
+  manager: QuotaRefreshManager
+  logger?: Logger
+  now?: () => number
+  random?: () => number
+  timer?: SchedulerTimer
+}
+
+type PendingDelay = {
+  handle: TimerHandle
+  resolve: () => void
+}
+
+const defaultTimer: SchedulerTimer = {
+  setTimer(callback, delayMs) {
+    return setTimeout(callback, delayMs)
+  },
+  clearTimer(handle) {
+    clearTimeout(handle as ReturnType<typeof setTimeout>)
+  },
+}
+
+function secondsToMs(seconds: number): number {
+  return seconds * 1000
+}
+
+function minutesToMs(minutes: number): number {
+  return minutes * 60 * 1000
+}
+
+function isSchedulingEnabled(config: ResolvedQuotaRefreshConfig): boolean {
+  return config.enabled && config.intervalMinutes > 0
+}
+
+export class QuotaRefreshScheduler {
+  private config: ResolvedQuotaRefreshConfig
+  private readonly logger: Logger
+  private readonly manager: QuotaRefreshManager
+  private readonly now: () => number
+  private readonly random: () => number
+  private readonly timer: SchedulerTimer
+  private pendingDelay?: PendingDelay
+  private roundTimer?: TimerHandle
+  private stopped = true
+
+  constructor(options: QuotaRefreshSchedulerOptions) {
+    this.config = options.config
+    this.logger = options.logger ?? consola
+    this.manager = options.manager
+    this.now = options.now ?? Date.now
+    this.random = options.random ?? Math.random
+    this.timer = options.timer ?? defaultTimer
+  }
+
+  start(config = this.config): void {
+    this.config = config
+    this.stop()
+
+    if (!isSchedulingEnabled(this.config)) {
+      return
+    }
+
+    this.stopped = false
+    this.scheduleRound(secondsToMs(this.config.startupDelaySeconds))
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.clearRoundTimer()
+    this.clearPendingDelay()
+  }
+
+  updateConfig(config: ResolvedQuotaRefreshConfig): void {
+    this.start(config)
+  }
+
+  private scheduleRound(delayMs: number): void {
+    this.clearRoundTimer()
+    this.roundTimer = this.timer.setTimer(
+      () => {
+        this.roundTimer = undefined
+        void this.runRound()
+      },
+      Math.max(0, delayMs),
+    )
+  }
+
+  private scheduleNextRound(): void {
+    if (!isSchedulingEnabled(this.config)) {
+      return
+    }
+
+    const intervalMs = minutesToMs(this.config.intervalMinutes)
+    this.scheduleRound(this.withJitter(intervalMs))
+  }
+
+  private withJitter(intervalMs: number): number {
+    const jitterMs = Math.floor(
+      intervalMs
+        * QUOTA_REFRESH_INTERVAL_JITTER_RATIO
+        * (this.random() * 2 - 1),
+    )
+    return Math.max(0, intervalMs + jitterMs)
+  }
+
+  private getStaggerDelayMs(): number {
+    const minMs = secondsToMs(this.config.staggerMinSeconds)
+    const maxMs = secondsToMs(this.config.staggerMaxSeconds)
+    if (maxMs <= minMs) {
+      return minMs
+    }
+
+    return minMs + Math.floor(this.random() * (maxMs - minMs))
+  }
+
+  private isFresh(account: AccountRuntime): boolean {
+    if (account.lastQuotaFetch === undefined) {
+      return false
+    }
+
+    return (
+      this.now() - account.lastQuotaFetch < QUOTA_REFRESH_FRESHNESS_GUARD_MS
+    )
+  }
+
+  private async schedulerDelay(delayMs: number): Promise<void> {
+    this.clearPendingDelay()
+
+    await new Promise<void>((resolve) => {
+      const handle = this.timer.setTimer(
+        () => {
+          if (this.pendingDelay?.handle === handle) {
+            this.pendingDelay = undefined
+          }
+          resolve()
+        },
+        Math.max(0, delayMs),
+      )
+
+      this.pendingDelay = { handle, resolve }
+    })
+  }
+
+  private clearRoundTimer(): void {
+    if (this.roundTimer === undefined) {
+      return
+    }
+
+    this.timer.clearTimer(this.roundTimer)
+    this.roundTimer = undefined
+  }
+
+  private clearPendingDelay(): void {
+    if (!this.pendingDelay) {
+      return
+    }
+
+    const { handle, resolve } = this.pendingDelay
+    this.pendingDelay = undefined
+    this.timer.clearTimer(handle)
+    resolve()
+  }
+
+  private async runRound(): Promise<void> {
+    try {
+      const accounts = this.manager.getQuotaRefreshAccounts()
+
+      for (const [index, account] of accounts.entries()) {
+        if (this.stopped) {
+          return
+        }
+        if (this.isFresh(account)) {
+          continue
+        }
+
+        try {
+          await this.manager.refreshAccountQuota(account)
+        } catch (error) {
+          this.logger.debug("Background quota refresh failed", {
+            accountId: account.id,
+            error,
+          })
+        }
+
+        if (index < accounts.length - 1) {
+          await this.schedulerDelay(this.getStaggerDelayMs())
+        }
+      }
+    } catch (error) {
+      this.logger.error("Background quota refresh round failed", error)
+    } finally {
+      if (!this.stopped) {
+        this.scheduleNextRound()
+      }
+    }
+  }
+}

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -303,6 +303,17 @@ export class AccountsManager {
     this.scheduleModelsRefresh()
   }
 
+  getQuotaRefreshAccounts(): Array<AccountRuntime> {
+    return this.getOrderedEnabledAccounts().filter(
+      (account) =>
+        !this.isAccountFailed(account) && account.copilotToken !== undefined,
+    )
+  }
+
+  refreshAccountQuota(account: AccountRuntime): Promise<void> {
+    return this.refreshQuota(account)
+  }
+
   private computeTokenRefreshDelayMs(refreshInSeconds: number): number {
     const baseDelay = Math.max((refreshInSeconds - 60) * 1000, 1000)
     const jitter = Math.floor(Math.random() * TOKEN_REFRESH_JITTER_MS)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,22 @@ export interface DevModeConfig {
   captureOther: boolean
 }
 
+export interface QuotaRefreshConfig {
+  enabled?: boolean
+  intervalMinutes?: number
+  startupDelaySeconds?: number
+  staggerMinSeconds?: number
+  staggerMaxSeconds?: number
+}
+
+export interface ResolvedQuotaRefreshConfig {
+  enabled: boolean
+  intervalMinutes: number
+  startupDelaySeconds: number
+  staggerMinSeconds: number
+  staggerMaxSeconds: number
+}
+
 export interface AppConfig {
   auth?: {
     apiKeys?: Array<string>
@@ -41,6 +57,7 @@ export interface AppConfig {
   claudeTokenMultiplier?: number
   logLevel?: LogLevel
   devMode?: DevModeConfig
+  quotaRefresh?: QuotaRefreshConfig
 }
 
 export interface ModelConfig {
@@ -81,6 +98,16 @@ const gpt5ExplorationPrompt = `## Exploration and reading files
 - **multi_tool_use.parallel** Use multi_tool_use.parallel to parallelize tool calls and only this.
 - **Only make sequential calls if you truly cannot know the next file without seeing a result first.**
 - **Workflow:** (a) plan all needed reads → (b) issue one parallel batch → (c) analyze results → (d) repeat if new, unpredictable reads arise.`
+
+const DEFAULT_QUOTA_REFRESH_CONFIG: ResolvedQuotaRefreshConfig = {
+  enabled: true,
+  intervalMinutes: 360,
+  startupDelaySeconds: 60,
+  staggerMinSeconds: 2,
+  staggerMaxSeconds: 5,
+}
+
+const MIN_QUOTA_REFRESH_INTERVAL_MINUTES = 30
 
 const gpt5CommentaryPrompt = `# Working with the user
 
@@ -140,6 +167,7 @@ const defaultConfig: AppConfig = {
     capture5xx: false,
     captureOther: false,
   },
+  quotaRefresh: DEFAULT_QUOTA_REFRESH_CONFIG,
 }
 
 let cachedConfig: AppConfig | null = null
@@ -166,6 +194,42 @@ function normalizeNonNegativeNumber(value: unknown): number | undefined {
   if (!Number.isFinite(value)) return undefined
   if (value < 0) return undefined
   return value
+}
+
+function normalizeQuotaRefreshIntervalMinutes(value: unknown): number {
+  const normalized = normalizeNonNegativeNumber(value)
+  const minutes = normalized ?? DEFAULT_QUOTA_REFRESH_CONFIG.intervalMinutes
+
+  if (minutes > 0 && minutes < MIN_QUOTA_REFRESH_INTERVAL_MINUTES) {
+    return MIN_QUOTA_REFRESH_INTERVAL_MINUTES
+  }
+
+  return minutes
+}
+
+export function normalizeQuotaRefreshConfig(
+  value: unknown,
+): ResolvedQuotaRefreshConfig {
+  const raw = isPlainObject(value) ? value : {}
+  const staggerMinSeconds =
+    normalizeNonNegativeNumber(raw.staggerMinSeconds)
+    ?? DEFAULT_QUOTA_REFRESH_CONFIG.staggerMinSeconds
+  const rawStaggerMaxSeconds =
+    normalizeNonNegativeNumber(raw.staggerMaxSeconds)
+    ?? DEFAULT_QUOTA_REFRESH_CONFIG.staggerMaxSeconds
+
+  return {
+    enabled:
+      typeof raw.enabled === "boolean" ?
+        raw.enabled
+      : DEFAULT_QUOTA_REFRESH_CONFIG.enabled,
+    intervalMinutes: normalizeQuotaRefreshIntervalMinutes(raw.intervalMinutes),
+    startupDelaySeconds:
+      normalizeNonNegativeNumber(raw.startupDelaySeconds)
+      ?? DEFAULT_QUOTA_REFRESH_CONFIG.startupDelaySeconds,
+    staggerMinSeconds,
+    staggerMaxSeconds: Math.max(staggerMinSeconds, rawStaggerMaxSeconds),
+  }
 }
 
 const LOG_LEVELS = new Set<LogLevel>(["error", "warn", "info", "debug"])
@@ -409,6 +473,22 @@ function mergeDefaultDevMode(config: AppConfig): ConfigMergeResult {
   }
 }
 
+function mergeDefaultQuotaRefresh(config: AppConfig): ConfigMergeResult {
+  const quotaRefresh = normalizeQuotaRefreshConfig(config.quotaRefresh)
+
+  if (JSON.stringify(config.quotaRefresh) === JSON.stringify(quotaRefresh)) {
+    return { mergedConfig: config, changed: false }
+  }
+
+  return {
+    mergedConfig: {
+      ...config,
+      quotaRefresh,
+    },
+    changed: true,
+  }
+}
+
 type ConfigMergeResult = {
   mergedConfig: AppConfig
   changed: boolean
@@ -443,6 +523,7 @@ export function mergeConfigWithDefaults(): AppConfig {
     mergeDefaultSessionAffinityRetention,
     mergeDefaultLogLevel,
     mergeDefaultDevMode,
+    mergeDefaultQuotaRefresh,
   ])
 
   if (changed) {
@@ -679,6 +760,10 @@ export function getModelRefreshIntervalMs(): number {
   const hours = getModelRefreshIntervalHours()
   if (!Number.isFinite(hours) || hours <= 0) return 0
   return hours * 60 * 60 * 1000
+}
+
+export function getQuotaRefreshConfig(): ResolvedQuotaRefreshConfig {
+  return normalizeQuotaRefreshConfig(getConfig().quotaRefresh)
 }
 
 export function getSessionAffinityRetentionDays(): number {

--- a/src/lib/quota-refresh-scheduler-runtime.ts
+++ b/src/lib/quota-refresh-scheduler-runtime.ts
@@ -1,0 +1,44 @@
+import { accountsManager } from "~/lib/accounts-manager"
+import { QuotaRefreshScheduler } from "~/lib/accounts-manager-quota-scheduler"
+import { getQuotaRefreshConfig } from "~/lib/config"
+
+export const quotaRefreshScheduler = new QuotaRefreshScheduler({
+  config: getQuotaRefreshConfig(),
+  manager: accountsManager,
+})
+
+type ShutdownRuntime = {
+  once(event: "exit", listener: () => void): unknown
+}
+
+const registeredShutdownRuntimes = new WeakSet<ShutdownRuntime>()
+let isQuotaRefreshSchedulerStarted = false
+
+export function startQuotaRefreshSchedulerFromConfig(): void {
+  isQuotaRefreshSchedulerStarted = true
+  quotaRefreshScheduler.start(getQuotaRefreshConfig())
+}
+
+export function stopQuotaRefreshScheduler(): void {
+  isQuotaRefreshSchedulerStarted = false
+  quotaRefreshScheduler.stop()
+}
+
+export function registerQuotaRefreshSchedulerShutdownCleanup(
+  runtime: ShutdownRuntime = process,
+): void {
+  if (registeredShutdownRuntimes.has(runtime)) {
+    return
+  }
+
+  registeredShutdownRuntimes.add(runtime)
+  runtime.once("exit", () => stopQuotaRefreshScheduler())
+}
+
+export function updateQuotaRefreshSchedulerFromConfig(): void {
+  if (!isQuotaRefreshSchedulerStarted) {
+    return
+  }
+
+  quotaRefreshScheduler.updateConfig(getQuotaRefreshConfig())
+}

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1109,7 +1109,13 @@ function applyQuotaRefreshConfig(
     delete next.quotaRefresh
     return undefined
   }
-  next.quotaRefresh = parsed.value
+  next.quotaRefresh =
+    next.quotaRefresh === undefined ?
+      parsed.value
+    : {
+        ...next.quotaRefresh,
+        ...parsed.value,
+      }
   return undefined
 }
 

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -27,8 +27,10 @@ import {
   type LogLevel,
   type ModelConfig,
   type ProviderConfig,
+  type QuotaRefreshConfig,
 } from "~/lib/config"
 import { PATHS } from "~/lib/paths"
+import { updateQuotaRefreshSchedulerFromConfig } from "~/lib/quota-refresh-scheduler-runtime"
 import {
   getRequestHistoryStore,
   getStatsStore,
@@ -195,6 +197,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "useMessagesApi",
   "useResponsesApiWebSearch",
   "devMode",
+  "quotaRefresh",
 ])
 
 const REASONING_EFFORTS = new Set<ReasoningEffort>([
@@ -1047,6 +1050,69 @@ function applyDevModeConfig(
   return undefined
 }
 
+const QUOTA_REFRESH_KEYS = new Set([
+  "enabled",
+  "intervalMinutes",
+  "startupDelaySeconds",
+  "staggerMinSeconds",
+  "staggerMaxSeconds",
+])
+
+function parseQuotaRefreshConfig(
+  value: unknown,
+): ParseFieldResult<QuotaRefreshConfig> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) return { error: "quotaRefresh must be an object" }
+
+  for (const key of Object.keys(value)) {
+    if (!QUOTA_REFRESH_KEYS.has(key)) {
+      return { error: `quotaRefresh.${key} is not supported` }
+    }
+  }
+
+  const out: QuotaRefreshConfig = {}
+
+  if (Object.hasOwn(value, "enabled")) {
+    const parsed = parseOptionalBoolean(value.enabled, "quotaRefresh.enabled")
+    if ("error" in parsed) return parsed
+    if ("value" in parsed) out.enabled = parsed.value
+  }
+
+  for (const key of [
+    "intervalMinutes",
+    "startupDelaySeconds",
+    "staggerMinSeconds",
+    "staggerMaxSeconds",
+  ] as const) {
+    if (!Object.hasOwn(value, key)) {
+      continue
+    }
+
+    const parsed = parseOptionalNonNegativeNumber(
+      value[key],
+      `quotaRefresh.${key}`,
+    )
+    if ("error" in parsed) return parsed
+    if ("value" in parsed) out[key] = parsed.value
+  }
+
+  return { value: out }
+}
+
+function applyQuotaRefreshConfig(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseQuotaRefreshConfig(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.quotaRefresh
+    return undefined
+  }
+  next.quotaRefresh = parsed.value
+  return undefined
+}
+
 type ConfigPatchHandler = (
   next: AppConfig,
   value: unknown,
@@ -1084,6 +1150,7 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
   useResponsesApiWebSearch: (next, value) =>
     applyOptionalBoolean(next, "useResponsesApiWebSearch", value),
   devMode: applyDevModeConfig,
+  quotaRefresh: applyQuotaRefreshConfig,
 }
 
 function applyConfigPatch(
@@ -1180,6 +1247,7 @@ adminApiRoutes.post("/config", async (c) => {
     const merged = mergeConfigWithDefaults()
     accountsManager.setAccountAffinityEnabled(isAccountAffinityEnabled())
     accountsManager.setModelsRefreshIntervalMs(getModelRefreshIntervalMs())
+    updateQuotaRefreshSchedulerFromConfig()
     applySharedSessionAffinityRetention()
     return c.json({ ...merged, _configPath: PATHS.CONFIG_PATH })
   } catch {

--- a/src/start.ts
+++ b/src/start.ts
@@ -5,6 +5,12 @@ import clipboard from "clipboardy"
 import consola from "consola"
 import { serve, type ServerHandler } from "srvx"
 
+import {
+  registerQuotaRefreshSchedulerShutdownCleanup,
+  startQuotaRefreshSchedulerFromConfig,
+  stopQuotaRefreshScheduler,
+} from "~/lib/quota-refresh-scheduler-runtime"
+
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
 import {
@@ -15,11 +21,6 @@ import {
 import { initOpencodeVersion } from "./lib/opencode"
 import { ensurePaths } from "./lib/paths"
 import { initProxyFromEnv } from "./lib/proxy"
-import {
-  registerQuotaRefreshSchedulerShutdownCleanup,
-  startQuotaRefreshSchedulerFromConfig,
-  stopQuotaRefreshScheduler,
-} from "./lib/quota-refresh-scheduler-runtime"
 import { applySharedSessionAffinityRetention } from "./lib/session-affinity-store"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"

--- a/src/start.ts
+++ b/src/start.ts
@@ -15,6 +15,11 @@ import {
 import { initOpencodeVersion } from "./lib/opencode"
 import { ensurePaths } from "./lib/paths"
 import { initProxyFromEnv } from "./lib/proxy"
+import {
+  registerQuotaRefreshSchedulerShutdownCleanup,
+  startQuotaRefreshSchedulerFromConfig,
+  stopQuotaRefreshScheduler,
+} from "./lib/quota-refresh-scheduler-runtime"
 import { applySharedSessionAffinityRetention } from "./lib/session-affinity-store"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"
@@ -203,6 +208,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
 
         // Re-initialize accounts manager with the new account
         accountsManager.shutdown()
+        stopQuotaRefreshScheduler()
         await accountsManager.initialize(state.vsCodeVersion)
         accountsManager.setModelsRefreshIntervalMs(getModelRefreshIntervalMs())
       } catch (error) {
@@ -211,6 +217,9 @@ export async function runServer(options: RunServerOptions): Promise<void> {
       }
     }
   }
+
+  startQuotaRefreshSchedulerFromConfig()
+  registerQuotaRefreshSchedulerShutdownCleanup()
 
   // Get models from the first available account
   const models = accountsManager.getFirstAccountModels()

--- a/tests/accounts-manager-401.test.ts
+++ b/tests/accounts-manager-401.test.ts
@@ -37,6 +37,39 @@ test("refreshQuota marks account failed on 401", async () => {
   }
 })
 
+test("refreshQuota does not mark account failed on non-401 errors", async () => {
+  const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+  const originalFetch = fetchHolder.fetch
+
+  const fetchMock = mock(() => new Response("server error", { status: 500 }))
+  // @ts-expect-error - mock doesn't implement full fetch signature
+  fetchHolder.fetch = fetchMock
+
+  try {
+    const manager = new AccountsManager()
+
+    const account: AccountRuntime = {
+      id: "octocat",
+      accountType: "individual",
+      addedAt: Date.now(),
+      githubToken: "ghp_test",
+      vsCodeVersion: "1.0.0",
+    }
+
+    const { accounts } = manager as unknown as {
+      accounts: Map<string, AccountRuntime>
+    }
+    accounts.set(account.id, account)
+
+    await manager.refreshQuota(account)
+
+    expect(account.failed).toBeUndefined()
+    expect(account.failureReason).toBeUndefined()
+  } finally {
+    fetchHolder.fetch = originalFetch
+  }
+})
+
 test("refreshQuota ignores stale 401 when githubToken changes before request resolves", async () => {
   const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
   const originalFetch = fetchHolder.fetch

--- a/tests/accounts-manager-quota-scheduler.test.ts
+++ b/tests/accounts-manager-quota-scheduler.test.ts
@@ -1,0 +1,348 @@
+import { expect, test } from "bun:test"
+
+import type { ResolvedQuotaRefreshConfig } from "~/lib/config"
+import type { AccountRuntime } from "~/lib/types/account"
+
+import { AccountsManager } from "~/lib/accounts-manager"
+import {
+  QuotaRefreshScheduler,
+  type QuotaRefreshManager,
+} from "~/lib/accounts-manager-quota-scheduler"
+import {
+  quotaRefreshScheduler,
+  registerQuotaRefreshSchedulerShutdownCleanup,
+} from "~/lib/quota-refresh-scheduler-runtime"
+
+type ScheduledTimer = {
+  callback: () => void
+  delayMs: number
+}
+
+type ShutdownEvent = "exit"
+
+class FakeShutdownRuntime {
+  private readonly listeners = new Map<ShutdownEvent, () => void>()
+
+  once(event: ShutdownEvent, listener: () => void): void {
+    this.listeners.set(event, listener)
+  }
+
+  emit(event: ShutdownEvent): void {
+    this.listeners.get(event)?.()
+  }
+}
+
+class FakeTimer {
+  private nextHandle = 1
+  private readonly timers = new Map<number, ScheduledTimer>()
+
+  setTimer = (callback: () => void, delayMs: number): unknown => {
+    const handle = this.nextHandle++
+    this.timers.set(handle, { callback, delayMs })
+    return handle
+  }
+
+  clearTimer = (handle: unknown): void => {
+    if (typeof handle === "number") {
+      this.timers.delete(handle)
+    }
+  }
+
+  get delayMsList(): Array<number> {
+    return [...this.timers.values()].map((timer) => timer.delayMs)
+  }
+
+  runNext(): number {
+    const next = this.timers.entries().next()
+    if (next.done) {
+      throw new Error("No timer scheduled")
+    }
+
+    const [handle, timer] = next.value
+    this.timers.delete(handle)
+    timer.callback()
+    return timer.delayMs
+  }
+}
+
+const flushAsyncWork = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const config = (
+  overrides: Partial<ResolvedQuotaRefreshConfig> = {},
+): ResolvedQuotaRefreshConfig => ({
+  enabled: true,
+  intervalMinutes: 360,
+  startupDelaySeconds: 60,
+  staggerMinSeconds: 2,
+  staggerMaxSeconds: 2,
+  ...overrides,
+})
+
+const account = (id: string, overrides: Partial<AccountRuntime> = {}) => ({
+  id,
+  accountType: "individual" as const,
+  addedAt: 1,
+  githubToken: `ghp_${id}`,
+  copilotToken: `copilot_${id}`,
+  ...overrides,
+})
+
+const logger = {
+  debug() {},
+  error() {},
+}
+
+test("QuotaRefreshScheduler schedules the first round after startup delay", () => {
+  const fakeTimer = new FakeTimer()
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [],
+    refreshAccountQuota: () => Promise.resolve(),
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config(),
+    logger,
+    manager,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+
+  expect(fakeTimer.delayMsList).toEqual([60_000])
+})
+
+test("QuotaRefreshScheduler does not schedule when disabled", () => {
+  const fakeTimer = new FakeTimer()
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [],
+    refreshAccountQuota: () => Promise.resolve(),
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ enabled: false }),
+    logger,
+    manager,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+
+  expect(fakeTimer.delayMsList).toEqual([])
+})
+
+test("QuotaRefreshScheduler refreshes serially and isolates account failures", async () => {
+  const fakeTimer = new FakeTimer()
+  const calls: Array<string> = []
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [account("a"), account("b")],
+    refreshAccountQuota: (runtime) => {
+      calls.push(runtime.id)
+      if (runtime.id === "a") {
+        return Promise.reject(new Error("boom"))
+      }
+      return Promise.resolve()
+    },
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ startupDelaySeconds: 0 }),
+    logger,
+    manager,
+    random: () => 0.5,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  expect(calls).toEqual(["a"])
+  expect(fakeTimer.delayMsList).toEqual([2_000])
+
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  expect(calls).toEqual(["a", "b"])
+  expect(fakeTimer.delayMsList).toEqual([21_600_000])
+})
+
+test("QuotaRefreshScheduler stop clears a pending stagger delay", async () => {
+  const fakeTimer = new FakeTimer()
+  const calls: Array<string> = []
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [account("a"), account("b")],
+    refreshAccountQuota: (runtime) => {
+      calls.push(runtime.id)
+      return Promise.resolve()
+    },
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ startupDelaySeconds: 0 }),
+    logger,
+    manager,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  scheduler.stop()
+  await flushAsyncWork()
+
+  expect(calls).toEqual(["a"])
+  expect(fakeTimer.delayMsList).toEqual([])
+})
+
+test("QuotaRefreshScheduler updateConfig disables work during a pending stagger delay", async () => {
+  const fakeTimer = new FakeTimer()
+  const calls: Array<string> = []
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [account("a"), account("b")],
+    refreshAccountQuota: (runtime) => {
+      calls.push(runtime.id)
+      return Promise.resolve()
+    },
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ startupDelaySeconds: 0 }),
+    logger,
+    manager,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  scheduler.updateConfig(config({ enabled: false }))
+  await flushAsyncWork()
+
+  expect(calls).toEqual(["a"])
+  expect(fakeTimer.delayMsList).toEqual([])
+})
+
+test("QuotaRefreshScheduler does not schedule when interval is non-positive", () => {
+  const fakeTimer = new FakeTimer()
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [],
+    refreshAccountQuota: () => Promise.resolve(),
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ intervalMinutes: 0 }),
+    logger,
+    manager,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+
+  expect(fakeTimer.delayMsList).toEqual([])
+})
+
+test("QuotaRefreshScheduler schedules the next round when account snapshot fails", async () => {
+  const fakeTimer = new FakeTimer()
+  const errors: Array<Array<unknown>> = []
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => {
+      throw new Error("snapshot failed")
+    },
+    refreshAccountQuota: () => Promise.resolve(),
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ startupDelaySeconds: 0 }),
+    logger: {
+      debug() {},
+      error(...args) {
+        errors.push(args)
+      },
+    },
+    manager,
+    random: () => 0.5,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  expect(errors).toHaveLength(1)
+  expect(fakeTimer.delayMsList).toEqual([21_600_000])
+})
+
+test("QuotaRefreshScheduler skips accounts refreshed inside the freshness guard", async () => {
+  const fakeTimer = new FakeTimer()
+  const calls: Array<string> = []
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [
+      account("fresh", { lastQuotaFetch: 9_900 }),
+      account("stale"),
+    ],
+    refreshAccountQuota: (runtime) => {
+      calls.push(runtime.id)
+      return Promise.resolve()
+    },
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ startupDelaySeconds: 0 }),
+    logger,
+    manager,
+    now: () => 10_000,
+    random: () => 0.5,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  expect(calls).toEqual(["stale"])
+  expect(fakeTimer.delayMsList).toEqual([21_600_000])
+})
+
+test("quota refresh scheduler runtime stops scheduler on process exit", () => {
+  const fakeRuntime = new FakeShutdownRuntime()
+  const originalStop = quotaRefreshScheduler.stop.bind(quotaRefreshScheduler)
+  let stops = 0
+
+  quotaRefreshScheduler.stop = () => {
+    stops += 1
+  }
+
+  try {
+    registerQuotaRefreshSchedulerShutdownCleanup(fakeRuntime)
+    fakeRuntime.emit("exit")
+
+    expect(stops).toBe(1)
+  } finally {
+    quotaRefreshScheduler.stop = originalStop
+  }
+})
+
+test("AccountsManager returns a quota refresh account snapshot", () => {
+  const manager = new AccountsManager()
+  const refreshable = account("refreshable")
+  const disabled = account("disabled", { enabled: false })
+  const failed = account("failed", { failed: true })
+  const uninitialized = account("uninitialized", { copilotToken: undefined })
+  const temporary = account("temporary")
+  const internals = manager as unknown as {
+    accountOrder: Array<string>
+    accounts: Map<string, AccountRuntime>
+    temporaryAccount?: AccountRuntime
+  }
+
+  for (const runtime of [refreshable, disabled, failed, uninitialized]) {
+    internals.accounts.set(runtime.id, runtime)
+    internals.accountOrder.push(runtime.id)
+  }
+  internals.temporaryAccount = temporary
+
+  const accounts = manager.getQuotaRefreshAccounts()
+
+  expect(accounts.map((runtime) => runtime.id)).toEqual([
+    "temporary",
+    "refreshable",
+  ])
+  expect(accounts).not.toBe(manager.getQuotaRefreshAccounts())
+})

--- a/tests/accounts-manager-quota-scheduler.test.ts
+++ b/tests/accounts-manager-quota-scheduler.test.ts
@@ -222,6 +222,39 @@ test("QuotaRefreshScheduler updateConfig disables work during a pending stagger 
   expect(fakeTimer.delayMsList).toEqual([])
 })
 
+test("QuotaRefreshScheduler ignores stale in-flight rounds after updateConfig restarts", async () => {
+  const fakeTimer = new FakeTimer()
+  const calls: Array<string> = []
+  let resolveRefresh: (() => void) | undefined
+  const refreshPromise = new Promise<void>((resolve) => {
+    resolveRefresh = resolve
+  })
+  const manager: QuotaRefreshManager = {
+    getQuotaRefreshAccounts: () => [account("a"), account("b")],
+    refreshAccountQuota: (runtime) => {
+      calls.push(runtime.id)
+      return runtime.id === "a" ? refreshPromise : Promise.resolve()
+    },
+  }
+  const scheduler = new QuotaRefreshScheduler({
+    config: config({ startupDelaySeconds: 0 }),
+    logger,
+    manager,
+    timer: fakeTimer,
+  })
+
+  scheduler.start()
+  fakeTimer.runNext()
+  await flushAsyncWork()
+
+  scheduler.updateConfig(config({ startupDelaySeconds: 30 }))
+  resolveRefresh?.()
+  await flushAsyncWork()
+
+  expect(calls).toEqual(["a"])
+  expect(fakeTimer.delayMsList).toEqual([30_000])
+})
+
 test("QuotaRefreshScheduler does not schedule when interval is non-positive", () => {
   const fakeTimer = new FakeTimer()
   const manager: QuotaRefreshManager = {

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -614,6 +614,65 @@ test("POST /api/admin/config updates quotaRefresh and clamps short positive inte
   })
 })
 
+test("POST /api/admin/config merges partial quotaRefresh updates", async () => {
+  await withConfig(
+    {
+      quotaRefresh: {
+        enabled: true,
+        intervalMinutes: 120,
+        startupDelaySeconds: 10,
+        staggerMinSeconds: 4,
+        staggerMaxSeconds: 8,
+      },
+    },
+    async () => {
+      const { server } = await import("../src/server")
+
+      const postRes = await server.fetch(
+        new Request("http://localhost/api/admin/config", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            quotaRefresh: {
+              enabled: false,
+            },
+          }),
+        }),
+      )
+
+      expect(postRes.status).toBe(200)
+
+      const postBody = (await postRes.json()) as {
+        quotaRefresh?: {
+          enabled?: boolean
+          intervalMinutes?: number
+          startupDelaySeconds?: number
+          staggerMinSeconds?: number
+          staggerMaxSeconds?: number
+        }
+      }
+      expect(postBody.quotaRefresh).toEqual({
+        enabled: false,
+        intervalMinutes: 120,
+        startupDelaySeconds: 10,
+        staggerMinSeconds: 4,
+        staggerMaxSeconds: 8,
+      })
+
+      const getRes = await server.fetch(
+        new Request("http://localhost/api/admin/config"),
+      )
+
+      expect(getRes.status).toBe(200)
+
+      const getBody = (await getRes.json()) as typeof postBody
+      expect(getBody.quotaRefresh).toEqual(postBody.quotaRefresh)
+    },
+  )
+})
+
 test("POST /api/admin/config refreshes the running quota scheduler config", async () => {
   await withConfig({}, async () => {
     const runtime = await import("../src/lib/quota-refresh-scheduler-runtime")

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -541,3 +541,154 @@ test("POST /api/admin/config rejects unknown top-level config keys", async () =>
     expect(body.error?.message).toContain("Unknown config key: notARealKey")
   })
 })
+
+test("GET /api/admin/config returns default quotaRefresh config", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config"),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      quotaRefresh?: {
+        enabled?: boolean
+        intervalMinutes?: number
+        startupDelaySeconds?: number
+        staggerMinSeconds?: number
+        staggerMaxSeconds?: number
+      }
+    }
+    expect(body.quotaRefresh).toEqual({
+      enabled: true,
+      intervalMinutes: 360,
+      startupDelaySeconds: 60,
+      staggerMinSeconds: 2,
+      staggerMaxSeconds: 5,
+    })
+  })
+})
+
+test("POST /api/admin/config updates quotaRefresh and clamps short positive interval", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          quotaRefresh: {
+            enabled: true,
+            intervalMinutes: 5,
+            startupDelaySeconds: 0,
+            staggerMinSeconds: 7,
+            staggerMaxSeconds: 3,
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      quotaRefresh?: {
+        enabled?: boolean
+        intervalMinutes?: number
+        startupDelaySeconds?: number
+        staggerMinSeconds?: number
+        staggerMaxSeconds?: number
+      }
+    }
+    expect(body.quotaRefresh).toEqual({
+      enabled: true,
+      intervalMinutes: 30,
+      startupDelaySeconds: 0,
+      staggerMinSeconds: 7,
+      staggerMaxSeconds: 7,
+    })
+  })
+})
+
+test("POST /api/admin/config refreshes the running quota scheduler config", async () => {
+  await withConfig({}, async () => {
+    const runtime = await import("../src/lib/quota-refresh-scheduler-runtime")
+    const originalStart = runtime.quotaRefreshScheduler.start.bind(
+      runtime.quotaRefreshScheduler,
+    )
+    const originalStop = runtime.quotaRefreshScheduler.stop.bind(
+      runtime.quotaRefreshScheduler,
+    )
+    const originalUpdateConfig =
+      runtime.quotaRefreshScheduler.updateConfig.bind(
+        runtime.quotaRefreshScheduler,
+      )
+    let starts = 0
+    let updates = 0
+
+    runtime.quotaRefreshScheduler.start = () => {
+      starts += 1
+    }
+    runtime.quotaRefreshScheduler.stop = () => {}
+    runtime.quotaRefreshScheduler.updateConfig = () => {
+      updates += 1
+    }
+
+    try {
+      runtime.startQuotaRefreshSchedulerFromConfig()
+      const { server } = await import("../src/server")
+
+      const res = await server.fetch(
+        new Request("http://localhost/api/admin/config", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            quotaRefresh: {
+              enabled: false,
+            },
+          }),
+        }),
+      )
+
+      expect(res.status).toBe(200)
+      expect(starts).toBe(1)
+      expect(updates).toBe(1)
+    } finally {
+      runtime.quotaRefreshScheduler.start = originalStart
+      runtime.quotaRefreshScheduler.stop = originalStop
+      runtime.quotaRefreshScheduler.updateConfig = originalUpdateConfig
+      runtime.stopQuotaRefreshScheduler()
+    }
+  })
+})
+
+test("POST /api/admin/config rejects invalid quotaRefresh fields", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          quotaRefresh: {
+            enabled: "yes",
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toBe("quotaRefresh.enabled must be a boolean")
+  })
+})


### PR DESCRIPTION
## Summary
- Add a configurable background scheduler for Premium quota refreshes across enabled, initialized accounts.
- Wire scheduler startup, shutdown cleanup, and admin config updates without changing request-path quota behavior.
- Cover scheduler lifecycle, filtering, failure isolation, config updates, and quota error handling with tests.

## Test plan
- [x] bun test
- [x] bun run typecheck
- [x] bun run lint
- [x] bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 引入账户配额自动刷新机制，定期更新账户配额信息
  * 新增配额刷新配置选项，支持自定义启用状态、刷新间隔、启动延迟和刷新策略

<!-- end of auto-generated comment: release notes by coderabbit.ai -->