### PR TITLE
Added Bun-native Responses WebSocket bridge for Codex compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Compared with routing everything through plain Chat Completions compatibility, t
 ## Features
 
 - **OpenAI & Anthropic Compatibility**: Exposes GitHub Copilot as an OpenAI-compatible (`/v1/responses`, `/v1/chat/completions`, `/v1/models`, `/v1/embeddings`) and Anthropic-compatible (`/v1/messages`) API.
+- **Codex Responses WebSocket Compatibility**: Accepts Codex's preferred Responses WebSocket transport on `/v1/responses` and bridges it through the existing Responses handler.
 - **Anthropic-First Routing for Claude Models**: When a model supports Copilot's native `/v1/messages` endpoint, the proxy prefers it over `/responses` or `/chat/completions`, preserving Anthropic-style `tool_use` / `tool_result` flows and more Claude-native behavior.
 - **Fewer Unnecessary Premium Requests**: Reduces wasted premium usage by routing warmup requests to `smallModel`, merging `tool_result` follow-ups back into the tool flow, and treating resumed tool turns as continuation traffic instead of fresh premium interactions.
 - **Phase-Aware `gpt-5.4` and `gpt-5.3-codex`**: These models can emit user-friendly commentary before deeper reasoning or tool use, so long-running coding actions are easier to understand instead of appearing as a sudden tool burst.
@@ -467,7 +468,7 @@ The `<target>` can be either the account ID (GitHub login) or a 1-based index.
 - **modelRefreshIntervalHours:** Interval for refreshing account model lists in the background. Set to `0` to disable refresh. Defaults to `24`.
 - **sessionAffinityRetentionDays:** Number of days to retain session affinity bindings. Defaults to `7`.
 - **useMessagesApi:** When `true` (default), Claude-family models that support Copilot's native `/v1/messages` endpoint may use the Messages API path. Set to `false` to skip the Messages API candidate and fall back to `/responses` (if supported) or `/chat/completions`.
