### PR TITLE
fix: support managed GitHub logins with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The `auth` command has three subcommands for managing multiple accounts:
 | --force   | Skip confirmation prompt | false   | -f    |
 | --verbose | Enable verbose logging   | false   | -v    |
 
-The `<target>` can be either the account ID (GitHub username) or a 1-based index.
+The `<target>` can be either the account ID (GitHub login) or a 1-based index.
 
 ### Debug Command Options
 
@@ -582,7 +582,7 @@ npx @nick3/copilot-api@latest auth ls -q
 # Remove an account by index (1-based)
 npx @nick3/copilot-api@latest auth rm 2
 
-# Remove an account by ID (GitHub username)
+# Remove an account by ID (GitHub login)
 npx @nick3/copilot-api@latest auth rm octocat
 
 # Show your Copilot usage/quota in the terminal (no server needed)

--- a/src/lib/accounts-registry.ts
+++ b/src/lib/accounts-registry.ts
@@ -19,18 +19,14 @@ import { accountTokenPath, PATHS } from "~/lib/paths"
 /**
  * Validate account ID (GitHub login).
  * Rules:
- * - Only alphanumeric characters, underscores, or single hyphens
  * - 1-39 chars
- * - Cannot begin or end with a hyphen or underscore
- * - No consecutive hyphens or underscores
+ * - Alphanumeric segments may be separated by single hyphens or underscores
+ * - Cannot begin or end with a separator
+ * - No consecutive separators
  */
 export function validateAccountId(id: string): boolean {
   if (id.length === 0 || id.length > 39) return false
-  if (!/^[\w-]+$/.test(id)) return false
-  if (id.startsWith("-") || id.endsWith("-")) return false
-  if (id.startsWith("_") || id.endsWith("_")) return false
-  if (id.includes("--") || id.includes("__")) return false
-  return true
+  return /^[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*$/u.test(id)
 }
 
 function assertValidAccountId(id: string): void {
@@ -40,7 +36,7 @@ function assertValidAccountId(id: string): void {
 }
 
 const ACCOUNT_ID_VALIDATION_RULES =
-  "1-39 chars, alphanumeric, underscores, or single hyphens, no leading/trailing underscore or hyphen, no consecutive underscores or hyphens."
+  "1-39 chars, alphanumeric with optional single hyphen/underscore separators, no leading/trailing separator, no consecutive separators."
 
 const accountMetaSchema = z.object({
   id: z.string().refine(validateAccountId, {

--- a/src/lib/accounts-registry.ts
+++ b/src/lib/accounts-registry.ts
@@ -19,23 +19,32 @@ import { accountTokenPath, PATHS } from "~/lib/paths"
 /**
  * Validate account ID (GitHub login).
  * Rules:
- * - Only alphanumeric characters or single hyphens
+ * - Only alphanumeric characters, underscores, or single hyphens
  * - 1-39 chars
- * - Cannot begin or end with a hyphen
- * - No consecutive hyphens
+ * - Cannot begin or end with a hyphen or underscore
+ * - No consecutive hyphens or underscores
  */
 export function validateAccountId(id: string): boolean {
   if (id.length === 0 || id.length > 39) return false
-  if (!/^[a-z0-9-]+$/i.test(id)) return false
+  if (!/^[\w-]+$/.test(id)) return false
   if (id.startsWith("-") || id.endsWith("-")) return false
-  if (id.includes("--")) return false
+  if (id.startsWith("_") || id.endsWith("_")) return false
+  if (id.includes("--") || id.includes("__")) return false
   return true
 }
 
+function assertValidAccountId(id: string): void {
+  if (!validateAccountId(id)) {
+    throw new Error(`Invalid account ID: ${id}`)
+  }
+}
+
+const ACCOUNT_ID_VALIDATION_RULES =
+  "1-39 chars, alphanumeric, underscores, or single hyphens, no leading/trailing underscore or hyphen, no consecutive underscores or hyphens."
+
 const accountMetaSchema = z.object({
   id: z.string().refine(validateAccountId, {
-    message:
-      "Invalid account id. Expected a GitHub login (1-39 chars, alphanumeric or single hyphens, no leading/trailing hyphen, no consecutive hyphens).",
+    message: `Invalid account id. Expected a GitHub login (${ACCOUNT_ID_VALIDATION_RULES})`,
   }),
   accountType: z.enum(["individual", "business", "enterprise"]),
   addedAt: z.number(),
@@ -52,8 +61,7 @@ export function isAccountEnabled(meta: AccountMeta): boolean {
 
 const accountClientIdentitySchema = z.object({
   login: z.string().refine(validateAccountId, {
-    message:
-      "Invalid client identity login. Expected a GitHub login (1-39 chars, alphanumeric or single hyphens, no leading/trailing hyphen, no consecutive hyphens).",
+    message: `Invalid client identity login. Expected a GitHub login (${ACCOUNT_ID_VALIDATION_RULES})`,
   }),
   oauthApp: z.string().min(1),
   enterpriseDomain: z.string().min(1),
@@ -337,9 +345,7 @@ export async function ensureAccountClientIdentity({
   oauthApp: string
   enterpriseDomain: string
 }): Promise<AccountClientIdentity> {
-  if (!validateAccountId(login)) {
-    throw new Error(`Invalid account ID: ${login}`)
-  }
+  assertValidAccountId(login)
 
   const normalizedOauthApp = oauthApp.trim()
   if (!normalizedOauthApp) {
@@ -399,9 +405,7 @@ export async function ensureAccountClientIdentity({
  * The account is appended to the end of the list (lowest priority).
  */
 export async function addAccountToRegistry(meta: AccountMeta): Promise<void> {
-  if (!validateAccountId(meta.id)) {
-    throw new Error(`Invalid account ID: ${meta.id}`)
-  }
+  assertValidAccountId(meta.id)
 
   await runWithRegistryLock(async () => {
     const { registry } = await loadRegistrySnapshot()
@@ -465,9 +469,7 @@ export async function listAccountsFromRegistry(): Promise<Array<AccountMeta>> {
  * Returns null if the token file doesn't exist.
  */
 export async function loadAccountToken(id: string): Promise<string | null> {
-  if (!validateAccountId(id)) {
-    throw new Error(`Invalid account ID: ${id}`)
-  }
+  assertValidAccountId(id)
 
   try {
     const tokenPath = accountTokenPath(id)
@@ -488,9 +490,7 @@ export async function saveAccountToken(
   id: string,
   token: string,
 ): Promise<void> {
-  if (!validateAccountId(id)) {
-    throw new Error(`Invalid account ID: ${id}`)
-  }
+  assertValidAccountId(id)
 
   const tokenPath = accountTokenPath(id)
   await fs.writeFile(tokenPath, token, { mode: 0o600 })
@@ -500,9 +500,7 @@ export async function saveAccountToken(
  * Remove the GitHub token file for a specific account.
  */
 export async function removeAccountToken(id: string): Promise<void> {
-  if (!validateAccountId(id)) {
-    throw new Error(`Invalid account ID: ${id}`)
-  }
+  assertValidAccountId(id)
 
   const tokenPath = accountTokenPath(id)
   try {

--- a/src/lib/types/account.ts
+++ b/src/lib/types/account.ts
@@ -33,7 +33,7 @@ export function parseAccountType(value: unknown): AccountType {
  * Metadata for a registered account, stored in the registry file.
  */
 export interface AccountMeta {
-  /** GitHub login (username) */
+  /** GitHub login */
   id: string
   /** Account subscription type */
   accountType: AccountType

--- a/tests/accounts-registry.test.ts
+++ b/tests/accounts-registry.test.ts
@@ -5,6 +5,7 @@ import type { AccountClientIdentity } from "../src/lib/types/account"
 
 import { buildIdentityKey } from "../src/lib/account-client-identity"
 import {
+  addAccountToRegistry,
   ensureAccountClientIdentity,
   getAccountClientIdentity,
   hasRegistry,
@@ -86,13 +87,49 @@ test("validateAccountId follows GitHub login rules", () => {
   expect(validateAccountId("octocat")).toBe(true)
   expect(validateAccountId("a-1")).toBe(true)
   expect(validateAccountId("A1")).toBe(true)
+  expect(validateAccountId("a_b")).toBe(true)
+  expect(validateAccountId("username_company")).toBe(true)
 
   // invalid
-  expect(validateAccountId("a_b")).toBe(false)
+  expect(validateAccountId("_abc")).toBe(false)
+  expect(validateAccountId("abc_")).toBe(false)
   expect(validateAccountId("-abc")).toBe(false)
   expect(validateAccountId("abc-")).toBe(false)
+  expect(validateAccountId("a__b")).toBe(false)
   expect(validateAccountId("a--b")).toBe(false)
   expect(validateAccountId("a".repeat(40))).toBe(false)
+})
+
+test("addAccountToRegistry accepts managed user logins with underscores", async () => {
+  let storedContent = ""
+
+  await withMockedFs(
+    {
+      readFile: (() => "   \n") as unknown as ReadFile,
+      writeFile: ((
+        _path: Parameters<WriteFile>[0],
+        data: Parameters<WriteFile>[1],
+      ) => {
+        storedContent = toWrittenString(data)
+        return Promise.resolve()
+      }) as unknown as WriteFile,
+    },
+    () =>
+      addAccountToRegistry({
+        id: "username_company",
+        accountType: "enterprise",
+        addedAt: 1,
+      }),
+  )
+
+  expect(JSON.parse(storedContent)).toMatchObject({
+    accounts: [{ id: "username_company" }],
+    clientIdentities: {
+      "public:default:username_company": {
+        login: "username_company",
+      },
+    },
+  })
 })
 
 test("loadRegistry returns empty registry on ENOENT", async () => {

--- a/tests/accounts-registry.test.ts
+++ b/tests/accounts-registry.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, expect, test } from "bun:test"
 import fs from "node:fs/promises"
 
-import type { AccountClientIdentity } from "../src/lib/types/account"
+import type { AccountClientIdentity } from "~/lib/types/account"
 
-import { buildIdentityKey } from "../src/lib/account-client-identity"
+import { buildIdentityKey } from "~/lib/account-client-identity"
 import {
   addAccountToRegistry,
   ensureAccountClientIdentity,
@@ -11,7 +11,7 @@ import {
   hasRegistry,
   loadRegistry,
   validateAccountId,
-} from "../src/lib/accounts-registry"
+} from "~/lib/accounts-registry"
 
 type ReadFile = typeof fs.readFile
 type WriteFile = typeof fs.writeFile
@@ -97,6 +97,8 @@ test("validateAccountId follows GitHub login rules", () => {
   expect(validateAccountId("abc-")).toBe(false)
   expect(validateAccountId("a__b")).toBe(false)
   expect(validateAccountId("a--b")).toBe(false)
+  expect(validateAccountId("a-_b")).toBe(false)
+  expect(validateAccountId("a_-b")).toBe(false)
   expect(validateAccountId("a".repeat(40))).toBe(false)
 })
 


### PR DESCRIPTION
## Summary
- Allow managed GitHub account logins with underscores in account ID validation
- Keep underscore placement constrained to avoid leading, trailing, or consecutive separators
- Update registry tests and docs to use GitHub login terminology

## Test plan
- [x] bun test tests/accounts-registry.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档
* 澄清 `auth rm` 命令参数接受 GitHub 账户 ID（登录名）而非用户名

## 功能改进
* 增强账户 ID 验证规则，现已支持包含下划线的账户标识符
* 优化账户标识符有效性检查逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->