### PR TITLE
Optimize Responses owner lookup affinity

### DIFF
--- a/src/lib/account-affinity.ts
+++ b/src/lib/account-affinity.ts
@@ -9,6 +9,7 @@ export interface AffinityContext {
 
 export interface AffinityPersistenceStore {
   get(key: string): string | undefined
+  getMany?(keys: ReadonlyArray<string>): ReadonlyMap<string, string>
   set(key: string, accountId: string): void
   delete(key: string): void
   clear(): void
@@ -74,6 +75,51 @@ export class AccountAffinityCache {
     return accountId
   }
 
+  getMany(keys: ReadonlyArray<string>): ReadonlyMap<string, string> {
+    const result = new Map<string, string>()
+    const missingKeys = new Array<string>()
+    const now = Date.now()
+
+    for (const key of keys) {
+      if (result.has(key)) {
+        continue
+      }
+
+      const entry = this.cache.get(key)
+      if (!entry) {
+        missingKeys.push(key)
+        continue
+      }
+
+      if (now >= entry.expiresAt) {
+        this.cache.delete(key)
+        missingKeys.push(key)
+        continue
+      }
+
+      result.set(key, entry.accountId)
+    }
+
+    if (missingKeys.length === 0) {
+      return result
+    }
+
+    const persistentEntries = this.readPersistentEntries(missingKeys)
+    for (const [key, accountId] of persistentEntries) {
+      this.setMemory(key, accountId)
+    }
+
+    if (result.size === 0) {
+      return persistentEntries
+    }
+
+    for (const [key, accountId] of persistentEntries) {
+      result.set(key, accountId)
+    }
+
+    return result
+  }
+
   /** Record a successful account mapping. Refreshes TTL and moves the entry to the newest position. */
   set(key: string, accountId: string): void {
     this.setMemory(key, accountId)
@@ -103,7 +149,9 @@ export class AccountAffinityCache {
     return this.cache.size
   }
 
-  private getPersistentStore(): AffinityPersistenceStore | undefined {
+  private getPersistentStore(
+    options: { throwOnProviderFailure?: boolean } = {},
+  ): AffinityPersistenceStore | undefined {
     if (this.persistentStore) {
       return this.persistentStore
     }
@@ -118,7 +166,11 @@ export class AccountAffinityCache {
       }
       return store
     } catch (error) {
-      this.persistentStoreProvider = undefined
+      if (options.throwOnProviderFailure) {
+        consola.error("Failed to resolve affinity persistence store:", error)
+        throw new Error("Affinity persistence store provider failed")
+      }
+
       consola.warn("Failed to resolve affinity persistence store:", error)
       return undefined
     }
@@ -139,6 +191,54 @@ export class AccountAffinityCache {
       )
       return undefined
     }
+  }
+
+  private readPersistentEntries(
+    keys: ReadonlyArray<string>,
+  ): ReadonlyMap<string, string> {
+    const store = this.getPersistentStore({ throwOnProviderFailure: true })
+    if (!store) {
+      return new Map()
+    }
+
+    if (store.getMany) {
+      try {
+        return store.getMany(keys)
+      } catch (error) {
+        consola.warn(
+          "Failed to batch-read affinity mappings from persistent store:",
+          error,
+        )
+        throw new Error(
+          `Affinity persistent store batch lookup failed for ${keys.length} keys`,
+        )
+      }
+    }
+
+    const result = new Map<string, string>()
+    const failedKeys = new Array<string>()
+    for (const key of keys) {
+      try {
+        const accountId = store.get(key)
+        if (accountId) {
+          result.set(key, accountId)
+        }
+      } catch (error) {
+        failedKeys.push(key)
+        consola.warn(
+          "Failed to read affinity mapping from persistent store:",
+          error,
+        )
+      }
+    }
+
+    if (failedKeys.length > 0) {
+      throw new Error(
+        `Affinity persistent store lookup failed for ${failedKeys.length}/${keys.length} keys`,
+      )
+    }
+
+    return result
   }
 
   private writePersistentEntry(key: string, accountId: string): void {

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -1298,15 +1298,28 @@ export class AccountsManager {
       return {}
     }
 
-    const accountIds = new Map<string, string>()
-    for (const key of ownershipKeys) {
-      const accountId = this.affinityCache.get(key)
-      if (accountId) {
-        accountIds.set(accountId, key)
-      }
+    let ownershipMappings: ReadonlyMap<string, string>
+    try {
+      ownershipMappings = this.affinityCache.getMany(ownershipKeys)
+    } catch (error) {
+      consola.warn(
+        "Failed to read Responses item owner mappings; falling back",
+        {
+          error,
+          ownershipKeyCount: ownershipKeys.length,
+        },
+      )
+      return {}
     }
 
-    if (accountIds.size !== 1) {
+    const accountIds = new Map<string, string>()
+    for (const key of ownershipKeys) {
+      const accountId = ownershipMappings.get(key)
+      if (!accountId) {
+        continue
+      }
+
+      accountIds.set(accountId, key)
       if (accountIds.size > 1) {
         consola.warn(
           "Conflicting Responses item owner mappings; falling back",
@@ -1315,7 +1328,11 @@ export class AccountsManager {
             ownershipKeyCount: ownershipKeys.length,
           },
         )
+        return {}
       }
+    }
+
+    if (accountIds.size === 0) {
       return {}
     }
 

--- a/src/lib/session-affinity-store.ts
+++ b/src/lib/session-affinity-store.ts
@@ -8,9 +8,19 @@ import { getSessionAffinityRetentionMs } from "./config"
 const DAY_MS = 24 * 60 * 60 * 1000
 const DEFAULT_MAX_AGE_MS = 7 * DAY_MS
 const CLEANUP_INTERVAL_MS = DAY_MS
+const MAX_BATCH_KEYS = 500
 
 const maybeUnref = (timer: ReturnType<typeof setInterval>) => {
   timer.unref()
+}
+
+function* chunks<T>(
+  values: ReadonlyArray<T>,
+  size: number,
+): Generator<ReadonlyArray<T>> {
+  for (let index = 0; index < values.length; index += size) {
+    yield values.slice(index, index + size)
+  }
 }
 
 export class SessionAffinityStore {
@@ -49,6 +59,99 @@ export class SessionAffinityStore {
     }
 
     return row.account_id
+  }
+
+  getMany(cacheKeys: ReadonlyArray<string>): Map<string, string> {
+    const uniqueKeys = [...new Set(cacheKeys)].filter(Boolean)
+    const result = new Map<string, string>()
+
+    let chunkIndex = 0
+    for (const keys of chunks(uniqueKeys, MAX_BATCH_KEYS)) {
+      try {
+        this.readManyChunk(keys, result)
+      } catch (error) {
+        consola.error("Failed to batch-read session affinity mappings", {
+          chunkIndex,
+          chunkKeyCount: keys.length,
+          error,
+          totalKeyCount: uniqueKeys.length,
+        })
+        throw error
+      }
+      chunkIndex += 1
+    }
+
+    if (result.size === 0) {
+      return result
+    }
+
+    const now = Date.now()
+    let touchChunkIndex = 0
+    const touchedKeyCount = result.size
+    for (const keys of chunks([...result.keys()], MAX_BATCH_KEYS)) {
+      try {
+        this.touchManyChunk(keys, now)
+      } catch (error) {
+        consola.warn(
+          "Failed to batch-update session affinity last_used_at_ms",
+          {
+            chunkIndex: touchChunkIndex,
+            chunkKeyCount: keys.length,
+            error,
+            touchedKeyCount,
+          },
+        )
+      }
+      touchChunkIndex += 1
+    }
+
+    return result
+  }
+
+  private readManyChunk(
+    cacheKeys: ReadonlyArray<string>,
+    result: Map<string, string>,
+  ): void {
+    if (cacheKeys.length === 0) {
+      return
+    }
+
+    const placeholders = cacheKeys.map(() => "?").join(", ")
+    const rows = this.db
+      .query(
+        `SELECT cache_key, account_id FROM session_affinity
+         WHERE cache_key IN (${placeholders});`,
+      )
+      .all(...cacheKeys) as Array<{
+      cache_key?: string
+      account_id?: string
+    }>
+
+    for (const row of rows) {
+      if (!row.cache_key || !row.account_id) {
+        consola.error("Invalid session affinity row returned from database", {
+          hasAccountId: Boolean(row.account_id),
+          hasCacheKey: Boolean(row.cache_key),
+        })
+        throw new Error("Invalid session affinity row returned from database")
+      }
+
+      result.set(row.cache_key, row.account_id)
+    }
+  }
+
+  private touchManyChunk(cacheKeys: ReadonlyArray<string>, now: number): void {
+    if (cacheKeys.length === 0) {
+      return
+    }
+
+    const placeholders = cacheKeys.map(() => "?").join(", ")
+    this.db
+      .query(
+        `UPDATE session_affinity SET last_used_at_ms = ?
+         WHERE cache_key IN (${placeholders});`,
+      )
+      .run(now, ...cacheKeys)
   }
 
   set(cacheKey: string, accountId: string): void {

--- a/tests/accounts-manager-session-affinity.test.ts
+++ b/tests/accounts-manager-session-affinity.test.ts
@@ -271,6 +271,190 @@ test("responses item ownership keeps mappings for temporarily failed accounts", 
   expect(store.get(ownerKey)).toBe("b")
 })
 
+test("responses item ownership batches lookup and stops after owner conflict", async () => {
+  const model = makeModel({ id: "free-model" })
+  const firstOwnerKey = buildResponsesItemOwnershipKey("id", "rs_owner_batch_a")
+  const secondOwnerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_batch_b",
+  )
+  const unusedOwnerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_batch_unused",
+  )
+  const storedMappings = new Map([
+    [firstOwnerKey, "a"],
+    [secondOwnerKey, "b"],
+    [unusedOwnerKey, "a"],
+  ])
+  const getCalls = new Array<string>()
+  const getManyCalls = new Array<ReadonlyArray<string>>()
+  const resultReads = new Array<string>()
+  const getManyResult = new (class extends Map<string, string> {
+    override get(key: string): string | undefined {
+      resultReads.push(key)
+      return super.get(key)
+    }
+  })(storedMappings)
+  const store = {
+    get(key: string): string | undefined {
+      getCalls.push(key)
+      return storedMappings.get(key)
+    },
+    getMany(keys: ReadonlyArray<string>): Map<string, string> {
+      getManyCalls.push([...keys])
+      return getManyResult
+    },
+    set() {},
+    delete() {},
+    clear() {},
+  }
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: store,
+  })
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    {
+      responsesItemOwnershipKeys: [
+        firstOwnerKey,
+        secondOwnerKey,
+        unusedOwnerKey,
+      ],
+    },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(getCalls).toEqual([])
+  expect(getManyCalls).toEqual([
+    [firstOwnerKey, secondOwnerKey, unusedOwnerKey],
+  ])
+  expect(resultReads).toEqual([firstOwnerKey, secondOwnerKey])
+})
+
+test("responses item ownership ignores partial degraded lookup results", async () => {
+  const model = makeModel({ id: "free-model" })
+  const memoryOwnerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_degraded_memory",
+  )
+  const persistentOwnerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_degraded_persistent",
+  )
+  const getCalls = new Array<string>()
+  const store = {
+    get(key: string): string | undefined {
+      getCalls.push(key)
+      return undefined
+    },
+    getMany(): Map<string, string> {
+      throw new Error("batch read failed")
+    },
+    set() {},
+    delete() {},
+    clear() {},
+  }
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: store,
+  })
+  manager.recordResponsesItemOwnership([memoryOwnerKey], "b")
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    { responsesItemOwnershipKeys: [memoryOwnerKey, persistentOwnerKey] },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(getCalls).toEqual([])
+})
+
+test("responses item ownership ignores partial lookup when store provider fails", async () => {
+  const model = makeModel({ id: "free-model" })
+  const memoryOwnerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_provider_memory",
+  )
+  const persistentOwnerKey = buildResponsesItemOwnershipKey(
+    "id",
+    "rs_owner_provider_persistent",
+  )
+  let providerCalls = 0
+  const storeProvider = () => {
+    providerCalls += 1
+    throw new Error("provider failed")
+  }
+
+  const accountA: AccountRuntime = {
+    id: "a",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_a",
+    models: makeModelsResponse([model]),
+  }
+  const accountB: AccountRuntime = {
+    id: "b",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghp_b",
+    models: makeModelsResponse([model]),
+  }
+
+  const manager = setupManager([accountA, accountB], {
+    persistentAffinityStore: storeProvider,
+  })
+  manager.recordResponsesItemOwnership([memoryOwnerKey], "b")
+
+  const selection = await manager.selectAccountForRequest(
+    [{ modelId: "free-model", endpoint: "/chat/completions" }],
+    { responsesItemOwnershipKeys: [memoryOwnerKey, persistentOwnerKey] },
+  )
+
+  expect(selection.ok).toBe(true)
+  if (!selection.ok) return
+
+  expect(selection.account.id).toBe("a")
+  expect(providerCalls).toBeGreaterThanOrEqual(2)
+})
+
 test("persistent affinity: stale binding pointing to unavailable account is purged and falls back", async () => {
   const db = new Database(":memory:")
   initAdminDb(db)

--- a/tests/accounts-manager-test-helpers.ts
+++ b/tests/accounts-manager-test-helpers.ts
@@ -1,4 +1,4 @@
-import type { AffinityPersistenceStore } from "../src/lib/account-affinity"
+import type { AffinityPersistenceStoreProvider } from "../src/lib/account-affinity"
 import type { AccountRuntime } from "../src/lib/types/account"
 import type { Model, ModelsResponse } from "../src/services/copilot/get-models"
 
@@ -6,7 +6,7 @@ import { AccountsManager } from "../src/lib/accounts-manager"
 
 type SetupManagerOptions = {
   temporaryAccount?: AccountRuntime
-  persistentAffinityStore?: AffinityPersistenceStore
+  persistentAffinityStore?: AffinityPersistenceStoreProvider
 }
 
 export function makeModel(overrides: Partial<Model> = {}): Model {


### PR DESCRIPTION
## Summary
- Batch Responses item owner affinity lookups through the affinity cache and SQLite session-affinity store.
- Stop owner-key conflict scans as soon as multiple account owners are detected.
- Treat batch/provider lookup failures as degraded owner lookup and fall back to normal account selection instead of routing on partial mappings.

## Test plan
- [x] `bun test "tests/account-affinity-cache.test.ts" "tests/session-affinity-store.test.ts" "tests/accounts-manager-session-affinity.test.ts"` (41 pass / 0 fail)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (479 pass / 0 fail)
- [x] Independent code review: no blockers
- [x] Silent-failure review: no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 添加批量查询支持，优化账户关联数据的检索性能。

* **改进**
  * 增强账户所有权查询的错误处理和冲突检测机制。
  * 改进会话关联存储的批量操作能力。

* **测试**
  * 扩展测试覆盖范围，验证边界情况和错误处理场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->