### PR TITLE
Fix Responses item ownership affinity

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -50,6 +50,8 @@ type AdminRequestItemWire = {
   affinity_key_used?: string | null
   affinity_key_source?: string | null
   selection_reason?: string | null
+  responses_item_owner_lookup_keys_json?: string | null
+  responses_item_owner_recorded_keys_json?: string | null
   upstream_error_message_raw?: string | null
 
   has_outbound?: boolean

--- a/admin-ui/src/lib/request-detail-ownership.ts
+++ b/admin-ui/src/lib/request-detail-ownership.ts
@@ -1,0 +1,52 @@
+import type { AdminRequestItem } from "./admin-api"
+
+const EMPTY = "—"
+
+type ResponsesItemOwnerFields = Pick<
+  AdminRequestItem,
+  | "responses_item_owner_lookup_keys_json"
+  | "responses_item_owner_recorded_keys_json"
+>
+
+export type RequestDetailResponsesItemOwnerRow = {
+  labelKey: string
+  tooltipKey: string
+  value: string
+}
+
+export function buildRequestDetailResponsesItemOwnerRows(
+  item: Partial<ResponsesItemOwnerFields>,
+): Array<RequestDetailResponsesItemOwnerRow> {
+  return [
+    {
+      labelKey: "requestDetailPage.fields.responsesItemOwnerLookupKeys",
+      tooltipKey: "requestDetailPage.fieldTooltip.responsesItemOwnerLookupKeys",
+      value: formatOwnerKeys(item.responses_item_owner_lookup_keys_json),
+    },
+    {
+      labelKey: "requestDetailPage.fields.responsesItemOwnerRecordedKeys",
+      tooltipKey: "requestDetailPage.fieldTooltip.responsesItemOwnerRecordedKeys",
+      value: formatOwnerKeys(item.responses_item_owner_recorded_keys_json),
+    },
+  ]
+}
+
+function formatOwnerKeys(raw: string | null | undefined): string {
+  if (!raw) {
+    return EMPTY
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) {
+      return raw
+    }
+
+    const values = parsed.filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    )
+    return values.length > 0 ? values.join("\n") : EMPTY
+  } catch {
+    return raw
+  }
+}

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -317,6 +317,8 @@
       "affinityKeyUsed": "Affinity Key Used",
       "affinityKeySource": "Affinity Key Source",
       "selectionReason": "Selection Reason",
+      "responsesItemOwnerLookupKeys": "Responses Item Owner Lookup Keys",
+      "responsesItemOwnerRecordedKeys": "Responses Item Owner Recorded Keys",
       "upstreamErrorMessageRaw": "Upstream Error (Raw)",
       "duration": "Duration (s)",
       "ttfb": "TTFB (s)"
@@ -340,6 +342,8 @@
       "affinityKeyUsed": "The exact key value used when evaluating account affinity for this request",
       "affinityKeySource": "Where the affinity key came from: prompt_cache_key, metadata.session_id, x-session-id, or request-id fallback",
       "selectionReason": "High-level reason recorded by the account selector for why this account was chosen",
+      "responsesItemOwnerLookupKeys": "Hashed Responses reasoning or compaction item owner keys extracted from this request before account selection",
+      "responsesItemOwnerRecordedKeys": "Hashed Responses reasoning or compaction item owner keys recorded from the successful upstream response",
       "upstreamErrorMessageRaw": "Sanitized raw upstream error message captured for debugging and ownership-mismatch analysis",
       "duration": "Total request processing time in seconds",
       "ttfb": "Time to first byte in seconds — latency before the first response chunk"

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -317,6 +317,8 @@
       "affinityKeyUsed": "实际使用的亲和性键",
       "affinityKeySource": "亲和性键来源",
       "selectionReason": "选中原因",
+      "responsesItemOwnerLookupKeys": "Responses Item Owner 查询键",
+      "responsesItemOwnerRecordedKeys": "Responses Item Owner 记录键",
       "upstreamErrorMessageRaw": "上游原始错误（脱敏后）",
       "duration": "耗时（s）",
       "ttfb": "首字节（s）"
@@ -340,6 +342,8 @@
       "affinityKeyUsed": "本次请求在评估账号亲和性时实际使用的键值",
       "affinityKeySource": "亲和性键的来源：prompt_cache_key、metadata.session_id、x-session-id，或 request-id 回退值",
       "selectionReason": "账号选择器记录的高层原因，用于解释这次为何选中当前账号",
+      "responsesItemOwnerLookupKeys": "账号选择前从本次请求里的 Responses reasoning 或 compaction 历史项提取的哈希归属键",
+      "responsesItemOwnerRecordedKeys": "上游请求成功后从 Responses reasoning 或 compaction 输出项记录的哈希归属键",
       "upstreamErrorMessageRaw": "为调试和所有权不匹配分析保存的、已脱敏的上游原始错误消息",
       "duration": "请求总处理时间（秒）",
       "ttfb": "首字节时间（秒）— 收到第一个响应块前的延迟"

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/admin-api"
 import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
+import { buildRequestDetailResponsesItemOwnerRows } from "@/lib/request-detail-ownership"
 import { JsonViewer } from "@/components/json/json-viewer"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -524,6 +525,19 @@ export function RequestDetailPage(): React.JSX.Element {
                     </TableCell>
                   </TableRow>
                 ) : null}
+                {buildRequestDetailResponsesItemOwnerRows(item).map((row) => (
+                  <TableRow key={row.labelKey}>
+                    <TableCell className="text-muted-foreground">
+                      <FieldLabel
+                        label={t(row.labelKey)}
+                        tooltip={t(row.tooltipKey)}
+                      />
+                    </TableCell>
+                    <TableCell className="font-mono text-xs whitespace-pre-wrap break-words">
+                      {row.value}
+                    </TableCell>
+                  </TableRow>
+                ))}
                 <TableRow>
                   <TableCell className="text-muted-foreground">
                     <FieldLabel

--- a/admin-ui/tests/request-detail-ownership.test.ts
+++ b/admin-ui/tests/request-detail-ownership.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+
+import { buildRequestDetailResponsesItemOwnerRows } from "../src/lib/request-detail-ownership"
+
+test("buildRequestDetailResponsesItemOwnerRows exposes lookup and recorded keys", () => {
+  const rows = buildRequestDetailResponsesItemOwnerRows({
+    responses_item_owner_lookup_keys_json: JSON.stringify(["lookup-key"]),
+    responses_item_owner_recorded_keys_json: JSON.stringify(["recorded-key"]),
+  })
+
+  expect(rows).toEqual([
+    {
+      labelKey: "requestDetailPage.fields.responsesItemOwnerLookupKeys",
+      tooltipKey: "requestDetailPage.fieldTooltip.responsesItemOwnerLookupKeys",
+      value: "lookup-key",
+    },
+    {
+      labelKey: "requestDetailPage.fields.responsesItemOwnerRecordedKeys",
+      tooltipKey:
+        "requestDetailPage.fieldTooltip.responsesItemOwnerRecordedKeys",
+      value: "recorded-key",
+    },
+  ])
+})
+
+test("buildRequestDetailResponsesItemOwnerRows uses placeholder for empty keys", () => {
+  const rows = buildRequestDetailResponsesItemOwnerRows({})
+
+  expect(rows.map((row) => row.value)).toEqual(["—", "—"])
+})

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -99,6 +99,7 @@ export type { AffinityContext } from "~/lib/account-affinity"
 export type AccountSelectionContext = AffinityContext & {
   ownershipLookupSessionId?: string
   ownershipWriteSessionId?: string
+  responsesItemOwnershipKeys?: ReadonlyArray<string>
 }
 
 export type SelectAccountForRequestFailureReason =
@@ -116,6 +117,7 @@ export type AccountSelectionReason =
   | "subagent_owner_miss"
   | "subagent_owner_unusable_fallback"
   | "subagent_marker_invalid_fallback"
