### PR TITLE
fix: improve admin request owner keys viewer

### DIFF
--- a/admin-ui/src/lib/request-detail-ownership.ts
+++ b/admin-ui/src/lib/request-detail-ownership.ts
@@ -1,6 +1,9 @@
 import type { AdminRequestItem } from "./admin-api"
 
 const EMPTY = "—"
+const PREVIEW_HEAD_COUNT = 2
+const PREVIEW_TAIL_COUNT = 1
+const PREVIEW_LINE_LIMIT = 96
 
 type ResponsesItemOwnerFields = Pick<
   AdminRequestItem,
@@ -8,10 +11,21 @@ type ResponsesItemOwnerFields = Pick<
   | "responses_item_owner_recorded_keys_json"
 >
 
+export type RequestDetailResponsesItemOwnerValue = {
+  raw: string
+  lines: Array<string>
+  count: number
+  charCount: number
+  previewLines: Array<string>
+  hiddenCount: number
+  empty: boolean
+}
+
 export type RequestDetailResponsesItemOwnerRow = {
+  id: "lookup" | "recorded"
   labelKey: string
   tooltipKey: string
-  value: string
+  value: RequestDetailResponsesItemOwnerValue
 }
 
 export function buildRequestDetailResponsesItemOwnerRows(
@@ -19,11 +33,13 @@ export function buildRequestDetailResponsesItemOwnerRows(
 ): Array<RequestDetailResponsesItemOwnerRow> {
   return [
     {
+      id: "lookup",
       labelKey: "requestDetailPage.fields.responsesItemOwnerLookupKeys",
       tooltipKey: "requestDetailPage.fieldTooltip.responsesItemOwnerLookupKeys",
       value: formatOwnerKeys(item.responses_item_owner_lookup_keys_json),
     },
     {
+      id: "recorded",
       labelKey: "requestDetailPage.fields.responsesItemOwnerRecordedKeys",
       tooltipKey: "requestDetailPage.fieldTooltip.responsesItemOwnerRecordedKeys",
       value: formatOwnerKeys(item.responses_item_owner_recorded_keys_json),
@@ -31,22 +47,88 @@ export function buildRequestDetailResponsesItemOwnerRows(
   ]
 }
 
-function formatOwnerKeys(raw: string | null | undefined): string {
+function formatOwnerKeys(
+  raw: string | null | undefined,
+): RequestDetailResponsesItemOwnerValue {
   if (!raw) {
-    return EMPTY
+    return emptyValue()
   }
 
   try {
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) {
-      return raw
+      return formatOwnerKeyLines(splitLines(raw), raw)
     }
 
-    const values = parsed.filter(
-      (value): value is string => typeof value === "string" && value.length > 0,
-    )
-    return values.length > 0 ? values.join("\n") : EMPTY
+    const values = parsed
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+
+    if (values.length === 0) {
+      return emptyValue()
+    }
+
+    return formatOwnerKeyLines(values, values.join("\n"))
   } catch {
-    return raw
+    return formatOwnerKeyLines(splitLines(raw), raw)
+  }
+}
+
+function formatOwnerKeyLines(
+  lines: Array<string>,
+  raw: string,
+): RequestDetailResponsesItemOwnerValue {
+  if (lines.length === 0) {
+    return emptyValue()
+  }
+
+  const previewLines = buildPreviewLines(lines)
+
+  return {
+    raw,
+    lines,
+    count: lines.length,
+    charCount: raw.length,
+    previewLines,
+    hiddenCount: Math.max(0, lines.length - previewLines.length),
+    empty: false,
+  }
+}
+
+function buildPreviewLines(lines: Array<string>): Array<string> {
+  const preview =
+    lines.length <= PREVIEW_HEAD_COUNT + PREVIEW_TAIL_COUNT ?
+      lines
+    : [
+        ...lines.slice(0, PREVIEW_HEAD_COUNT),
+        ...lines.slice(-PREVIEW_TAIL_COUNT),
+      ]
+
+  return preview.map((line) => truncatePreviewLine(line))
+}
+
+function truncatePreviewLine(line: string): string {
+  return line.length <= PREVIEW_LINE_LIMIT ?
+      line
+    : `${line.slice(0, PREVIEW_LINE_LIMIT - 1)}…`
+}
+
+function splitLines(raw: string): Array<string> {
+  return raw
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+function emptyValue(): RequestDetailResponsesItemOwnerValue {
+  return {
+    raw: EMPTY,
+    lines: [],
+    count: 0,
+    charCount: 0,
+    previewLines: [EMPTY],
+    hiddenCount: 0,
+    empty: true,
   }
 }

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -279,8 +279,10 @@
     "searchPlaceholder": "Search key or value…",
     "toast": {
       "copiedJson": "Copied JSON",
+      "copiedText": "Copied text",
       "copyFailed": "Copy failed",
       "downloadedJson": "Downloaded JSON",
+      "downloadedText": "Downloaded text",
       "downloadFailed": "Download failed"
     },
     "sections": {
@@ -358,6 +360,19 @@
       "before": "Before",
       "after": "After",
       "diff": "Change"
+    },
+    "ownerKeys": {
+      "summary": "{{keyCount}} keys · {{charCount}} chars",
+      "morePreview": "{{hiddenCount}} more hidden",
+      "viewAll": "View all",
+      "viewerDescription": "Full Responses Item Owner key list with search, copy, and download controls.",
+      "searchPlaceholder": "Filter keys…",
+      "wrapLines": "Wrap lines",
+      "preserveLineBreaks": "Preserve layout",
+      "copyAll": "Copy all",
+      "downloadAll": "Download all",
+      "viewerStats": "Showing {{shownCount}} / {{totalCount}} keys · {{charCount}} chars",
+      "noMatches": "No matching keys."
     },
     "replay": {
       "button": "Replay",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -279,8 +279,10 @@
     "searchPlaceholder": "搜索键或值…",
     "toast": {
       "copiedJson": "已复制 JSON",
+      "copiedText": "已复制文本",
       "copyFailed": "复制失败",
       "downloadedJson": "已下载 JSON",
+      "downloadedText": "已下载文本",
       "downloadFailed": "下载失败"
     },
     "sections": {
@@ -358,6 +360,19 @@
       "before": "之前",
       "after": "之后",
       "diff": "变化"
+    },
+    "ownerKeys": {
+      "summary": "{{keyCount}} 条键 · {{charCount}} 个字符",
+      "morePreview": "另有 {{hiddenCount}} 条未展开",
+      "viewAll": "查看全部",
+      "viewerDescription": "完整的 Responses Item Owner 键列表，支持搜索、复制和下载。",
+      "searchPlaceholder": "过滤键…",
+      "wrapLines": "自动换行",
+      "preserveLineBreaks": "保留原样",
+      "copyAll": "复制全部",
+      "downloadAll": "下载全部",
+      "viewerStats": "显示 {{shownCount}} / {{totalCount}} 条 · {{charCount}} 个字符",
+      "noMatches": "没有匹配的键。"
     },
     "replay": {
       "button": "重放",

--- a/admin-ui/src/pages/request-detail-page.tsx
+++ b/admin-ui/src/pages/request-detail-page.tsx
@@ -1,6 +1,8 @@
 import {
   ArrowLeftIcon,
+  CopyIcon,
   DownloadIcon,
+  EyeIcon,
   LoaderCircleIcon,
   PlayIcon,
   RefreshCwIcon,
@@ -16,13 +18,26 @@ import {
   getAdminRequestDetail,
   getDevMode,
 } from "@/lib/admin-api"
+import { copyText as writeClipboardText } from "@/lib/clipboard"
 import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
-import { buildRequestDetailResponsesItemOwnerRows } from "@/lib/request-detail-ownership"
+import {
+  buildRequestDetailResponsesItemOwnerRows,
+  type RequestDetailResponsesItemOwnerRow,
+} from "@/lib/request-detail-ownership"
+import { cn } from "@/lib/utils"
 import { JsonViewer } from "@/components/json/json-viewer"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { InlineAlert } from "@/components/ui/inline-alert"
 import {
   Card,
   CardContent,
@@ -30,7 +45,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { InlineAlert } from "@/components/ui/inline-alert"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
@@ -146,6 +167,234 @@ function FieldLabel({
   )
 }
 
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    return typeof window !== "undefined" ? window.matchMedia(query).matches : true
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined
+    }
+
+    const mediaQuery = window.matchMedia(query)
+    const update = () => setMatches(mediaQuery.matches)
+
+    update()
+    mediaQuery.addEventListener("change", update)
+
+    return () => mediaQuery.removeEventListener("change", update)
+  }, [query])
+
+  return matches
+}
+
+function OwnerKeysSummaryValue({
+  row,
+  onView,
+  onCopy,
+  onDownload,
+}: {
+  row: RequestDetailResponsesItemOwnerRow
+  onView: () => void
+  onCopy: () => void
+  onDownload: () => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+
+  if (row.value.empty) {
+    return <>{row.value.raw}</>
+  }
+
+  return (
+    <div className="space-y-2 py-0.5">
+      <div className="font-sans text-[11px] text-muted-foreground">
+        {t("requestDetailPage.ownerKeys.summary", {
+          keyCount: fmtNum(row.value.count),
+          charCount: fmtNum(row.value.charCount),
+        })}
+      </div>
+
+      <div className="rounded-md border bg-muted/15 p-2">
+        <div className="font-mono text-[11px] leading-5 whitespace-pre-wrap break-all">
+          {row.value.previewLines.join("\n")}
+        </div>
+        {row.value.hiddenCount > 0 ? (
+          <div className="mt-2 font-sans text-[11px] text-muted-foreground">
+            {t("requestDetailPage.ownerKeys.morePreview", {
+              hiddenCount: fmtNum(row.value.hiddenCount),
+            })}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap gap-2 font-sans">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-[11px]"
+          onClick={onView}
+        >
+          <EyeIcon className="size-3.5" />
+          {t("requestDetailPage.ownerKeys.viewAll")}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-[11px]"
+          onClick={onCopy}
+        >
+          <CopyIcon className="size-3.5" />
+          {t("common.copy")}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-[11px]"
+          onClick={onDownload}
+        >
+          <DownloadIcon className="size-3.5" />
+          {t("common.download")}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function OwnerKeysViewer({
+  row,
+  open,
+  isDesktop,
+  onOpenChange,
+  onCopy,
+  onDownload,
+}: {
+  row: RequestDetailResponsesItemOwnerRow | null
+  open: boolean
+  isDesktop: boolean
+  onOpenChange: (open: boolean) => void
+  onCopy: () => void
+  onDownload: () => void
+}): React.JSX.Element | null {
+  const { t } = useTranslation()
+  const [filter, setFilter] = useState("")
+  const [wrapLines, setWrapLines] = useState(true)
+
+  if (!row || row.value.empty) {
+    return null
+  }
+
+  const normalizedFilter = filter.trim().toLowerCase()
+  const filteredLines = normalizedFilter
+    ? row.value.lines.filter((line) =>
+        line.toLowerCase().includes(normalizedFilter),
+      )
+    : row.value.lines
+  const title = t(row.labelKey)
+  const description = t("requestDetailPage.ownerKeys.viewerDescription")
+
+  const viewerBody = (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4 sm:px-6 sm:pb-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Input
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          placeholder={t("requestDetailPage.ownerKeys.searchPlaceholder")}
+          aria-label={t("requestDetailPage.ownerKeys.searchPlaceholder")}
+          className="h-8 sm:max-w-sm"
+        />
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs"
+            aria-pressed={wrapLines}
+            onClick={() => setWrapLines((value) => !value)}
+          >
+            {wrapLines ?
+              t("requestDetailPage.ownerKeys.preserveLineBreaks")
+            : t("requestDetailPage.ownerKeys.wrapLines")}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={onCopy}
+          >
+            <CopyIcon className="size-3.5" />
+            {t("requestDetailPage.ownerKeys.copyAll")}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={onDownload}
+          >
+            <DownloadIcon className="size-3.5" />
+            {t("requestDetailPage.ownerKeys.downloadAll")}
+          </Button>
+        </div>
+      </div>
+
+      <div className="text-xs text-muted-foreground">
+        {t("requestDetailPage.ownerKeys.viewerStats", {
+          shownCount: fmtNum(filteredLines.length),
+          totalCount: fmtNum(row.value.count),
+          charCount: fmtNum(row.value.charCount),
+        })}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto rounded-md border bg-muted/10 p-3">
+        {filteredLines.length > 0 ? (
+          <div
+            className={cn(
+              "font-mono text-xs leading-5",
+              wrapLines ?
+                "whitespace-pre-wrap break-all"
+              : "overflow-x-auto whitespace-pre",
+            )}
+          >
+            {filteredLines.join("\n")}
+          </div>
+        ) : (
+          <div className="flex h-full min-h-24 items-center justify-center text-sm text-muted-foreground">
+            {t("requestDetailPage.ownerKeys.noMatches")}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden p-0 sm:max-w-4xl">
+          <DialogHeader className="border-b px-4 pt-4 pb-4 sm:px-6">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          {viewerBody}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="flex h-[85vh] flex-col gap-0 rounded-t-xl p-0"
+      >
+        <SheetHeader className="border-b px-4 py-4 text-left">
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
+        </SheetHeader>
+        {viewerBody}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main Component                                                    */
 /* ------------------------------------------------------------------ */
@@ -166,6 +415,14 @@ export function RequestDetailPage(): React.JSX.Element {
   const [search, setSearch] = useState("")
   const [devModeEnabled, setDevModeEnabled] = useState(false)
   const [hasOutbound, setHasOutbound] = useState(false)
+  const [activeOwnerKeysRowId, setActiveOwnerKeysRowId] = useState<
+    RequestDetailResponsesItemOwnerRow["id"] | null
+  >(null)
+  const isDesktop = useMediaQuery("(min-width: 640px)")
+
+  useEffect(() => {
+    setActiveOwnerKeysRowId(null)
+  }, [requestId])
 
   useEffect(() => {
     let cancelled = false
@@ -242,13 +499,13 @@ export function RequestDetailPage(): React.JSX.Element {
       .finally(() => setLoading(false))
   }
 
-  async function copyRaw(): Promise<void> {
-    if (!item) return
-
+  async function copyText(
+    value: string,
+    successMessage: string,
+  ): Promise<void> {
     try {
-      const raw = JSON.stringify(item, null, 2)
-      await navigator.clipboard.writeText(raw)
-      toast.success(t("requestDetailPage.toast.copiedJson"))
+      await writeClipboardText(value)
+      toast.success(successMessage)
     } catch (err) {
       toast.error(t("requestDetailPage.toast.copyFailed"), {
         description: String(err),
@@ -256,26 +513,65 @@ export function RequestDetailPage(): React.JSX.Element {
     }
   }
 
-  function downloadRaw(): void {
-    if (!item) return
-
+  function downloadText(
+    value: string,
+    fileName: string,
+    mimeType: string,
+    successMessage: string,
+  ): void {
     try {
-      const raw = JSON.stringify(item, null, 2)
-      const blob = new Blob([raw], { type: "application/json" })
+      const blob = new Blob([value], { type: mimeType })
       const url = URL.createObjectURL(blob)
 
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `${item.request_id}.json`
-      a.click()
+      const anchor = document.createElement("a")
+      anchor.href = url
+      anchor.download = fileName
+      anchor.click()
 
       URL.revokeObjectURL(url)
-      toast.success(t("requestDetailPage.toast.downloadedJson"))
+      toast.success(successMessage)
     } catch (err) {
       toast.error(t("requestDetailPage.toast.downloadFailed"), {
         description: String(err),
       })
     }
+  }
+
+  async function copyRaw(): Promise<void> {
+    if (!item) return
+
+    await copyText(
+      JSON.stringify(item, null, 2),
+      t("requestDetailPage.toast.copiedJson"),
+    )
+  }
+
+  function downloadRaw(): void {
+    if (!item) return
+
+    downloadText(
+      JSON.stringify(item, null, 2),
+      `${item.request_id}.json`,
+      "application/json",
+      t("requestDetailPage.toast.downloadedJson"),
+    )
+  }
+
+  async function copyOwnerKeys(row: RequestDetailResponsesItemOwnerRow): Promise<void> {
+    if (row.value.empty) return
+
+    await copyText(row.value.raw, t("requestDetailPage.toast.copiedText"))
+  }
+
+  function downloadOwnerKeys(row: RequestDetailResponsesItemOwnerRow): void {
+    if (row.value.empty) return
+
+    downloadText(
+      row.value.raw,
+      `${requestId}-${row.id}-owner-keys.txt`,
+      "text/plain;charset=utf-8",
+      t("requestDetailPage.toast.downloadedText"),
+    )
   }
 
   /* Loading state */
@@ -339,6 +635,9 @@ export function RequestDetailPage(): React.JSX.Element {
   }
 
   const quota = getQuotaLabel(item)
+  const ownerKeyRows = buildRequestDetailResponsesItemOwnerRows(item)
+  const activeOwnerKeysRow =
+    ownerKeyRows.find((row) => row.id === activeOwnerKeysRowId) ?? null
 
   return (
     <div className="space-y-4 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-300">
@@ -525,7 +824,7 @@ export function RequestDetailPage(): React.JSX.Element {
                     </TableCell>
                   </TableRow>
                 ) : null}
-                {buildRequestDetailResponsesItemOwnerRows(item).map((row) => (
+                {ownerKeyRows.map((row) => (
                   <TableRow key={row.labelKey}>
                     <TableCell className="text-muted-foreground">
                       <FieldLabel
@@ -533,8 +832,13 @@ export function RequestDetailPage(): React.JSX.Element {
                         tooltip={t(row.tooltipKey)}
                       />
                     </TableCell>
-                    <TableCell className="font-mono text-xs whitespace-pre-wrap break-words">
-                      {row.value}
+                    <TableCell className="font-mono text-xs">
+                      <OwnerKeysSummaryValue
+                        row={row}
+                        onView={() => setActiveOwnerKeysRowId(row.id)}
+                        onCopy={() => void copyOwnerKeys(row)}
+                        onDownload={() => downloadOwnerKeys(row)}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}
@@ -821,6 +1125,28 @@ export function RequestDetailPage(): React.JSX.Element {
           </CardContent>
         </Card>
       </div>
+
+      <OwnerKeysViewer
+        key={activeOwnerKeysRow?.id ?? "closed"}
+        row={activeOwnerKeysRow}
+        open={activeOwnerKeysRow !== null}
+        isDesktop={isDesktop}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActiveOwnerKeysRowId(null)
+          }
+        }}
+        onCopy={() => {
+          if (activeOwnerKeysRow) {
+            void copyOwnerKeys(activeOwnerKeysRow)
+          }
+        }}
+        onDownload={() => {
+          if (activeOwnerKeysRow) {
+            downloadOwnerKeys(activeOwnerKeysRow)
+          }
+        }}
+      />
     </div>
   )
 }

--- a/admin-ui/tests/request-detail-ownership.test.ts
+++ b/admin-ui/tests/request-detail-ownership.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 
 import { buildRequestDetailResponsesItemOwnerRows } from "../src/lib/request-detail-ownership"
 
-test("buildRequestDetailResponsesItemOwnerRows exposes lookup and recorded keys", () => {
+test("buildRequestDetailResponsesItemOwnerRows exposes structured lookup and recorded keys", () => {
   const rows = buildRequestDetailResponsesItemOwnerRows({
     responses_item_owner_lookup_keys_json: JSON.stringify(["lookup-key"]),
     responses_item_owner_recorded_keys_json: JSON.stringify(["recorded-key"]),
@@ -10,21 +10,58 @@ test("buildRequestDetailResponsesItemOwnerRows exposes lookup and recorded keys"
 
   expect(rows).toEqual([
     {
+      id: "lookup",
       labelKey: "requestDetailPage.fields.responsesItemOwnerLookupKeys",
       tooltipKey: "requestDetailPage.fieldTooltip.responsesItemOwnerLookupKeys",
-      value: "lookup-key",
+      value: {
+        raw: "lookup-key",
+        lines: ["lookup-key"],
+        count: 1,
+        charCount: 10,
+        previewLines: ["lookup-key"],
+        hiddenCount: 0,
+        empty: false,
+      },
     },
     {
+      id: "recorded",
       labelKey: "requestDetailPage.fields.responsesItemOwnerRecordedKeys",
       tooltipKey:
         "requestDetailPage.fieldTooltip.responsesItemOwnerRecordedKeys",
-      value: "recorded-key",
+      value: {
+        raw: "recorded-key",
+        lines: ["recorded-key"],
+        count: 1,
+        charCount: 12,
+        previewLines: ["recorded-key"],
+        hiddenCount: 0,
+        empty: false,
+      },
     },
   ])
 })
 
-test("buildRequestDetailResponsesItemOwnerRows uses placeholder for empty keys", () => {
+test("buildRequestDetailResponsesItemOwnerRows uses placeholder metadata for empty keys", () => {
   const rows = buildRequestDetailResponsesItemOwnerRows({})
 
-  expect(rows.map((row) => row.value)).toEqual(["—", "—"])
+  expect(rows.map((row) => row.value)).toEqual([
+    {
+      raw: "—",
+      lines: [],
+      count: 0,
+      charCount: 0,
+      previewLines: ["—"],
+      hiddenCount: 0,
+      empty: true,
+    },
+    {
+      raw: "—",
+      lines: [],
+      count: 0,
+      charCount: 0,
+      previewLines: ["—"],
+      hiddenCount: 0,
+      empty: true,
+    },
+  ])
 })

--- a/admin-ui/tests/request-detail-ownership.test.ts
+++ b/admin-ui/tests/request-detail-ownership.test.ts
@@ -65,3 +65,21 @@ test("buildRequestDetailResponsesItemOwnerRows uses placeholder metadata for emp
     },
   ])
 })
+
+test("buildRequestDetailResponsesItemOwnerRows preserves raw fallback text while normalizing preview lines", () => {
+  const raw = "  key-a  \n\n key-b "
+
+  const rows = buildRequestDetailResponsesItemOwnerRows({
+    responses_item_owner_lookup_keys_json: raw,
+  })
+
+  expect(rows[0]?.value).toEqual({
+    raw,
+    lines: ["key-a", "key-b"],
+    count: 2,
+    charCount: 18,
+    previewLines: ["key-a", "key-b"],
+    hiddenCount: 0,
+    empty: false,
+  })
+})


### PR DESCRIPTION
## Summary
- move long Responses Item Owner keys in the request detail page to a compact summary with preview and actions
- add a modal/sheet viewer with search, copy, download, and responsive height constraints for large payloads
- update owner-key formatting helpers, locale strings, and tests to match the new structured display

## Test plan
- [x] bun test tests/request-detail-ownership.test.ts
- [x] bun run --cwd admin-ui lint
- [x] bash -lc 'cd "/Users/nick/.paseo/worktrees/0tmm0jdb/meaty-donkey/admin-ui" && bunx tsc --noEmit -p tsconfig.app.json --ignoreDeprecations 5.0'
- [x] bash -lc 'cd "/Users/nick/.paseo/worktrees/0tmm0jdb/meaty-donkey/admin-ui" && bunx vite build'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了所有者密钥查看器，在桌面设备上以对话框展示，在移动设备上以抽屉式菜单展示
  * 支持批量复制和下载所有者密钥数据
  * 新增搜索、预览、换行和布局选项

* **本地化**
  * 补充了中英文本地化字符串，用于复制/下载确认提示和所有者密钥管理界面

<!-- end of auto-generated comment: release notes by coderabbit.ai -->