-- **useResponsesApiWebSocket:** When `true` (default), Responses API requests use Copilot's WebSocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable WebSocket routing.
+- **useResponsesApiWebSocket:** When `true` (default), outbound Copilot Responses API requests use Copilot's WebSocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable upstream WebSocket routing. This does not disable the inbound Codex-compatible WebSocket listener on `/v1/responses`.
 - **useResponsesApiWebSearch:** When `true` (default), `/v1/responses` keeps tools with `type: "web_search"` and forwards them upstream. Set to `false` to strip them before the Copilot request is sent.
 - **logLevel:** Controls handler file-log verbosity under `logs/*.log`. Allowed values: `error`, `warn`, `info`, `debug`. Defaults to `info`. Set it to `debug` when you need payload- or stream-level diagnostics written into file logs.
 - **anthropicApiKey:** Optional Anthropic API key used for accurate Claude token counting (see [Accurate Claude Token Counting](#accurate-claude-token-counting) below). Can also be set via the `ANTHROPIC_API_KEY` environment variable. If not set, token counting falls back to GPT tokenizer estimation.
@@ -505,6 +506,7 @@ These endpoints mimic the OpenAI API structure.
 | Endpoint                    | Method | Description                                                      |
 | --------------------------- | ------ | ---------------------------------------------------------------- |
 | `POST /v1/responses`        | `POST` | OpenAI Most advanced interface for generating model responses.          |
+| `GET /v1/responses`         | `WS`   | Codex-compatible Responses WebSocket transport.                  |
 | `POST /v1/chat/completions` | `POST` | Creates a model response for the given chat conversation.        |
 | `GET /v1/models`            | `GET`  | Lists the currently available models.                            |
 | `POST /v1/embeddings`       | `POST` | Creates an embedding vector representing the input text.         |
@@ -696,6 +698,42 @@ Or use inline environment variable:
 ```sh
 COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 ```
+
+## Using with Codex CLI
+
+Codex can use this proxy as an OpenAI-compatible Responses API provider. The proxy supports both Codex's HTTP `POST /v1/responses` path and its preferred WebSocket upgrade on `GET /v1/responses`.
+
+Start the proxy:
+
+```sh
+bunx --bun @nick3/copilot-api@latest start
+```
+
+> **Note:** The inbound Codex WebSocket listener on `GET /v1/responses` requires the Bun server runtime, so start the proxy with `bunx --bun` (or a local Bun install). The `npx` path is only supported for the lightweight MCP bridge and does not run the WebSocket listener.
+
+Add a provider to `~/.codex/config.toml`:
+
+```toml
+[model_providers.copilot-api]
+name = "copilot-api"
+base_url = "http://localhost:4141/v1"
+wire_api = "responses"
+supports_websockets = true
+
+[profiles.copilot-api]
+model_provider = "copilot-api"
+model = "gpt-5.4"
+```
+
+Then run Codex with that profile:
+
+```sh
+codex -p copilot-api
+```
+
+If you configured `auth.apiKeys`, add the same key to Codex's provider headers or bearer-token configuration so both HTTP and WebSocket requests authenticate successfully. For troubleshooting only, set `supports_websockets = false` in Codex to force its HTTP fallback path.
+
+> **Note:** When using Codex via GitHub Copilot, it is currently recommended to disable Codex multi-agent features because Copilot billing may count Codex traffic based on the final user-role message.
 
 ## Using with Claude Code
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,7 @@
 ## 功能特性
 
 - **OpenAI 与 Anthropic 双兼容**：以 OpenAI 兼容接口（`/v1/responses`、`/v1/chat/completions`、`/v1/models`、`/v1/embeddings`）和 Anthropic 兼容接口（`/v1/messages`）对外暴露 GitHub Copilot。
+- **Codex Responses WebSocket 兼容**：在 `/v1/responses` 接受 Codex 偏好的 Responses WebSocket transport，并桥接到现有 Responses handler。
 - **Claude 模型优先走 Anthropic 原生路由**：当模型支持 Copilot 原生 `/v1/messages` 端点时，代理会优先使用它，而不是 `/responses` 或 `/chat/completions`，从而保留 Anthropic 风格的 `tool_use` / `tool_result` 流程以及更原生的 Claude 行为。
 - **减少不必要的 Premium 请求**：通过把预热请求路由到 `smallModel`、将 `tool_result` 的后续消息重新并入工具流，以及把恢复的工具轮次视为延续流量而非全新高级交互，减少浪费的 premium 使用量。
 - **分阶段的 `gpt-5.4` 与 `gpt-5.3-codex`**：这些模型可以在更深入推理或调用工具前先发出面向用户的 commentary，让长时间运行的编码操作更容易理解，而不是突然开始一串工具调用。
@@ -476,7 +477,7 @@ MCP HTTP 的浏览器 CORS 默认只允许 loopback origin。可设置 `COPILOT_
 - **modelRefreshIntervalHours：** 后台刷新账号模型列表的间隔小时数。设为 `0` 可关闭自动刷新。默认值为 `24`。
 - **sessionAffinityRetentionDays：** session affinity 绑定的保留天数。默认值为 `7`。
 - **useMessagesApi：** 当为 `true`（默认）时，支持 Copilot 原生 `/v1/messages` 端点的 Claude 系模型会走 Messages API 路径。设为 `false` 时，将跳过 Messages API 候选，回退到 `/responses`（如支持）或 `/chat/completions`。
-- **useResponsesApiWebSocket：** 当为 `true`（默认）时，Responses API 请求会对声明了 `ws:/responses` 的模型使用 Copilot WebSocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用 WebSocket 路由。
+- **useResponsesApiWebSocket：** 当为 `true`（默认）时，发往上游 Copilot Responses API 的请求会对声明了 `ws:/responses` 的模型使用 Copilot WebSocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用上游 WebSocket 路由。该配置不会禁用 `/v1/responses` 上面向 Codex 的入站 WebSocket listener。
 - **useResponsesApiWebSearch：** 当为 `true`（默认）时，`/v1/responses` 会保留 `type: "web_search"` 的工具并转发到上游。设为 `false` 则会在发送 Copilot 请求之前将其剥离。
 - **logLevel：** 控制 `logs/*.log` 下 handler 文件日志的详细级别。可选值：`error`、`warn`、`info`、`debug`。默认值为 `info`。如果你需要把 payload 级或 stream 级的调试内容写入文件日志，请显式设置为 `debug`。
 - **anthropicApiKey：** 可选的 Anthropic API key，用于精确的 Claude token 计数（见下文 [精确的 Claude Token 计数](#accurate-claude-token-counting)）。也可通过环境变量 `ANTHROPIC_API_KEY` 设置。未配置时会回退到 GPT tokenizer 估算。
@@ -514,6 +515,7 @@ curl http://localhost:4141/v1/models \
 | 端点 | 方法 | 说明 |
 | --- | --- | --- |
 | `POST /v1/responses` | `POST` | OpenAI 中用于生成模型响应的高级接口。 |
+| `GET /v1/responses` | `WS` | Codex 兼容的 Responses WebSocket transport。 |
 | `POST /v1/chat/completions` | `POST` | 为给定聊天对话创建模型响应。 |
 | `GET /v1/models` | `GET` | 列出当前可用模型。 |
 | `POST /v1/embeddings` | `POST` | 创建表示输入文本的向量嵌入。 |
@@ -706,6 +708,42 @@ bunx --bun @nick3/copilot-api@latest auth
 ```sh
 COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 ```
+
+## 与 Codex CLI 一起使用
+
+Codex 可以把本代理作为 OpenAI 兼容的 Responses API provider 使用。本代理同时支持 Codex 的 HTTP `POST /v1/responses` 路径，以及它偏好的 `GET /v1/responses` WebSocket upgrade。
+
+启动代理：
+
+```sh
+bunx --bun @nick3/copilot-api@latest start
+```
+
+> **注意：** `GET /v1/responses` 上的入站 Codex WebSocket listener 需要 Bun 服务端运行时，因此请使用 `bunx --bun`（或本地安装的 Bun）启动代理。`npx` 路径仅支持轻量级 MCP bridge，不会运行该 WebSocket listener。
+
+在 `~/.codex/config.toml` 中添加 provider：
+
+```toml
+[model_providers.copilot-api]
+name = "copilot-api"
+base_url = "http://localhost:4141/v1"
+wire_api = "responses"
+supports_websockets = true
+
+[profiles.copilot-api]
+model_provider = "copilot-api"
+model = "gpt-5.4"
+```
+
+然后使用该 profile 启动 Codex：
+
+```sh
+codex -p copilot-api
+```
+
+如果你配置了 `auth.apiKeys`，需要在 Codex 的 provider headers 或 bearer-token 配置里使用同一个 key，这样 HTTP 与 WebSocket 请求都能通过认证。仅在排障时，可以在 Codex 中设置 `supports_websockets = false` 来强制走 HTTP fallback。
+
+> **注意：** 通过 GitHub Copilot 使用 Codex 时，目前建议关闭 Codex multi-agent 功能，因为 Copilot 可能会根据最后一条 user-role 消息来计算 Codex 流量。
 
 ## 与 Claude Code 一起使用
 

--- a/src/lib/request-auth.ts
+++ b/src/lib/request-auth.ts
@@ -73,12 +73,16 @@ export function getConfiguredApiKeys(): Array<string> {
 }
 
 export function extractRequestApiKey(c: Context): string | null {
-  const xApiKey = c.req.header("x-api-key")?.trim()
+  return extractHeadersApiKey(c.req.raw.headers)
+}
+
+export function extractHeadersApiKey(headers: Headers): string | null {
+  const xApiKey = headers.get("x-api-key")?.trim()
   if (xApiKey) {
     return xApiKey
   }
 
-  const authorization = c.req.header("authorization")
+  const authorization = headers.get("authorization")
   if (!authorization) {
     return null
   }
@@ -90,6 +94,40 @@ export function extractRequestApiKey(c: Context): string | null {
 
   const bearerToken = rest.join(" ").trim()
   return bearerToken || null
+}
+
+export function isAuthorizedHeaders(
+  headers: Headers,
+  getApiKeys: () => Array<string> = getConfiguredApiKeys,
+): boolean {
+  const apiKeys = getApiKeys()
+  if (apiKeys.length === 0) {
+    return true
+  }
+
+  const requestApiKey = extractHeadersApiKey(headers)
+  return requestApiKey ?
+      apiKeys.some((apiKey) => timingSafeKeyCompare(requestApiKey, apiKey))
+    : false
+}
+
+export function createUnauthorizedRawResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message:
+          "Unauthorized. Provide Authorization: Bearer <key> or x-api-key.",
+        type: "unauthorized",
+      },
+    }),
+    {
+      status: 401,
+      headers: {
+        "content-type": "application/json",
+        "WWW-Authenticate": 'Bearer realm="copilot-api"',
+      },
+    },
+  )
 }
 
 function createUnauthorizedResponse(c: Context): Response {
@@ -163,17 +201,7 @@ export function createAuthMiddleware(
       return next()
     }
 
-    const apiKeys = getApiKeys()
-    if (apiKeys.length === 0) {
-      return next()
-    }
-
-    const requestApiKey = extractRequestApiKey(c)
-    const hasValidApiKey =
-      requestApiKey ?
-        apiKeys.some((apiKey) => timingSafeKeyCompare(requestApiKey, apiKey))
-      : false
-    if (!hasValidApiKey) {
+    if (!isAuthorizedHeaders(c.req.raw.headers, getApiKeys)) {
       return createUnauthorizedResponse(c)
     }
 

--- a/src/routes/responses/websocket.ts
+++ b/src/routes/responses/websocket.ts
@@ -1,0 +1,388 @@
+import consola from "consola"
+
+import {
+  createUnauthorizedRawResponse,
+  isAuthorizedHeaders,
+} from "~/lib/request-auth"
+
+const RESPONSES_WEBSOCKET_PATHS = new Set(["/responses", "/v1/responses"])
+const SSE_RECORD_SEPARATOR = /\r?\n\r?\n/u
+const FORWARDED_HEADER_NAMES = [
+  "authorization",
+  "x-api-key",
+  "user-agent",
+  "x-session-id",
+  "x-session-affinity",
+  "x-parent-session-id",
+  "x-trace-id",
+]
+
+type ServerWebSocket = Bun.ServerWebSocket<ResponsesWebSocketData>
+type AppFetch = (request: Request) => Response | Promise<Response>
+
+export type ResponsesWebSocketData = {
+  active: boolean
+  controller: AbortController | null
+  headers: Array<[string, string]>
+  url: string
+}
+
+type ResponsesWebSocketFrame = {
+  type?: unknown
+  [key: string]: unknown
+}
+
+export function createResponsesWebSocketHandler(
+  appFetch: AppFetch,
+): Bun.WebSocketHandler<ResponsesWebSocketData> {
+  return {
+    data: {} as ResponsesWebSocketData,
+    idleTimeout: 0,
+    async message(ws, message) {
+      await handleResponsesWebSocketMessage(ws, message, appFetch)
+    },
+    close(ws) {
+      // Abort any in-flight upstream Responses request so we stop consuming
+      // tokens/quota and worker time once the client disconnects.
+      ws.data.controller?.abort()
+    },
+  }
+}
+
+export function handleResponsesWebSocketUpgrade(
+  req: Request,
+  server: Bun.Server<ResponsesWebSocketData>,
+): Response | null | undefined {
+  if (!isResponsesWebSocketUpgrade(req)) {
+    return null
+  }
+
+  if (!isAuthorizedHeaders(req.headers)) {
+    return createUnauthorizedRawResponse()
+  }
+
+  const upgraded = server.upgrade(req, {
+    data: buildResponsesWebSocketData(req),
+  })
+
+  if (upgraded) {
+    return undefined
+  }
+
+  return new Response("WebSocket upgrade failed", { status: 400 })
+}
+
+export function isResponsesWebSocketUpgrade(req: Request): boolean {
+  if (req.method !== "GET") {
+    return false
+  }
+
+  const pathname = new URL(req.url).pathname
+  if (!RESPONSES_WEBSOCKET_PATHS.has(pathname)) {
+    return false
+  }
+
+  return req.headers.get("upgrade")?.toLowerCase() === "websocket"
+}
+
+export async function handleResponsesWebSocketMessage(
+  ws: ServerWebSocket,
+  message: string | ArrayBuffer | Uint8Array,
+  appFetch: AppFetch,
+): Promise<void> {
+  let frame: ResponsesWebSocketFrame
+  try {
+    frame = JSON.parse(
+      normalizeWebSocketMessage(message),
+    ) as ResponsesWebSocketFrame
+  } catch {
+    sendResponsesWebSocketError(ws, "Invalid websocket JSON frame", 400)
+    return
+  }
+
+  if (frame.type === "response.processed") {
+    return
+  }
+
+  if (frame.type !== "response.create") {
+    sendResponsesWebSocketError(ws, "Unsupported websocket frame type", 400)
+    return
+  }
+
+  if (frame.generate === false) {
+    sendResponsesWebSocketWarmupCompleted(ws)
+    return
+  }
+
+  if (ws.data.active) {
+    sendResponsesWebSocketError(
+      ws,
+      "Responses websocket request already active",
+      409,
+    )
+    return
+  }
+
+  ws.data.active = true
+  const controller = new AbortController()
+  ws.data.controller = controller
+  try {
+    await forwardResponseCreateFrame(ws, frame, appFetch, controller)
+  } catch (error) {
+    consola.warn("Responses websocket bridge failed:", error)
+    sendResponsesWebSocketError(
+      ws,
+      error instanceof Error ? error.message : String(error),
+      500,
+    )
+  } finally {
+    ws.data.active = false
+    ws.data.controller = null
+  }
+}
+
+export function parseSseRecords(chunk: string): {
+  events: Array<string>
+  remainder: string
+} {
+  const events: Array<string> = []
+  let remainder = chunk
+
+  while (true) {
+    const match = SSE_RECORD_SEPARATOR.exec(remainder)
+    if (!match) {
+      break
+    }
+
+    const record = remainder.slice(0, match.index)
+    remainder = remainder.slice(match.index + match[0].length)
+    const data = parseSseRecordData(record)
+    if (data !== null && data !== "[DONE]") {
+      events.push(data)
+    }
+  }
+
+  return { events, remainder }
+}
+
+function buildResponsesWebSocketData(req: Request): ResponsesWebSocketData {
+  return {
+    active: false,
+    controller: null,
+    headers: collectForwardedHeaders(req.headers),
+    url: req.url,
+  }
+}
+
+function collectForwardedHeaders(headers: Headers): Array<[string, string]> {
+  const forwarded: Array<[string, string]> = []
+  for (const name of FORWARDED_HEADER_NAMES) {
+    const value = headers.get(name)
+    if (value) {
+      forwarded.push([name, value])
+    }
+  }
+  return forwarded
+}
+
+async function forwardResponseCreateFrame(
+  ws: ServerWebSocket,
+  frame: ResponsesWebSocketFrame,
+  appFetch: AppFetch,
+  controller: AbortController,
+): Promise<void> {
+  const payload = { ...frame, stream: true }
+  delete payload.type
+
+  const response = await appFetch(
+    new Request(buildInternalResponsesUrl(ws.data.url), {
+      method: "POST",
+      headers: buildInternalResponsesHeaders(ws.data.headers),
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    }),
+  )
+
+  if (!response.ok) {
+    sendResponsesWebSocketError(
+      ws,
+      await readErrorResponseMessage(response),
+      response.status,
+    )
+    return
+  }
+
+  if (!response.body) {
+    sendResponsesWebSocketError(ws, "Responses stream body is empty", 500)
+    return
+  }
+
+  await streamSseResponseToWebSocket(ws, response.body, controller)
+}
+
+function buildInternalResponsesUrl(sourceUrl: string): string {
+  const url = new URL(sourceUrl)
+  url.protocol = "http:"
+  url.pathname =
+    url.pathname.startsWith("/v1/") ? "/v1/responses" : "/responses"
+  url.search = ""
+  url.hash = ""
+  return url.toString()
+}
+
+function buildInternalResponsesHeaders(
+  forwardedHeaders: Array<[string, string]>,
+): Headers {
+  const headers = new Headers(forwardedHeaders)
+  headers.set("content-type", "application/json")
+  return headers
+}
+
+async function streamSseResponseToWebSocket(
+  ws: ServerWebSocket,
+  body: ReadableStream<Uint8Array>,
+  controller: AbortController,
+): Promise<void> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  // Cancel the upstream reader as soon as the connection is aborted (client
+  // close or a failed send) so the upstream stream is torn down promptly.
+  const onAbort = () => {
+    void reader.cancel()
+  }
+  controller.signal.addEventListener("abort", onAbort)
+
+  try {
+    while (!controller.signal.aborted) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+
+      buffer += decoder.decode(value, { stream: true })
+      const parsed = parseSseRecords(buffer)
+      buffer = parsed.remainder
+      if (!relaySseEvents(ws, parsed.events, controller)) {
+        return
+      }
+    }
+
+    if (controller.signal.aborted) {
+      return
+    }
+
+    buffer += decoder.decode()
+    const parsed = parseSseRecords(`${buffer}\n\n`)
+    relaySseEvents(ws, parsed.events, controller)
+  } finally {
+    controller.signal.removeEventListener("abort", onAbort)
+    try {
+      reader.releaseLock()
+    } catch {
+      // Reader may already be released after cancellation; ignore.
+    }
+  }
+}
+
+/**
+ * Relay parsed SSE events to the client. Returns `false` if a send failed and
+ * the upstream request was aborted, signalling the caller to stop streaming.
+ */
+function relaySseEvents(
+  ws: ServerWebSocket,
+  events: Array<string>,
+  controller: AbortController,
+): boolean {
+  for (const event of events) {
+    if (controller.signal.aborted) {
+      return false
+    }
+    try {
+      ws.send(event)
+    } catch (error) {
+      consola.warn("Responses websocket send failed:", error)
+      controller.abort()
+      return false
+    }
+  }
+  return true
+}
+
+function parseSseRecordData(record: string): string | null {
+  const lines = record.split(/\r?\n/u)
+  const dataLines = lines
+    .filter((line) => line.startsWith("data:"))
+    // Per the SSE spec, strip only a single optional leading space after the
+    // colon (not arbitrary whitespace), preserving whitespace-sensitive data.
+    .map((line) => (line.startsWith("data: ") ? line.slice(6) : line.slice(5)))
+
+  if (dataLines.length === 0) {
+    return null
+  }
+
+  return dataLines.join("\n")
+}
+
+function normalizeWebSocketMessage(
+  message: string | ArrayBuffer | Uint8Array,
+): string {
+  if (typeof message === "string") {
+    return message
+  }
+
+  return new TextDecoder().decode(message)
+}
+
+function sendResponsesWebSocketError(
+  ws: ServerWebSocket,
+  message: string,
+  status: number,
+): void {
+  // Mirror the Responses stream error contract (see ResponseErrorEvent in
+  // src/services/copilot/create-responses.ts) so clients always receive the
+  // same top-level event shape regardless of where the error originates.
+  ws.send(
+    JSON.stringify({
+      code: status ? String(status) : null,
+      message,
+      param: null,
+      sequence_number: 0,
+      type: "error",
+    }),
+  )
+}
+
+function sendResponsesWebSocketWarmupCompleted(ws: ServerWebSocket): void {
+  ws.send(
+    JSON.stringify({
+      response: {
+        id: "",
+      },
+      sequence_number: 0,
+      type: "response.completed",
+    }),
+  )
+}
+
+async function readErrorResponseMessage(response: Response): Promise<string> {
+  const body = await response.text()
+  if (!body) {
+    return `Responses request failed with status ${response.status}`
+  }
+
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: unknown }
+      message?: unknown
+    }
+    const message =
+      typeof parsed.error?.message === "string" ? parsed.error.message
+      : typeof parsed.message === "string" ? parsed.message
+      : undefined
+    return message ?? body
+  } catch {
+    return body
+  }
+}