+  | "responses_item_owner_hit"
 
 type SelectAccountForRequestSuccess = {
   ok: true
@@ -173,6 +175,14 @@ function preserveSubagentSelectionReason(
   return initialSelectionReason.startsWith("subagent_") ?
       initialSelectionReason
     : nextSelectionReason
+}
+
+function normalizeCacheKeys(keys?: ReadonlyArray<string>): Array<string> {
+  if (!keys) {
+    return []
+  }
+
+  return [...new Set(keys.map((key) => key.trim()).filter(Boolean))]
 }
 
 type ScoredAccountRuntime = {
@@ -1073,6 +1083,19 @@ export class AccountsManager {
     }
 
     const orderedAccounts = this.getOrderedEnabledAccounts()
+    const itemOwnerSelection = await this.selectPreferredResponsesItemOwner({
+      ownershipKeys: context?.responsesItemOwnershipKeys,
+      orderedAccounts,
+      candidates,
+    })
+    if (itemOwnerSelection.result) {
+      this.attachConfirmOwnership(
+        itemOwnerSelection.result,
+        context?.ownershipWriteSessionId,
+      )
+      return itemOwnerSelection.result
+    }
+
     const ownerSelection = await this.selectPreferredSessionOwner({
       lookupSessionId: context?.ownershipLookupSessionId,
       orderedAccounts,
@@ -1222,6 +1245,20 @@ export class AccountsManager {
     this.affinityCache.delete(normalizedCacheKey)
   }
 
+  recordResponsesItemOwnership(
+    ownershipKeys: ReadonlyArray<string>,
+    accountId: string,
+  ): void {
+    const normalizedAccountId = accountId.trim()
+    if (!normalizedAccountId) {
+      return
+    }
+
+    for (const key of normalizeCacheKeys(ownershipKeys)) {
+      this.affinityCache.set(key, normalizedAccountId)
+    }
+  }
+
   private attachConfirmOwnership(
     result: SelectAccountForRequestSuccess,
     ownershipWriteSessionId: string | undefined,
@@ -1238,6 +1275,48 @@ export class AccountsManager {
       }
       this.sessionOwnership.set(rootSessionId, result.account.id)
     }
+  }
+
+  private async selectPreferredResponsesItemOwner(params: {
+    ownershipKeys: ReadonlyArray<string> | undefined
+    orderedAccounts: Array<AccountRuntime>
+    candidates: Array<AccountRequestCandidate>
+  }): Promise<{
+    result?: SelectAccountForRequestSuccess
+  }> {
+    const { orderedAccounts, candidates } = params
+    const ownershipKeys = normalizeCacheKeys(params.ownershipKeys)
+    if (ownershipKeys.length === 0) {
+      return {}
+    }
+
+    const accountIds = new Map<string, string>()
+    for (const key of ownershipKeys) {
+      const accountId = this.affinityCache.get(key)
+      if (accountId) {
+        accountIds.set(accountId, key)
+      }
+    }
+
+    if (accountIds.size !== 1) {
+      return {}
+    }
+
+    const [[accountId, ownerKey]] = [...accountIds]
+    const ownerResult = await this.tryAffinityAccount(
+      accountId,
+      orderedAccounts,
+      candidates,
+    )
+    if (!ownerResult) {
+      return {}
+    }
+
+    ownerResult.affinityHit = true
+    ownerResult.affinityCacheKey = ownerKey
+    ownerResult.selectionReason = "responses_item_owner_hit"
+
+    return { result: ownerResult }
   }
 
   private async selectPreferredSessionOwner(params: {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1249,6 +1249,10 @@ export class AccountsManager {
     ownershipKeys: ReadonlyArray<string>,
     accountId: string,
   ): void {
+    if (!this.accountAffinityEnabled) {
+      return
+    }
+
     const normalizedAccountId = accountId.trim()
     if (!normalizedAccountId) {
       return
@@ -1284,6 +1288,10 @@ export class AccountsManager {
   }): Promise<{
     result?: SelectAccountForRequestSuccess
   }> {
+    if (!this.accountAffinityEnabled) {
+      return {}
+    }
+
     const { orderedAccounts, candidates } = params
     const ownershipKeys = normalizeCacheKeys(params.ownershipKeys)
     if (ownershipKeys.length === 0) {
@@ -1299,6 +1307,15 @@ export class AccountsManager {
     }
 
     if (accountIds.size !== 1) {
+      if (accountIds.size > 1) {
+        consola.warn(
+          "Conflicting Responses item owner mappings; falling back",
+          {
+            accountIds: [...accountIds.keys()],
+            ownershipKeyCount: ownershipKeys.length,
+          },
+        )
+      }
       return {}
     }
 
@@ -1309,6 +1326,9 @@ export class AccountsManager {
       candidates,
     )
     if (!ownerResult) {
+      if (this.isMissingOrDisabledAccount(accountId, orderedAccounts)) {
+        this.deleteResponsesItemOwnershipMappings(ownershipKeys, accountId)
+      }
       return {}
     }
 
@@ -1317,6 +1337,24 @@ export class AccountsManager {
     ownerResult.selectionReason = "responses_item_owner_hit"
 
     return { result: ownerResult }
+  }
+
+  private isMissingOrDisabledAccount(
+    accountId: string,
+    orderedAccounts: ReadonlyArray<AccountRuntime>,
+  ): boolean {
+    return !orderedAccounts.some((account) => account.id === accountId)
+  }
+
+  private deleteResponsesItemOwnershipMappings(
+    ownershipKeys: ReadonlyArray<string>,
+    accountId: string,
+  ): void {
+    for (const key of ownershipKeys) {
+      if (this.affinityCache.get(key) === accountId) {
+        this.affinityCache.delete(key)
+      }
+    }
   }
 
   private async selectPreferredSessionOwner(params: {

--- a/src/lib/admin-db.ts
+++ b/src/lib/admin-db.ts
@@ -320,7 +320,23 @@ function migrateV12(db: Database): void {
   db.run("PRAGMA user_version = 12;")
 }
 
-function migrateV8ToV12(db: Database, current: number): void {
+function migrateV13(db: Database): void {
+  if (!hasRequestLogColumn(db, "responses_item_owner_lookup_keys_json")) {
+    db.run(
+      "ALTER TABLE request_log ADD COLUMN responses_item_owner_lookup_keys_json TEXT;",
+    )
+  }
+
+  if (!hasRequestLogColumn(db, "responses_item_owner_recorded_keys_json")) {
+    db.run(
+      "ALTER TABLE request_log ADD COLUMN responses_item_owner_recorded_keys_json TEXT;",
+    )
+  }
+
+  db.run("PRAGMA user_version = 13;")
+}
+
+function migrateV8ToV13(db: Database, current: number): void {
   if (current < 8) {
     migrateV8(db)
   }
@@ -340,6 +356,10 @@ function migrateV8ToV12(db: Database, current: number): void {
   if (current < 12) {
     migrateV12(db)
   }
+
+  if (current < 13) {
+    migrateV13(db)
+  }
 }
 
 // eslint-disable-next-line complexity -- migration chain grows with each version
@@ -349,9 +369,13 @@ function migrateAdminDb(db: Database): void {
   } | null
   const current = row?.user_version ?? 0
 
-  if (current >= 12) {
-    if (current === 12) migrateV12(db)
+  if (current >= 13) {
+    if (current === 13) migrateV13(db)
     return
+  }
+
+  if (current === 12) {
+    migrateV12(db)
   }
 
   if (current === 11) {
@@ -450,5 +474,5 @@ function migrateAdminDb(db: Database): void {
     db.run("PRAGMA user_version = 7;")
   }
 
-  migrateV8ToV12(db, current)
+  migrateV8ToV13(db, current)
 }

--- a/src/lib/request-history.ts
+++ b/src/lib/request-history.ts
@@ -206,6 +206,8 @@ export type RequestLogInsert = {
   affinityKeyUsed?: string
   affinityKeySource?: AffinityKeySource
   selectionReason?: AccountSelectionReason
+  responsesItemOwnerLookupKeysJson?: string
+  responsesItemOwnerRecordedKeysJson?: string
 
   tokensInput?: number
   tokensOutput?: number
@@ -268,6 +270,8 @@ export type RequestLogRow = {
   affinity_key_used: string | null
   affinity_key_source: string | null
   selection_reason: string | null
+  responses_item_owner_lookup_keys_json: string | null
+  responses_item_owner_recorded_keys_json: string | null
 
   tokens_input: number | null
   tokens_output: number | null
@@ -400,6 +404,8 @@ function buildInsertArgs(record: RequestLogInsert) {
     toDbNull(record.affinityKeyUsed),
     toDbNull(record.affinityKeySource),
     toDbNull(record.selectionReason),
+    toDbNull(record.responsesItemOwnerLookupKeysJson),
+    toDbNull(record.responsesItemOwnerRecordedKeysJson),
 
     toDbNull(record.tokensInput),
     toDbNull(record.tokensOutput),
@@ -470,6 +476,8 @@ export class RequestHistoryStore {
       "affinity_key_used",
       "affinity_key_source",
       "selection_reason",
+      "responses_item_owner_lookup_keys_json",
+      "responses_item_owner_recorded_keys_json",
       "tokens_input",
       "tokens_output",
       "tokens_total",

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -50,6 +50,11 @@ import {
   resolveAffinityKey,
 } from "~/lib/utils"
 import {
+  extractAnthropicResponsesItemOwnerKeys,
+  extractResponsesResultOwnerKeys,
+  extractResponsesStreamEventOwnerKeys,
+} from "~/routes/messages/responses-item-ownership"
+import {
   buildErrorEvent,
   createResponsesStreamState,
   translateResponsesStreamEvent,
@@ -148,6 +153,8 @@ type InstrumentationContext = {
   affinityKeyUsed?: string
   affinityKeySource?: AffinityKeySource
   selectionReason?: AccountSelectionReason
+  responsesItemOwnerLookupKeys?: ReadonlyArray<string>
+  responsesItemOwnerRecordedKeys?: ReadonlyArray<string>
 
   clientModel: string
 
@@ -303,12 +310,15 @@ export async function handleCompletion(c: Context) {
     headerSessionId,
     upstreamRequestId,
   })
+  const responsesItemOwnershipKeys =
+    extractAnthropicResponsesItemOwnerKeys(anthropicPayload)
 
   const selection = await accountsManager.selectAccountForRequest(candidates, {
     requestId: affinityKey.requestId,
     affinityModelId,
     ownershipLookupSessionId,
     ownershipWriteSessionId,
+    responsesItemOwnershipKeys,
   })
   const selectionReason =
     invalidSubagentMarkerSelectionReason ?? selection.selectionReason
@@ -373,6 +383,7 @@ export async function handleCompletion(c: Context) {
     affinityKeyUsed: affinityKey.affinityKeyUsed,
     affinityKeySource: affinityKey.affinityKeySource,
     selectionReason,
+    responsesItemOwnerLookupKeys: responsesItemOwnershipKeys,
   }
   if (endpoint === MESSAGES_ENDPOINT) {
     return await handleWithMessagesApi({
@@ -619,6 +630,10 @@ type ChatCompletionsStream = Exclude<
 
 type MessagesResult = Awaited<ReturnType<typeof createMessages>>
 
+function stringifyOwnerKeys(keys?: ReadonlyArray<string>): string | undefined {
+  return keys && keys.length > 0 ? JSON.stringify(keys) : undefined
+}
+
 function insertRequestLog(
   instr: InstrumentationContext,
   record: Omit<
@@ -689,6 +704,12 @@ function insertRequestLog(
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     ...record,
+    responsesItemOwnerLookupKeysJson: stringifyOwnerKeys(
+      instr.responsesItemOwnerLookupKeys,
+    ),
+    responsesItemOwnerRecordedKeysJson: stringifyOwnerKeys(
+      instr.responsesItemOwnerRecordedKeys,
+    ),
   })
   void flushPendingCapture(requestId)
 }
@@ -987,6 +1008,12 @@ async function handleResponsesNonStreaming(params: {
 
   try {
     usage = extractResponsesUsageFromResult(result)
+    const responseOwnerKeys = extractResponsesResultOwnerKeys(result)
+    instr.responsesItemOwnerRecordedKeys = responseOwnerKeys
+    accountsManager.recordResponsesItemOwnership(
+      responseOwnerKeys,
+      instr.account.id,
+    )
 
     logger.debug(
       "Non-streaming Responses result:",
@@ -1075,6 +1102,42 @@ async function writeAnthropicStreamError(
   }
 }
 
+function collectResponsesStreamOwnerKeys(
+  event: ResponseStreamEvent,
+  responseOwnerKeys: Set<string>,
+): void {
+  for (const key of extractResponsesStreamEventOwnerKeys(event)) {
+    responseOwnerKeys.add(key)
+  }
+}
+
+function createResponsesStreamStateWithUsage(params: {
+  estimatedInputTokens?: number
+  historicalUsage?: NormalizedUsage
+}): ReturnType<typeof createResponsesStreamState> {
+  const streamState = createResponsesStreamState()
+  streamState.estimatedInputTokens = params.estimatedInputTokens
+  streamState.historicalInputTokens = params.historicalUsage?.tokensInput
+  streamState.historicalOutputTokens = params.historicalUsage?.tokensOutput
+  streamState.historicalCachedInputTokens =
+    params.historicalUsage?.tokensCachedInput
+  return streamState
+}
+
+function recordStreamOwnerKeys(
+  streamState: ReturnType<typeof createResponsesStreamState>,
+  responseOwnerKeys: Set<string>,
+  instr: InstrumentationContext,
+): void {
+  if (!streamState.messageCompleted) {
+    return
+  }
+
+  const ownerKeys = [...responseOwnerKeys]
+  instr.responsesItemOwnerRecordedKeys = ownerKeys
+  accountsManager.recordResponsesItemOwnership(ownerKeys, instr.account.id)
+}
+
 async function streamResponsesAndLog(params: {
   stream: StreamSseStream
   response: AsyncIterable<unknown>
@@ -1082,8 +1145,7 @@ async function streamResponsesAndLog(params: {
   estimatedInputTokens?: number
   historicalUsage?: NormalizedUsage
 }): Promise<void> {
-  const { stream, response, instr, estimatedInputTokens, historicalUsage } =
-    params
+  const { stream, response, instr } = params
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
@@ -1093,11 +1155,8 @@ async function streamResponsesAndLog(params: {
   let errorMessage: string | undefined
   let upstreamErrorMessageRaw: string | undefined
 
-  const streamState = createResponsesStreamState()
-  streamState.estimatedInputTokens = estimatedInputTokens
-  streamState.historicalInputTokens = historicalUsage?.tokensInput
-  streamState.historicalOutputTokens = historicalUsage?.tokensOutput
-  streamState.historicalCachedInputTokens = historicalUsage?.tokensCachedInput
+  const streamState = createResponsesStreamStateWithUsage(params)
+  const responseOwnerKeys = new Set<string>()
 
   try {
     for await (const chunk of response) {
@@ -1119,6 +1178,7 @@ async function streamResponsesAndLog(params: {
       logger.debug("Responses raw stream event:", data)
 
       const parsed = JSON.parse(data) as ResponseStreamEvent
+      collectResponsesStreamOwnerKeys(parsed, responseOwnerKeys)
       const u = extractResponsesUsageFromStreamEvent(parsed)
       if (u.usageJson) {
         lastUsage = u
@@ -1148,6 +1208,8 @@ async function streamResponsesAndLog(params: {
         errorMessage = message
       },
     })
+
+    recordStreamOwnerKeys(streamState, responseOwnerKeys, instr)
   } catch (error) {
     const details = await extractErrorObservability(error)
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -343,6 +343,7 @@ export async function handleCompletion(c: Context) {
       affinityKeyUsed: affinityKey.affinityKeyUsed,
       affinityKeySource: affinityKey.affinityKeySource,
       selectionReason,
+      responsesItemOwnerLookupKeys: responsesItemOwnershipKeys,
       selection,
     })
   }
@@ -1010,10 +1011,6 @@ async function handleResponsesNonStreaming(params: {
     usage = extractResponsesUsageFromResult(result)
     const responseOwnerKeys = extractResponsesResultOwnerKeys(result)
     instr.responsesItemOwnerRecordedKeys = responseOwnerKeys
-    accountsManager.recordResponsesItemOwnership(
-      responseOwnerKeys,
-      instr.account.id,
-    )
 
     logger.debug(
       "Non-streaming Responses result:",
@@ -1023,7 +1020,15 @@ async function handleResponsesNonStreaming(params: {
     const anthropicResponse = translateResponsesResultToAnthropic(result)
     debugJson(logger, "Translated Anthropic response:", anthropicResponse)
 
-    return c.json(anthropicResponse)
+    const response = c.json(anthropicResponse)
+    if (result.status === "completed") {
+      accountsManager.recordResponsesItemOwnership(
+        responseOwnerKeys,
+        instr.account.id,
+      )
+    }
+
+    return response
   } catch (error) {
     const details = await extractErrorObservability(error)
 
@@ -1135,7 +1140,55 @@ function recordStreamOwnerKeys(
 
   const ownerKeys = [...responseOwnerKeys]
   instr.responsesItemOwnerRecordedKeys = ownerKeys
-  accountsManager.recordResponsesItemOwnership(ownerKeys, instr.account.id)
+  if (streamState.responseStatus === "completed") {
+    accountsManager.recordResponsesItemOwnership(ownerKeys, instr.account.id)
+  }
+}
+
+function getResponsesStreamEventError(event: ResponseStreamEvent):
+  | {
+      errorName: string
+      errorStatus: number
+      errorMessage: string
+      upstreamErrorMessageRaw: string
+    }
+  | undefined {
+  if (event.type === "response.failed") {
+    const message =
+      event.response.error?.message ?? "Responses stream failed upstream."
+    return {
+      errorName: "ResponsesStreamFailed",
+      errorStatus: 502,
+      errorMessage: message,
+      upstreamErrorMessageRaw: message,
+    }
+  }
+
+  if (event.type === "error") {
+    const message = event.message || "Responses stream returned an error."
+    return {
+      errorName: "ResponsesStreamError",
+      errorStatus: 502,
+      errorMessage: message,
+      upstreamErrorMessageRaw: message,
+    }
+  }
+
+  return undefined
+}
+
+async function writeTranslatedAnthropicStreamEvents(
+  stream: StreamSseStream,
+  events: Array<AnthropicStreamEventData>,
+): Promise<void> {
+  for (const event of events) {
+    const eventData = JSON.stringify(event)
+    logger.debug("Translated Anthropic event:", eventData)
+    await stream.writeSSE({
+      event: event.type,
+      data: eventData,
+    })
+  }
 }
 
 async function streamResponsesAndLog(params: {
@@ -1178,6 +1231,14 @@ async function streamResponsesAndLog(params: {
       logger.debug("Responses raw stream event:", data)
 
       const parsed = JSON.parse(data) as ResponseStreamEvent
+      const streamEventError = getResponsesStreamEventError(parsed)
+      if (streamEventError) {
+        errorName = streamEventError.errorName
+        errorStatus = streamEventError.errorStatus
+        errorMessage = streamEventError.errorMessage
+        upstreamErrorMessageRaw = streamEventError.upstreamErrorMessageRaw
+      }
+
       collectResponsesStreamOwnerKeys(parsed, responseOwnerKeys)
       const u = extractResponsesUsageFromStreamEvent(parsed)
       if (u.usageJson) {
@@ -1185,14 +1246,7 @@ async function streamResponsesAndLog(params: {
       }
 
       const events = translateResponsesStreamEvent(parsed, streamState)
-      for (const event of events) {
-        const eventData = JSON.stringify(event)
-        logger.debug("Translated Anthropic event:", eventData)
-        await stream.writeSSE({
-          event: event.type,
-          data: eventData,
-        })
-      }
+      await writeTranslatedAnthropicStreamEvents(stream, events)
 
       if (streamState.messageCompleted) {
         logger.debug("Message completed, ending stream")

--- a/src/routes/messages/responses-item-ownership.ts
+++ b/src/routes/messages/responses-item-ownership.ts
@@ -68,7 +68,10 @@ export function extractResponsesStreamEventOwnerKeys(
     return unique(keys)
   }
 
-  if (event.type === "response.completed") {
+  if (
+    event.type === "response.completed"
+    || event.type === "response.incomplete"
+  ) {
     return extractResponsesResultOwnerKeys(event.response)
   }
 

--- a/src/routes/messages/responses-item-ownership.ts
+++ b/src/routes/messages/responses-item-ownership.ts
@@ -1,0 +1,143 @@
+import { createHash } from "node:crypto"
+
+import type {
+  ResponseOutputItem,
+  ResponseStreamEvent,
+  ResponsesResult,
+} from "~/services/copilot/create-responses"
+
+import type { AnthropicMessagesPayload } from "./anthropic-types"
+
+import { decodeCompactionCarrierSignature } from "./responses-translation"
+
+type OwnershipKeyKind = "id" | "encrypted_content"
+
+type OwnerBearingOutputItem = Extract<
+  ResponseOutputItem,
+  { type: "reasoning" | "compaction" }
+>
+
+export function buildResponsesItemOwnershipKey(
+  kind: OwnershipKeyKind,
+  value: string,
+): string {
+  const digest = createHash("sha256").update(value).digest("hex")
+  return `responses-item-owner:${kind}:${digest}`
+}
+
+export function extractAnthropicResponsesItemOwnerKeys(
+  payload: AnthropicMessagesPayload,
+): Array<string> {
+  const keys: Array<string> = []
+
+  for (const message of payload.messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue
+    }
+
+    for (const block of message.content) {
+      if (block.type !== "thinking" || !block.signature) {
+        continue
+      }
+
+      addSignatureOwnerKeys(keys, block.signature)
+    }
+  }
+
+  return unique(keys)
+}
+
+export function extractResponsesResultOwnerKeys(
+  result: Pick<ResponsesResult, "output">,
+): Array<string> {
+  const keys: Array<string> = []
+
+  for (const item of result.output) {
+    addOutputItemOwnerKeys(keys, item)
+  }
+
+  return unique(keys)
+}
+
+export function extractResponsesStreamEventOwnerKeys(
+  event: ResponseStreamEvent,
+): Array<string> {
+  if (event.type === "response.output_item.done") {
+    const keys: Array<string> = []
+    addOutputItemOwnerKeys(keys, event.item)
+    return unique(keys)
+  }
+
+  if (event.type === "response.completed") {
+    return extractResponsesResultOwnerKeys(event.response)
+  }
+
+  return []
+}
+
+function addSignatureOwnerKeys(keys: Array<string>, signature: string): void {
+  if (signature.startsWith("cm1#")) {
+    const compaction = decodeCompactionCarrierSignature(signature)
+    if (compaction) {
+      addRawOwnerKeys(keys, compaction.id, compaction.encrypted_content)
+    }
+    return
+  }
+
+  const reasoning = parseReasoningSignature(signature)
+  if (!reasoning) {
+    return
+  }
+
+  addRawOwnerKeys(keys, reasoning.id, reasoning.encryptedContent)
+}
+
+function parseReasoningSignature(
+  signature: string,
+): { encryptedContent: string; id: string } | undefined {
+  const splitIndex = signature.lastIndexOf("@")
+  if (splitIndex <= 0 || splitIndex === signature.length - 1) {
+    return undefined
+  }
+
+  return {
+    encryptedContent: signature.slice(0, splitIndex),
+    id: signature.slice(splitIndex + 1),
+  }
+}
+
+function addOutputItemOwnerKeys(
+  keys: Array<string>,
+  item: ResponseOutputItem,
+): void {
+  if (!isOwnerBearingOutputItem(item)) {
+    return
+  }
+
+  addRawOwnerKeys(keys, item.id, item.encrypted_content)
+}
+
+function isOwnerBearingOutputItem(
+  item: ResponseOutputItem,
+): item is OwnerBearingOutputItem {
+  return item.type === "reasoning" || item.type === "compaction"
+}
+
+function addRawOwnerKeys(
+  keys: Array<string>,
+  id: string | undefined,
+  encryptedContent: string | undefined,
+): void {
+  if (id) {
+    keys.push(buildResponsesItemOwnershipKey("id", id))
+  }
+  if (encryptedContent) {
+    keys.push(
+      buildResponsesItemOwnershipKey("encrypted_content", encryptedContent),
+    )
+  }
+}
+
+function unique(values: Array<string>): Array<string> {
+  return [...new Set(values)]
+}

--- a/src/routes/messages/responses-stream-translation.ts
+++ b/src/routes/messages/responses-stream-translation.ts
@@ -66,6 +66,7 @@ export interface ResponsesStreamState {
   openBlocks: Set<number>
   blockHasDelta: Set<number>
   functionCallStateByOutputIndex: Map<number, FunctionCallStreamState>
+  responseStatus?: string
   estimatedInputTokens?: number
   historicalInputTokens?: number
   historicalOutputTokens?: number
@@ -469,6 +470,7 @@ const handleResponseCompleted = (
   const events = new Array<AnthropicStreamEventData>()
 
   closeAllOpenBlocks(state, events)
+  state.responseStatus = response.status
   const anthropic = translateResponsesResultToAnthropic(response)
   events.push(
     {
@@ -492,6 +494,7 @@ const handleResponseFailed = (
   const response = rawEvent.response
   const events = new Array<AnthropicStreamEventData>()
   closeAllOpenBlocks(state, events)
+  state.responseStatus = response.status
 
   const message =
     response.error?.message ?? "The response failed due to an unknown error."

--- a/src/routes/messages/utils.ts
+++ b/src/routes/messages/utils.ts
@@ -78,7 +78,12 @@ type SelectionFailureContext = {
   affinityKeyUsed?: string
   affinityKeySource?: AffinityKeySource
   selectionReason?: AccountSelectionReason
+  responsesItemOwnerLookupKeys?: ReadonlyArray<string>
   selection: SelectionFailure
+}
+
+function stringifyOwnerKeys(keys?: ReadonlyArray<string>): string | undefined {
+  return keys && keys.length > 0 ? JSON.stringify(keys) : undefined
 }
 
 export const isWarmupProbeRequest = (
@@ -137,6 +142,7 @@ export const handleSelectionFailure = (
     affinityKeyUsed,
     affinityKeySource,
     selectionReason,
+    responsesItemOwnerLookupKeys,
     selection,
   } = context
   const finishedAtMs = Date.now()
@@ -160,6 +166,9 @@ export const handleSelectionFailure = (
     isSubagent,
     affinityKeyUsed,
     affinityKeySource,
+    responsesItemOwnerLookupKeysJson: stringifyOwnerKeys(
+      responsesItemOwnerLookupKeys,
+    ),
     httpStatus: selection.reason === "MODEL_NOT_SUPPORTED" ? 400 : 429,
     selectionReason: selectionReason ?? selection.selectionReason,
     selectionFailureReason: selection.reason,

--- a/tests/accounts-manager-session-affinity.test.ts
+++ b/tests/accounts-manager-session-affinity.test.ts
@@ -6,6 +6,7 @@ import type { AccountRuntime } from "../src/lib/types/account"
 import { buildAffinityCacheKey } from "../src/lib/account-affinity"
 import { initAdminDb } from "../src/lib/admin-db"
 import { SessionAffinityStore } from "../src/lib/session-affinity-store"
+import { buildResponsesItemOwnershipKey } from "../src/routes/messages/responses-item-ownership"
 import {
   makeModel,
   makeModelsResponse,
@@ -57,6 +58,54 @@ test("persistent affinity: pre-written binding routes to the same account on fre
   expect(selection.account.id).toBe("b")
   expect(selection.affinityHit).toBe(true)
   expect(selection.selectionReason).toBe("affinity_hit")
+})
+
+test("responses item ownership routes before ordinary session affinity", async () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new SessionAffinityStore(db)
+
+  const model = makeModel({ id: "free-model" })
+  const affinityKey = buildAffinityCacheKey("session-1", "free-model")
+  const ownerKey = buildResponsesItemOwnershipKey("id", "rs_owner")
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  store.set(affinityKey, "a")
+  store.set(ownerKey, "b")
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: store,
+  })
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    {
+      requestId: "session-1",
+      responsesItemOwnershipKeys: [ownerKey],
+    },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("b")
+  expect(selection.affinityHit).toBe(true)
+  expect(selection.affinityCacheKey).toBe(ownerKey)
+  expect(selection.selectionReason).toBe("responses_item_owner_hit")
 })
 
 test("persistent affinity: stale binding pointing to unavailable account is purged and falls back", async () => {

--- a/tests/accounts-manager-session-affinity.test.ts
+++ b/tests/accounts-manager-session-affinity.test.ts
@@ -1,12 +1,13 @@
 import { Database } from "bun:sqlite"
 import { expect, test } from "bun:test"
 
-import type { AccountRuntime } from "../src/lib/types/account"
+import type { AccountRuntime } from "~/lib/types/account"
 
-import { buildAffinityCacheKey } from "../src/lib/account-affinity"
-import { initAdminDb } from "../src/lib/admin-db"
-import { SessionAffinityStore } from "../src/lib/session-affinity-store"
-import { buildResponsesItemOwnershipKey } from "../src/routes/messages/responses-item-ownership"
+import { buildAffinityCacheKey } from "~/lib/account-affinity"
+import { initAdminDb } from "~/lib/admin-db"
+import { SessionAffinityStore } from "~/lib/session-affinity-store"
+import { buildResponsesItemOwnershipKey } from "~/routes/messages/responses-item-ownership"
+
 import {
   makeModel,
   makeModelsResponse,
@@ -106,6 +107,168 @@ test("responses item ownership routes before ordinary session affinity", async (
   expect(selection.affinityHit).toBe(true)
   expect(selection.affinityCacheKey).toBe(ownerKey)
   expect(selection.selectionReason).toBe("responses_item_owner_hit")
+})
+
+test("responses item ownership lookup is ignored when account affinity is disabled", async () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new SessionAffinityStore(db)
+
+  const model = makeModel({ id: "free-model" })
+  const ownerKey = buildResponsesItemOwnershipKey("id", "rs_owner_disabled")
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  store.set(ownerKey, "b")
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: store,
+  })
+  manager.setAccountAffinityEnabled(false)
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    { responsesItemOwnershipKeys: [ownerKey] },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(selection.affinityHit).toBeUndefined()
+  expect(selection.selectionReason).toBe("no_session_key")
+})
+
+test("responses item ownership recording is skipped when account affinity is disabled", async () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new SessionAffinityStore(db)
+
+  const model = makeModel({ id: "free-model" })
+  const ownerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_record_disabled",
+  )
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: store,
+  })
+  manager.setAccountAffinityEnabled(false)
+  manager.recordResponsesItemOwnership([ownerKey], "b")
+  manager.setAccountAffinityEnabled(true)
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    { responsesItemOwnershipKeys: [ownerKey] },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(store.get(ownerKey)).toBeUndefined()
+})
+
+test("responses item ownership stale account mapping is purged and falls back", async () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new SessionAffinityStore(db)
+
+  const model = makeModel({ id: "free-model" })
+  const ownerKey = buildResponsesItemOwnershipKey("id", "rs_owner_stale")
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+
+  store.set(ownerKey, "ghost-account")
+
+  const manager = setupManager([accountA], { persistentAffinityStore: store })
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    { responsesItemOwnershipKeys: [ownerKey] },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(store.get(ownerKey)).toBeUndefined()
+})
+
+test("responses item ownership keeps mappings for temporarily failed accounts", async () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new SessionAffinityStore(db)
+
+  const model = makeModel({ id: "free-model" })
+  const ownerKey = buildResponsesItemOwnershipKey("id", "rs_owner_failed")
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    failed: true,
+    models: makeModelsResponse([model]),
+  }
+
+  store.set(ownerKey, "b")
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: store,
+  })
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    { responsesItemOwnershipKeys: [ownerKey] },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(store.get(ownerKey)).toBe("b")
 })
 
 test("persistent affinity: stale binding pointing to unavailable account is purged and falls back", async () => {

--- a/tests/admin-db-migrations.test.ts
+++ b/tests/admin-db-migrations.test.ts
@@ -25,6 +25,26 @@ test("initAdminDb creates Responses item owner request_log columns", () => {
   expect(columnNames).toContain("responses_item_owner_recorded_keys_json")
 })
 
+test("migrateV13 adds Responses item owner columns to v12 databases", () => {
+  const db = new Database(":memory:")
+  db.run("CREATE TABLE request_log (request_id TEXT PRIMARY KEY);")
+  db.run("PRAGMA user_version = 12;")
+
+  initAdminDb(db)
+
+  const columns = db.query("PRAGMA table_info(request_log);").all() as Array<{
+    name: string
+  }>
+  const columnNames = columns.map((column) => column.name)
+  const version = (
+    db.query("PRAGMA user_version;").get() as { user_version: number }
+  ).user_version
+
+  expect(columnNames).toContain("responses_item_owner_lookup_keys_json")
+  expect(columnNames).toContain("responses_item_owner_recorded_keys_json")
+  expect(version).toBeGreaterThanOrEqual(13)
+})
+
 test("migrateV11 creates request_outbound with FK cascade", () => {
   const db = new Database(":memory:")
   initAdminDb(db)

--- a/tests/admin-db-migrations.test.ts
+++ b/tests/admin-db-migrations.test.ts
@@ -12,6 +12,19 @@ function countTable(db: Database, name: string): number {
   return row.c
 }
 
+test("initAdminDb creates Responses item owner request_log columns", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+
+  const columns = db.query("PRAGMA table_info(request_log);").all() as Array<{
+    name: string
+  }>
+  const columnNames = columns.map((column) => column.name)
+
+  expect(columnNames).toContain("responses_item_owner_lookup_keys_json")
+  expect(columnNames).toContain("responses_item_owner_recorded_keys_json")
+})
+
 test("migrateV11 creates request_outbound with FK cascade", () => {
   const db = new Database(":memory:")
   initAdminDb(db)

--- a/tests/messages-handler-responses-ownership.test.ts
+++ b/tests/messages-handler-responses-ownership.test.ts
@@ -314,3 +314,215 @@ describe("messages handler Responses item ownership", () => {
     )
   })
 })
+
+describe("messages handler Responses item ownership review fixes", () => {
+  test("logs but does not cache owner keys from incomplete non-streaming Responses output", async () => {
+    const selection = buildSelection("/responses", "responses-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...buildResponsesResult("responses-model", "responses"),
+            status: "incomplete",
+            incomplete_details: { reason: "max_output_tokens" },
+            output: [
+              {
+                id: "rs_incomplete",
+                type: "reasoning",
+                summary: [],
+                encrypted_content: "enc-incomplete",
+                status: "incomplete",
+              },
+              {
+                id: "out_1",
+                type: "message",
+                role: "assistant",
+                status: "incomplete",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "responses",
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload()),
+      }),
+    )
+
+    const idKey = buildResponsesItemOwnershipKey("id", "rs_incomplete")
+    const encryptedKey = buildResponsesItemOwnershipKey(
+      "encrypted_content",
+      "enc-incomplete",
+    )
+    const row = getAdminDb()
+      .query(
+        `SELECT count(*) AS c FROM session_affinity
+         WHERE cache_key IN (?, ?);`,
+      )
+      .get(idKey, encryptedKey) as { c: number }
+
+    const requestLog = getAdminDb()
+      .query(
+        `SELECT responses_item_owner_recorded_keys_json
+         FROM request_log
+         ORDER BY id DESC
+         LIMIT 1;`,
+      )
+      .get() as {
+      responses_item_owner_recorded_keys_json: string | null
+    } | null
+
+    expect(response.status).toBe(200)
+    expect(row.c).toBe(0)
+    expect(requestLog?.responses_item_owner_recorded_keys_json).toBe(
+      JSON.stringify([idKey, encryptedKey]),
+    )
+  })
+
+  test("logs owner lookup keys when account selection fails", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve({ ok: false, reason: "NO_QUOTA" })
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            messages: [
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "thinking",
+                    thinking: "Thinking...",
+                    signature: "enc-selection-failure@rs_selection_failure",
+                  },
+                ],
+              },
+              { role: "user", content: "continue" },
+            ],
+          }),
+        ),
+      }),
+    )
+
+    const lookupIdKey = buildResponsesItemOwnershipKey(
+      "id",
+      "rs_selection_failure",
+    )
+    const lookupEncryptedKey = buildResponsesItemOwnershipKey(
+      "encrypted_content",
+      "enc-selection-failure",
+    )
+    const requestLog = getAdminDb()
+      .query(
+        `SELECT responses_item_owner_lookup_keys_json
+         FROM request_log
+         ORDER BY id DESC
+         LIMIT 1;`,
+      )
+      .get() as {
+      responses_item_owner_lookup_keys_json: string | null
+    } | null
+
+    expect(response.status).toBe(429)
+    expect(requestLog?.responses_item_owner_lookup_keys_json).toBe(
+      JSON.stringify([lookupIdKey, lookupEncryptedKey]),
+    )
+  })
+})
+
+describe("messages handler Responses stream review fixes", () => {
+  test("logs upstream stream failed events as request errors", async () => {
+    const responseBase = {
+      ...buildResponsesResult("responses-model", ""),
+      output: [],
+      output_text: "",
+      status: "in_progress",
+    }
+    const upstreamSse =
+      "event: response.created\n"
+      + "data: "
+      + JSON.stringify({
+        type: "response.created",
+        sequence_number: 0,
+        response: responseBase,
+      })
+      + "\n\n"
+      + "event: response.failed\n"
+      + "data: "
+      + JSON.stringify({
+        type: "response.failed",
+        sequence_number: 1,
+        response: {
+          ...responseBase,
+          status: "failed",
+          error: { message: "upstream failed" },
+        },
+      })
+      + "\n\n"
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(upstreamSse, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload({ stream: true })),
+      }),
+    )
+
+    await response.text()
+
+    const requestLog = getAdminDb()
+      .query(
+        `SELECT http_status, error_name, error_message, upstream_error_message_raw
+         FROM request_log
+         ORDER BY id DESC
+         LIMIT 1;`,
+      )
+      .get() as {
+      http_status: number | null
+      error_name: string | null
+      error_message: string | null
+      upstream_error_message_raw: string | null
+    } | null
+
+    expect(response.status).toBe(200)
+    expect(requestLog?.http_status).toBe(502)
+    expect(requestLog?.error_name).toBe("ResponsesStreamFailed")
+    expect(requestLog?.error_message).toBe("upstream failed")
+    expect(requestLog?.upstream_error_message_raw).toBe("upstream failed")
+  })
+})

--- a/tests/messages-handler-responses-ownership.test.ts
+++ b/tests/messages-handler-responses-ownership.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+import type { AccountRuntime } from "~/lib/types/account"
+import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+import type { Model } from "~/services/copilot/get-models"
+
+import { accountsManager } from "~/lib/accounts-manager"
+import { getAdminDb } from "~/lib/admin-db"
+import { state } from "~/lib/state"
+import { buildResponsesItemOwnershipKey } from "~/routes/messages/responses-item-ownership"
+import { messageRoutes } from "~/routes/messages/route"
+
+const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+const originalFetch = fetchHolder.fetch
+const originalSelect =
+  accountsManager.selectAccountForRequest.bind(accountsManager)
+const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
+const originalMarkFailed =
+  accountsManager.markAccountFailed.bind(accountsManager)
+
+function buildAccount(): AccountRuntime {
+  return {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghu_test",
+    copilotToken: "copilot_test",
+    vsCodeVersion: "1.0.0",
+    premiumRemaining: 10,
+    unlimited: false,
+  }
+}
+
+function buildModel(id: string): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+
+function buildSelection(endpoint: string, modelId: string) {
+  return {
+    ok: true as const,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId),
+    endpoint,
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    confirmOwnership: mock(() => {}),
+    affinityHit: false,
+    selectionReason: "affinity_miss" as const,
+  }
+}
+
+function buildResponsesResult(model: string, text: string) {
+  return {
+    id: "resp_1",
+    object: "response",
+    created_at: Date.now(),
+    model,
+    output: [
+      {
+        id: "out_1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [
+          {
+            type: "output_text",
+            text,
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    output_text: text,
+    status: "completed",
+    usage: {
+      input_tokens: 1,
+      output_tokens: 1,
+      total_tokens: 2,
+    },
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    parallel_tool_calls: true,
+    temperature: 1,
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1,
+  }
+}
+
+function createPayload(
+  overrides: Partial<AnthropicMessagesPayload> = {},
+): AnthropicMessagesPayload {
+  return {
+    model: "original-model",
+    max_tokens: 128,
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  state.manualApprove = false
+  state.verbose = false
+
+  getAdminDb().run("DELETE FROM request_log;")
+  getAdminDb().run("DELETE FROM session_affinity;")
+
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/responses", "responses-model"))
+  accountsManager.finalizeQuota = () => Promise.resolve()
+  accountsManager.markAccountFailed = () => {}
+})
+
+afterEach(() => {
+  fetchHolder.fetch = originalFetch
+  accountsManager.selectAccountForRequest = originalSelect
+  accountsManager.finalizeQuota = originalFinalize
+  accountsManager.markAccountFailed = originalMarkFailed
+})
+
+describe("messages handler Responses item ownership", () => {
+  test("passes owner keys from thinking signatures into account selection", async () => {
+    let selectionOwnerKeys: ReadonlyArray<string> | undefined
+
+    const selection = buildSelection("/responses", "responses-model")
+    accountsManager.selectAccountForRequest = (_candidates, options) => {
+      selectionOwnerKeys = options?.responsesItemOwnershipKeys
+      return Promise.resolve(selection)
+    }
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("responses-model", "responses")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            messages: [
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "thinking",
+                    thinking: "Thinking...",
+                    signature: "enc-owner@rs_owner",
+                  },
+                ],
+              },
+              { role: "user", content: "continue" },
+            ],
+          }),
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(selectionOwnerKeys).toEqual([
+      buildResponsesItemOwnershipKey("id", "rs_owner"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-owner"),
+    ])
+    expect(selectionOwnerKeys?.join("\n")).not.toContain("enc-owner")
+  })
+
+  test("records owner keys from successful non-streaming Responses output", async () => {
+    const selection = buildSelection("/responses", "responses-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...buildResponsesResult("responses-model", "responses"),
+            output: [
+              {
+                id: "rs_recorded",
+                type: "reasoning",
+                summary: [],
+                encrypted_content: "enc-recorded",
+                status: "completed",
+              },
+              {
+                id: "out_1",
+                type: "message",
+                role: "assistant",
+                status: "completed",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "responses",
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            messages: [
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "thinking",
+                    thinking: "Thinking...",
+                    signature: "enc-lookup@rs_lookup",
+                  },
+                ],
+              },
+              { role: "user", content: "continue" },
+            ],
+          }),
+        ),
+      }),
+    )
+
+    const lookupIdKey = buildResponsesItemOwnershipKey("id", "rs_lookup")
+    const lookupEncryptedKey = buildResponsesItemOwnershipKey(
+      "encrypted_content",
+      "enc-lookup",
+    )
+    const idKey = buildResponsesItemOwnershipKey("id", "rs_recorded")
+    const encryptedKey = buildResponsesItemOwnershipKey(
+      "encrypted_content",
+      "enc-recorded",
+    )
+    const rows = getAdminDb()
+      .query(
+        `SELECT cache_key, account_id FROM session_affinity
+         WHERE cache_key IN (?, ?)
+         ORDER BY cache_key;`,
+      )
+      .all(idKey, encryptedKey) as Array<{
+      cache_key: string
+      account_id: string
+    }>
+
+    const requestLog = getAdminDb()
+      .query(
+        `SELECT
+           responses_item_owner_lookup_keys_json,
+           responses_item_owner_recorded_keys_json
+         FROM request_log
+         ORDER BY id DESC
+         LIMIT 1;`,
+      )
+      .get() as {
+      responses_item_owner_lookup_keys_json: string | null
+      responses_item_owner_recorded_keys_json: string | null
+    } | null
+
+    expect(response.status).toBe(200)
+    expect(rows).toEqual([
+      { cache_key: encryptedKey, account_id: "octocat" },
+      { cache_key: idKey, account_id: "octocat" },
+    ])
+    expect(requestLog?.responses_item_owner_lookup_keys_json).toBe(
+      JSON.stringify([lookupIdKey, lookupEncryptedKey]),
+    )
+    expect(requestLog?.responses_item_owner_recorded_keys_json).toBe(
+      JSON.stringify([idKey, encryptedKey]),
+    )
+  })
+})

--- a/tests/request-history-responses-ownership.test.ts
+++ b/tests/request-history-responses-ownership.test.ts
@@ -1,0 +1,33 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+
+import { initAdminDb } from "~/lib/admin-db"
+import { RequestHistoryStore } from "~/lib/request-history"
+
+test("RequestHistoryStore persists Responses item ownership keys", () => {
+  const db = new Database(":memory:")
+  initAdminDb(db)
+  const store = new RequestHistoryStore(db)
+
+  const lookupKeys = ["responses-item-owner:id:lookup"]
+  const recordedKeys = ["responses-item-owner:id:recorded"]
+
+  store.insert({
+    requestId: "req-owner-keys",
+    startedAtMs: 1,
+    method: "POST",
+    path: "/v1/messages",
+    stream: false,
+    responsesItemOwnerLookupKeysJson: JSON.stringify(lookupKeys),
+    responsesItemOwnerRecordedKeysJson: JSON.stringify(recordedKeys),
+  })
+
+  const row = store.getByRequestId("req-owner-keys")
+
+  expect(row?.responses_item_owner_lookup_keys_json).toBe(
+    JSON.stringify(lookupKeys),
+  )
+  expect(row?.responses_item_owner_recorded_keys_json).toBe(
+    JSON.stringify(recordedKeys),
+  )
+})

--- a/tests/responses-item-ownership.test.ts
+++ b/tests/responses-item-ownership.test.ts
@@ -91,4 +91,46 @@ describe("responses item ownership", () => {
       buildResponsesItemOwnershipKey("encrypted_content", "enc-stream"),
     ])
   })
+
+  test("extracts owner keys from Responses completed stream events", () => {
+    const event = {
+      type: "response.completed",
+      sequence_number: 1,
+      response: {
+        output: [
+          {
+            id: "rs_completed",
+            type: "reasoning",
+            encrypted_content: "enc-completed",
+          },
+        ],
+      },
+    } as ResponseStreamEvent
+
+    expect(extractResponsesStreamEventOwnerKeys(event)).toEqual([
+      buildResponsesItemOwnershipKey("id", "rs_completed"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-completed"),
+    ])
+  })
+
+  test("extracts owner keys from Responses incomplete stream events", () => {
+    const event = {
+      type: "response.incomplete",
+      sequence_number: 1,
+      response: {
+        output: [
+          {
+            id: "rs_incomplete",
+            type: "reasoning",
+            encrypted_content: "enc-incomplete",
+          },
+        ],
+      },
+    } as ResponseStreamEvent
+
+    expect(extractResponsesStreamEventOwnerKeys(event)).toEqual([
+      buildResponsesItemOwnershipKey("id", "rs_incomplete"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-incomplete"),
+    ])
+  })
 })

--- a/tests/responses-item-ownership.test.ts
+++ b/tests/responses-item-ownership.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+
+import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+import type {
+  ResponseStreamEvent,
+  ResponsesResult,
+} from "~/services/copilot/create-responses"
+
+import {
+  buildResponsesItemOwnershipKey,
+  extractAnthropicResponsesItemOwnerKeys,
+  extractResponsesResultOwnerKeys,
+  extractResponsesStreamEventOwnerKeys,
+} from "~/routes/messages/responses-item-ownership"
+
+describe("responses item ownership", () => {
+  test("extracts hashed owner keys from Anthropic thinking signatures", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "gpt-5",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "Thinking...",
+              signature: "enc-reasoning@rs_123",
+            },
+            {
+              type: "thinking",
+              thinking: "Thinking...",
+              signature: "cm1#enc-compaction@cmp_123",
+            },
+          ],
+        },
+        { role: "user", content: "continue" },
+      ],
+    }
+
+    const keys = extractAnthropicResponsesItemOwnerKeys(payload)
+
+    expect(keys).toEqual([
+      buildResponsesItemOwnershipKey("id", "rs_123"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-reasoning"),
+      buildResponsesItemOwnershipKey("id", "cmp_123"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-compaction"),
+    ])
+    expect(keys.join("\n")).not.toContain("enc-reasoning")
+    expect(keys.join("\n")).not.toContain("enc-compaction")
+  })
+
+  test("extracts owner keys from Responses result output", () => {
+    const result = {
+      output: [
+        {
+          id: "rs_result",
+          type: "reasoning",
+          encrypted_content: "enc-result",
+        },
+        {
+          id: "cmp_result",
+          type: "compaction",
+          encrypted_content: "enc-cmp-result",
+        },
+      ],
+    } as Pick<ResponsesResult, "output">
+
+    expect(extractResponsesResultOwnerKeys(result)).toEqual([
+      buildResponsesItemOwnershipKey("id", "rs_result"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-result"),
+      buildResponsesItemOwnershipKey("id", "cmp_result"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-cmp-result"),
+    ])
+  })
+
+  test("extracts owner keys from Responses output_item.done stream events", () => {
+    const event = {
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 1,
+      item: {
+        id: "rs_stream",
+        type: "reasoning",
+        encrypted_content: "enc-stream",
+      },
+    } as ResponseStreamEvent
+
+    expect(extractResponsesStreamEventOwnerKeys(event)).toEqual([
+      buildResponsesItemOwnershipKey("id", "rs_stream"),
+      buildResponsesItemOwnershipKey("encrypted_content", "enc-stream"),
+    ])
+  })
+})

--- a/tests/session-affinity-store.test.ts
+++ b/tests/session-affinity-store.test.ts
@@ -4,14 +4,14 @@ import { expect, test } from "bun:test"
 import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
 import { SessionAffinityStore } from "../src/lib/session-affinity-store"
 
-test("initAdminDb migrates admin DB to user_version 12", () => {
+test("initAdminDb migrates admin DB to user_version 13", () => {
   const db = new Database(":memory:")
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(12)
+  expect(getAdminDbUserVersion(db)).toBe(13)
 })
 
-test("initAdminDb upgrades an existing v7 DB with request_log to v12 and creates session_affinity", () => {
+test("initAdminDb upgrades an existing v7 DB with request_log to v13 and creates session_affinity", () => {
   const db = new Database(":memory:")
 
   db.run(`
@@ -93,9 +93,11 @@ test("initAdminDb upgrades an existing v7 DB with request_log to v12 and creates
     .all() as Array<{ name: string }>
   const columnNamesAfter = requestLogColumnsAfter.map((column) => column.name)
 
-  expect(getAdminDbUserVersion(db)).toBe(12)
+  expect(getAdminDbUserVersion(db)).toBe(13)
   expect(after?.name).toBe("session_affinity")
   expect(columnNamesAfter).toContain("outbound_x_request_id")
+  expect(columnNamesAfter).toContain("responses_item_owner_lookup_keys_json")
+  expect(columnNamesAfter).toContain("responses_item_owner_recorded_keys_json")
 })
 
 test("initAdminDb creates session_affinity with the expected columns", () => {

--- a/tests/stats-store.test.ts
+++ b/tests/stats-store.test.ts
@@ -4,11 +4,11 @@ import { expect, test } from "bun:test"
 import { getAdminDbUserVersion, initAdminDb } from "../src/lib/admin-db"
 import { StatsStore, toLocalDateString } from "../src/lib/stats-store"
 
-test("initAdminDb migrates admin DB to user_version 12", () => {
+test("initAdminDb migrates admin DB to user_version 13", () => {
   const db = new Database(":memory:")
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(12)
+  expect(getAdminDbUserVersion(db)).toBe(13)
 })
 
 test("daily_premium_stats table has the expected columns", () => {
@@ -304,7 +304,7 @@ test("v9 migration backfills from existing request_log data", () => {
   // Re-run migration (should trigger v9 since user_version is 8)
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(12)
+  expect(getAdminDbUserVersion(db)).toBe(13)
 
   const rows = db
     .query(
@@ -364,7 +364,7 @@ test("v10 migration backfills quota_snapshots from request_log", () => {
 
   initAdminDb(db)
 
-  expect(getAdminDbUserVersion(db)).toBe(12)
+  expect(getAdminDbUserVersion(db)).toBe(13)
 
   const rows = db
     .query(


### PR DESCRIPTION
## Summary
- Route `/responses` continuations with prior reasoning/compaction items back to the owning Copilot account using hashed owner keys.
- Persist request lookup and response recorded owner keys in `request_log` and show them on the Admin UI request detail page.
- Add DB migration v13 plus focused backend, handler, and Admin UI helper coverage.

## Test plan
- [x] `bun test "tests/admin-db-migrations.test.ts" "tests/request-history-responses-ownership.test.ts" "tests/messages-handler-responses-ownership.test.ts" "admin-ui/tests/request-detail-ownership.test.ts" "tests/session-affinity-store.test.ts" "tests/stats-store.test.ts"`
- [x] `bun test "./admin-ui/tests/request-detail-ownership.test.ts"`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run lint:admin`
- [x] `bun run typecheck:admin`
- [x] `bun test`
- [x] `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在请求详情页面中添加"响应项所有者"相关字段，显示查询密钥和记录密钥信息

* **Chores**
  * 数据库架构升级至版本 13，新增两个持久化字段
  * 增强了账户选择逻辑，支持基于响应项所有权的优先级路由
  * 添加了英文和中文本地化支持

* **测试**
  * 添加了综合单元测试覆盖新的所有权追踪和数据库迁移功能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->