--- a/src/start.ts
+++ b/src/start.ts
@@ -3,7 +3,6 @@
 import { defineCommand } from "citty"
 import clipboard from "clipboardy"
 import consola from "consola"
-import { serve } from "srvx"
 
 import {
   registerQuotaRefreshSchedulerShutdownCleanup,
@@ -11,6 +10,10 @@ import {
   stopQuotaRefreshScheduler,
 } from "~/lib/quota-refresh-scheduler-runtime"
 import { isMcpHttpEnabledFromEnv } from "~/mcp-http-config"
+import {
+  createResponsesWebSocketHandler,
+  handleResponsesWebSocketUpgrade,
+} from "~/routes/responses/websocket"
 
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
@@ -255,13 +258,25 @@ export async function runServer(options: RunServerOptions): Promise<void> {
 
   const { createServer } = await import("./server")
   const server = createServer({ enableMcpHttp })
+  const responsesWebSocketHandler = createResponsesWebSocketHandler(
+    server.fetch,
+  )
 
-  serve({
-    fetch: server.fetch,
+  Bun.serve({
     port: options.port,
-    bun: {
-      idleTimeout: 0,
+    idleTimeout: 0,
+    fetch: (request, bunServer) => {
+      const websocketResponse = handleResponsesWebSocketUpgrade(
+        request,
+        bunServer,
+      )
+      if (websocketResponse !== null) {
+        return websocketResponse
+      }
+
+      return server.fetch(request)
     },
+    websocket: responsesWebSocketHandler,
   })
 }
 

--- a/tests/request-auth.test.ts
+++ b/tests/request-auth.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test"
 import { Hono } from "hono"
 
-import { createAuthMiddleware } from "../src/lib/request-auth"
+import {
+  createAuthMiddleware,
+  extractHeadersApiKey,
+  isAuthorizedHeaders,
+} from "~/lib/request-auth"
 
 function createTestApp() {
   const app = new Hono()
@@ -56,6 +60,49 @@ test("authenticated route requires valid key", async () => {
     }),
   )
   expect(authorized.status).toBe(200)
+})
+
+test("raw headers auth supports x-api-key and bearer tokens", () => {
+  expect(
+    isAuthorizedHeaders(
+      new Headers({
+        "x-api-key": "k",
+      }),
+      () => ["k"],
+    ),
+  ).toBe(true)
+
+  expect(
+    isAuthorizedHeaders(
+      new Headers({
+        authorization: "Bearer k",
+      }),
+      () => ["k"],
+    ),
+  ).toBe(true)
+
+  expect(
+    isAuthorizedHeaders(
+      new Headers({
+        authorization: "Bearer wrong",
+      }),
+      () => ["k"],
+    ),
+  ).toBe(false)
+})
+
+test("raw headers auth allows requests when no keys are configured", () => {
+  expect(isAuthorizedHeaders(new Headers(), () => [])).toBe(true)
+})
+
+test("extractHeadersApiKey ignores unsupported authorization schemes", () => {
+  expect(
+    extractHeadersApiKey(
+      new Headers({
+        authorization: "Basic k",
+      }),
+    ),
+  ).toBe(null)
 })
 
 test("server keeps admin routes outside request auth middleware", async () => {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1,0 +1,263 @@
+import { expect, test } from "bun:test"
+
+import {
+  createResponsesWebSocketHandler,
+  handleResponsesWebSocketMessage,
+  isResponsesWebSocketUpgrade,
+  parseSseRecords,
+  type ResponsesWebSocketData,
+} from "~/routes/responses/websocket"
+
+type MockWebSocket = {
+  data: ResponsesWebSocketData
+  sent: Array<string>
+  send: (message: string) => number
+}
+
+function createMockWebSocket(): MockWebSocket {
+  const sent: Array<string> = []
+  return {
+    data: {
+      active: false,
+      controller: null,
+      headers: [],
+      url: "http://localhost:4141/v1/responses",
+    },
+    sent,
+    send(message: string) {
+      sent.push(message)
+      return message.length
+    },
+  }
+}
+
+test("detects Responses websocket upgrade requests", () => {
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/v1/responses", {
+        headers: {
+          upgrade: "websocket",
+        },
+      }),
+    ),
+  ).toBe(true)
+
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/responses", {
+        headers: {
+          upgrade: "WebSocket",
+        },
+      }),
+    ),
+  ).toBe(true)
+
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/v1/models", {
+        headers: {
+          upgrade: "websocket",
+        },
+      }),
+    ),
+  ).toBe(false)
+})
+
+test("does not treat normal Responses HTTP requests as websocket upgrades", () => {
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/v1/responses", {
+        method: "POST",
+      }),
+    ),
+  ).toBe(false)
+})
+
+test("parses SSE records into websocket payloads", () => {
+  const parsed = parseSseRecords(
+    'event: response.created\ndata: {"type":"response.created"}\n\n'
+      + 'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+  )
+
+  expect(parsed).toEqual({
+    events: ['{"type":"response.created"}', '{"type":"response.completed"}'],
+    remainder: "",
+  })
+})
+
+test("keeps incomplete SSE records as remainder", () => {
+  const parsed = parseSseRecords(
+    'event: response.created\ndata: {"type":"response.created"}\n\nevent:',
+  )
+
+  expect(parsed).toEqual({
+    events: ['{"type":"response.created"}'],
+    remainder: "event:",
+  })
+})
+
+test("ignores SSE done markers", () => {
+  expect(parseSseRecords("data: [DONE]\n\n")).toEqual({
+    events: [],
+    remainder: "",
+  })
+})
+
+test("responds to websocket warmup without calling app fetch", async () => {
+  const ws = createMockWebSocket()
+  let fetchCalled = false
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({
+      generate: false,
+      model: "gpt-test",
+      type: "response.create",
+    }),
+    () => {
+      fetchCalled = true
+      return Promise.resolve(new Response(null, { status: 500 }))
+    },
+  )
+
+  expect(fetchCalled).toBe(false)
+  expect(ws.sent.map((item) => JSON.parse(item) as unknown)).toEqual([
+    {
+      response: {
+        id: "",
+      },
+      sequence_number: 0,
+      type: "response.completed",
+    },
+  ])
+})
+
+test("forwards response.create to app fetch and relays SSE events", async () => {
+  const ws = createMockWebSocket()
+  let requestBody: unknown
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({
+      input: "hello",
+      model: "gpt-test",
+      type: "response.create",
+    }),
+    async (request) => {
+      requestBody = await request.json()
+      return new Response(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-1"}}\n\n',
+        {
+          headers: {
+            "content-type": "text/event-stream",
+          },
+        },
+      )
+    },
+  )
+
+  expect(requestBody).toEqual({
+    input: "hello",
+    model: "gpt-test",
+    stream: true,
+  })
+  expect(ws.sent).toEqual([
+    '{"type":"response.completed","response":{"id":"resp-1"}}',
+  ])
+})
+
+test("preserves a single leading space in SSE data per spec", () => {
+  expect(parseSseRecords('data:  {"value":"x"}\n\n')).toEqual({
+    events: [' {"value":"x"}'],
+    remainder: "",
+  })
+})
+
+test("emits a spec-shaped error frame for invalid JSON", async () => {
+  const ws = createMockWebSocket()
+
+  await handleResponsesWebSocketMessage(ws as never, "{not valid", () =>
+    Promise.resolve(new Response(null, { status: 500 })),
+  )
+
+  expect(ws.sent.map((item) => JSON.parse(item) as unknown)).toEqual([
+    {
+      code: "400",
+      message: "Invalid websocket JSON frame",
+      param: null,
+      sequence_number: 0,
+      type: "error",
+    },
+  ])
+})
+
+test("relays upstream errors as spec-shaped error frames", async () => {
+  const ws = createMockWebSocket()
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({ input: "hi", model: "gpt-test", type: "response.create" }),
+    () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: { message: "boom" } }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+  )
+
+  expect(JSON.parse(ws.sent[0]) as unknown).toEqual({
+    code: "429",
+    message: "boom",
+    param: null,
+    sequence_number: 0,
+    type: "error",
+  })
+})
+
+test("aborts the upstream stream when the client disconnects", async () => {
+  const ws = createMockWebSocket()
+  let cancelled = false
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          'event: response.created\ndata: {"type":"response.created"}\n\n',
+        ),
+      )
+    },
+    // Never resolves on its own; only torn down via cancel().
+    pull() {
+      return new Promise<void>(() => {})
+    },
+    cancel() {
+      cancelled = true
+    },
+  })
+
+  const handler = createResponsesWebSocketHandler(() =>
+    Promise.resolve(
+      new Response(stream, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    ),
+  )
+
+  const messagePromise = handler.message(
+    ws as never,
+    JSON.stringify({ input: "hi", model: "gpt-test", type: "response.create" }),
+  )
+
+  // Let the first SSE event flow through before disconnecting.
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  expect(ws.sent).toContain('{"type":"response.created"}')
+  expect(ws.data.controller).not.toBeNull()
+
+  // Simulate the client closing the websocket.
+  void handler.close?.(ws as never, 1000, "client closed")
+  await messagePromise
+
+  expect(cancelled).toBe(true)
+  expect(ws.data.controller).toBeNull()
+})


### PR DESCRIPTION
## Summary

Adds Codex CLI compatibility for the Responses WebSocket transport.

Codex prefers opening a WebSocket with `GET /v1/responses` before falling back to HTTP `POST /v1/responses`. Previously, `copilot-api` only exposed the HTTP route, so Codex saw repeated `404 Not Found` WebSocket upgrade failures before eventually falling back to HTTP.

This change adds a Bun-native inbound WebSocket bridge for `/responses` and `/v1/responses` while keeping the existing Responses handler as the source of truth.

## Why

Without this, Codex users see repeated reconnect attempts like:

```text
Unexpected status 404 Not Found: 404 Not Found, url: ws://localhost:4141/v1/responses
```

Codex eventually falls back to HTTP, but the UX is slow and noisy. Supporting the preferred WebSocket transport removes the reconnect delay and allows Codex to use its normal Responses transport path.

## What Changed

- Add a Bun WebSocket bridge for `GET /responses` and `GET /v1/responses`.
- Authenticate WebSocket upgrade requests with the same `auth.apiKeys` / `COPILOT_API_KEY` / legacy `apiKey` behavior as HTTP routes.
- Forward Codex `response.create` frames into the existing internal `POST /responses` or `POST /v1/responses` handler with `stream: true`.
- Relay SSE `data:` payloads back to Codex as WebSocket text frames.
- Handle Codex `generate: false` warmup frames locally so startup prewarm does not block the real prompt.
- Treat `response.processed` frames as a no-op for now.
- Switch server startup from `srvx` to `Bun.serve` so the project can use Bun's native WebSocket support directly.
- Document Codex CLI setup and the new inbound WebSocket endpoint in both READMEs.


## Notes

- The existing `/v1/responses` POST route remains the main implementation path for model routing, account selection, quota handling, request history, stream error handling, and upstream Copilot transport selection.
- `useResponsesApiWebSocket` continues to control outbound Copilot WebSocket routing for models that advertise `ws:/responses`; it does not disable the inbound Codex-compatible WebSocket listener.
- `response.processed` is currently ignored because it is an acknowledgement/optimization frame and is not required for correctness.

## Testing

Ran:

```sh
bun test tests/request-auth.test.ts tests/responses-websocket.test.ts
bun run typecheck
bun run lint
```

Also manually verified Codex no longer receives `404` WebSocket upgrade errors and can receive model responses through the copilot-api proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加 Codex 兼容的 GET /v1/responses WebSocket 实时响应支持

* **文档**
  * 新增 Codex CLI 集成使用指南并更新配置说明，明确 WebSocket 行为与回退策略
  * 更新中文 README 对应条目

* **改进**
  * 强化对 WebSocket 连接的鉴权与错误处理，改进连接中止时的上游流取消

* **测试**
  * 增加对 WebSocket 流、SSE 解析与鉴权逻辑的单元与集成测试

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nick3/copilot-api/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->