### PR TITLE
fix: keep MCP bridge compatible with npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ English | [简体中文](./README.zh-CN.md)
 >
 > 2. **Recommend for Opencode:** When using with opencode, we recommend starting with the opencode OAuth app. This approach behaves identically to opencode's built-in GitHub Copilot provider with no Terms of Service risk:
 >    ```sh
->    npx @nick3/copilot-api@latest --oauth-app=opencode start
+>    bunx --bun @nick3/copilot-api@latest --oauth-app=opencode start
 >    ```
 >
 > 3. **Disable multi agent when using codex:** If you're using codex via GitHub Copilot, it's recommended to disable the multi agent feature. Currently, GitHub Copilot charges based on the last message being a user role when using codex, and the billing logic has not been adjusted.
@@ -126,7 +126,7 @@ When an Anthropic API key is configured, the proxy forwards Claude model token c
 ## Prerequisites
 
 - Bun (>= 1.2.x)
-- Node.js if you plan to run the published CLI with `npx`
+- Node.js only if you want to run the lightweight MCP bridge through `npx`
 - GitHub account with Copilot subscription (individual, business, or enterprise)
 
 ## Installation
@@ -143,25 +143,27 @@ To start the server directly from source:
 bun run start start
 ```
 
-## Using with npx
+## Using the published CLI with Bun
 
-You can run the project directly using npx:
+The server and account-management commands are Bun-only because the Admin UI and request history use `bun:sqlite`. Run the published CLI with Bun so the `#!/usr/bin/env node` shebang does not force Node.js:
 
 ```sh
-npx @nick3/copilot-api@latest start
+bunx --bun @nick3/copilot-api@latest start
 ```
 
 With options:
 
 ```sh
-npx @nick3/copilot-api@latest start --port 8080
+bunx --bun @nick3/copilot-api@latest start --port 8080
 ```
 
 For authentication only:
 
 ```sh
-npx @nick3/copilot-api@latest auth
+bunx --bun @nick3/copilot-api@latest auth
 ```
+
+The lightweight MCP bridge is the exception and can still be launched with `npx`; see [GPT Tool Search](#gpt-tool-search).
 
 ## Using with Docker
 
@@ -570,84 +572,87 @@ The server also exposes a built-in admin UI and API for inspecting account statu
 
 ## Example Usage
 
-Using with npx:
+Using the published CLI with Bun:
 
 ```sh
 # Basic usage with start command
-npx @nick3/copilot-api@latest start
+bunx --bun @nick3/copilot-api@latest start
 
 # Run on custom port with verbose logging
-npx @nick3/copilot-api@latest start --port 8080 --verbose
+bunx --bun @nick3/copilot-api@latest start --port 8080 --verbose
 
 # Use with a business plan GitHub account
-npx @nick3/copilot-api@latest start --account-type business
+bunx --bun @nick3/copilot-api@latest start --account-type business
 
 # Use with an enterprise plan GitHub account
-npx @nick3/copilot-api@latest start --account-type enterprise
+bunx --bun @nick3/copilot-api@latest start --account-type enterprise
 
 # Enable manual approval for each request
-npx @nick3/copilot-api@latest start --manual
+bunx --bun @nick3/copilot-api@latest start --manual
 
 # Set rate limit to 30 seconds between requests
-npx @nick3/copilot-api@latest start --rate-limit 30
+bunx --bun @nick3/copilot-api@latest start --rate-limit 30
 
 # Wait instead of error when rate limit is hit
-npx @nick3/copilot-api@latest start --rate-limit 30 --wait
+bunx --bun @nick3/copilot-api@latest start --rate-limit 30 --wait
 
 # Provide GitHub token directly
-npx @nick3/copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
+bunx --bun @nick3/copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
 
 # Run only the auth flow
-npx @nick3/copilot-api@latest auth
+bunx --bun @nick3/copilot-api@latest auth
 
 # Run auth flow with verbose logging
-npx @nick3/copilot-api@latest auth --verbose
+bunx --bun @nick3/copilot-api@latest auth --verbose
 
 # Add multiple accounts (each account is added in order)
-npx @nick3/copilot-api@latest auth add
-npx @nick3/copilot-api@latest auth add  # add second account
+bunx --bun @nick3/copilot-api@latest auth add
+bunx --bun @nick3/copilot-api@latest auth add  # add second account
 
 # List all registered accounts
-npx @nick3/copilot-api@latest auth ls
+bunx --bun @nick3/copilot-api@latest auth ls
 
 # List accounts with quota information
-npx @nick3/copilot-api@latest auth ls -q
+bunx --bun @nick3/copilot-api@latest auth ls -q
 
 # Remove an account by index (1-based)
-npx @nick3/copilot-api@latest auth rm 2
+bunx --bun @nick3/copilot-api@latest auth rm 2
 
 # Remove an account by ID (GitHub login)
-npx @nick3/copilot-api@latest auth rm octocat
+bunx --bun @nick3/copilot-api@latest auth rm octocat
 
 # Show your Copilot usage/quota in the terminal (no server needed)
-npx @nick3/copilot-api@latest check-usage
+bunx --bun @nick3/copilot-api@latest check-usage
 
 # Display debug information for troubleshooting
-npx @nick3/copilot-api@latest debug
+bunx --bun @nick3/copilot-api@latest debug
 
 # Display debug information in JSON format
-npx @nick3/copilot-api@latest debug --json
+bunx --bun @nick3/copilot-api@latest debug --json
 
 # Initialize proxy from environment variables (HTTP_PROXY, HTTPS_PROXY, etc.)
-npx @nick3/copilot-api@latest start --proxy-env
+bunx --bun @nick3/copilot-api@latest start --proxy-env
 
 # Use opencode GitHub Copilot authentication
-COPILOT_API_OAUTH_APP=opencode npx @nick3/copilot-api@latest start
+COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 
 # Set custom API home directory via command line
-npx @nick3/copilot-api@latest --api-home=/path/to/custom/dir start
+bunx --bun @nick3/copilot-api@latest --api-home=/path/to/custom/dir start
 
 # Use GitHub Enterprise via command line
-npx @nick3/copilot-api@latest --enterprise-url=company.ghe.com start
+bunx --bun @nick3/copilot-api@latest --enterprise-url=company.ghe.com start
 
 # Use opencode OAuth via command line
-npx @nick3/copilot-api@latest --oauth-app=opencode start
+bunx --bun @nick3/copilot-api@latest --oauth-app=opencode start
 
 # Combine multiple global options
-npx @nick3/copilot-api@latest --api-home=/custom/path --oauth-app=opencode --enterprise-url=company.ghe.com start
+bunx --bun @nick3/copilot-api@latest --api-home=/custom/path --oauth-app=opencode --enterprise-url=company.ghe.com start
+```
 
-# Run the published CLI with Bun instead of Node.js
-bunx --bun @nick3/copilot-api@latest start
+For the MCP tool-search bridge only, `npx` remains supported:
+
+```sh
+npx -y @nick3/copilot-api@latest mcp
 ```
 
 ### Opencode OAuth Authentication
@@ -659,14 +664,14 @@ You can use opencode GitHub Copilot authentication instead of the default one:
 export COPILOT_API_OAUTH_APP=opencode
 
 # Then run start or auth commands
-npx @nick3/copilot-api@latest start
-npx @nick3/copilot-api@latest auth
+bunx --bun @nick3/copilot-api@latest start
+bunx --bun @nick3/copilot-api@latest auth
 ```
 
 Or use inline environment variable:
 
 ```sh
-COPILOT_API_OAUTH_APP=opencode npx @nick3/copilot-api@latest start
+COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 ```
 
 ## Using with Claude Code
@@ -680,7 +685,7 @@ There are two ways to configure Claude Code to use this proxy:
 To get started, run the `start` command with the `--claude-code` flag:
 
 ```sh
-npx @nick3/copilot-api@latest start --claude-code
+bunx --bun @nick3/copilot-api@latest start --claude-code
 ```
 
 You will be prompted to select a primary model and a "small, fast" model for background tasks. After selecting the models, a command will be copied to your clipboard. This command sets the necessary environment variables for Claude Code to use the proxy.
@@ -736,6 +741,8 @@ Do not set Claude Code's native `ENABLE_TOOL_SEARCH` for GPT models. That flag e
 
 If you install `tool-search@copilot-api-marketplace`, Claude Code receives this MCP bridge automatically and you can skip the manual Claude Code MCP setup below.
 
+This MCP bridge is intentionally small and does not load the server or SQLite code, so it remains safe to run through `npx`. Use Bun for the main `start`, `auth`, `check-usage`, and `debug` commands.
+
 Add the tool search bridge to the MCP config used by Claude Code:
 
 ```json
@@ -778,7 +785,7 @@ OpenCode already has a direct GitHub Copilot provider. Use this section when you
 Start the proxy with the OpenCode OAuth app:
 
 ```sh
-npx @nick3/copilot-api@latest --oauth-app=opencode start
+bunx --bun @nick3/copilot-api@latest --oauth-app=opencode start
 ```
 
 Then point OpenCode at the proxy with `@ai-sdk/anthropic`.
@@ -868,7 +875,7 @@ Why these fields matter:
 curl "http://localhost:4141/api/admin/meta"
 
 # Enable remote admin UI/API access (server-side)
-# ADMIN_TOKEN=your_admin_token_here npx @nick3/copilot-api@latest start
+# ADMIN_TOKEN=your_admin_token_here bunx --bun @nick3/copilot-api@latest start
 
 # Remote access (token required)
 curl -H "x-admin-token: your_admin_token_here" "http://localhost:4141/api/admin/accounts?include_stats=1"
@@ -886,9 +893,9 @@ curl "http://localhost:4141/api/admin/requests/<requestId>"
 
 The proxy includes a built-in admin UI served from your running instance. It lets you inspect account status and request history captured by the proxy (models/endpoints, tokens/usage, timing, and error summaries).
 
-1. Start the server. For example, using npx:
+1. Start the server. For example, using Bun:
     ```sh
-    npx @nick3/copilot-api@latest start
+    bunx --bun @nick3/copilot-api@latest start
     ```
 2. Open the UI in your browser:
     - `http://localhost:4141/admin` (replace the port if you changed it)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@
 >
 > 2. **推荐给 opencode 用户：** 与 opencode 搭配时，推荐优先使用 opencode OAuth app 启动。该方式与 opencode 内置的 GitHub Copilot provider 行为一致，且不存在 Terms of Service 风险：
 >    ```sh
->    npx @nick3/copilot-api@latest --oauth-app=opencode start
+>    bunx --bun @nick3/copilot-api@latest --oauth-app=opencode start
 >    ```
 >
 > 3. **通过 codex 使用时请关闭 multi agent：** 如果你是通过 GitHub Copilot 使用 codex，建议关闭 multi agent 功能。目前 GitHub Copilot 在 codex 场景下会按最后一条消息是否为 user role 计费，而这部分计费逻辑尚未调整。
@@ -133,7 +133,7 @@
 ## 前置要求
 
 - Bun（>= 1.2.x）
-- 如果要通过 `npx` 运行已发布 CLI，需要 Node.js
+- 只有通过 `npx` 运行轻量 MCP bridge 时才需要 Node.js
 - 已订阅 Copilot 的 GitHub 账号（个人版、Business 或 Enterprise）
 
 ## 安装
@@ -150,25 +150,27 @@ bun install
 bun run start start
 ```
 
-## 通过 npx 使用
+## 通过 Bun 使用已发布 CLI
 
-你可以直接用 npx 运行本项目：
+服务端和账号管理命令是 Bun-only，因为 Admin UI 与请求历史使用 `bun:sqlite`。运行已发布 CLI 时请使用 Bun，避免 `#!/usr/bin/env node` shebang 强制走 Node.js：
 
 ```sh
-npx @nick3/copilot-api@latest start
+bunx --bun @nick3/copilot-api@latest start
 ```
 
 带参数示例：
 
 ```sh
-npx @nick3/copilot-api@latest start --port 8080
+bunx --bun @nick3/copilot-api@latest start --port 8080
 ```
 
 如果只想做认证：
 
 ```sh
-npx @nick3/copilot-api@latest auth
+bunx --bun @nick3/copilot-api@latest auth
 ```
+
+轻量 MCP bridge 是例外，仍可通过 `npx` 启动；见 [GPT Tool Search](#gpt-tool-search)。
 
 ## 配合 Docker 使用
 
@@ -580,84 +582,87 @@ curl "http://localhost:4141/usage/0"
 
 ## 使用示例
 
-通过 npx 使用：
+通过 Bun 使用已发布 CLI：
 
 ```sh
 # 基础启动
-npx @nick3/copilot-api@latest start
+bunx --bun @nick3/copilot-api@latest start
 
 # 自定义端口并开启详细日志
-npx @nick3/copilot-api@latest start --port 8080 --verbose
+bunx --bun @nick3/copilot-api@latest start --port 8080 --verbose
 
 # 使用 GitHub Business 方案账号
-npx @nick3/copilot-api@latest start --account-type business
+bunx --bun @nick3/copilot-api@latest start --account-type business
 
 # 使用 GitHub Enterprise 方案账号
-npx @nick3/copilot-api@latest start --account-type enterprise
+bunx --bun @nick3/copilot-api@latest start --account-type enterprise
 
 # 对每个请求启用手动审批
-npx @nick3/copilot-api@latest start --manual
+bunx --bun @nick3/copilot-api@latest start --manual
 
 # 将请求间隔限制为 30 秒
-npx @nick3/copilot-api@latest start --rate-limit 30
+bunx --bun @nick3/copilot-api@latest start --rate-limit 30
 
 # 命中速率限制时等待，而不是直接报错
-npx @nick3/copilot-api@latest start --rate-limit 30 --wait
+bunx --bun @nick3/copilot-api@latest start --rate-limit 30 --wait
 
 # 直接传入 GitHub token
-npx @nick3/copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
+bunx --bun @nick3/copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
 
 # 仅执行认证流程
-npx @nick3/copilot-api@latest auth
+bunx --bun @nick3/copilot-api@latest auth
 
 # 认证时启用详细日志
-npx @nick3/copilot-api@latest auth --verbose
+bunx --bun @nick3/copilot-api@latest auth --verbose
 
 # 添加多个账号（账号会按添加顺序记录）
-npx @nick3/copilot-api@latest auth add
-npx @nick3/copilot-api@latest auth add  # 添加第二个账号
+bunx --bun @nick3/copilot-api@latest auth add
+bunx --bun @nick3/copilot-api@latest auth add  # 添加第二个账号
 
 # 列出所有已注册账号
-npx @nick3/copilot-api@latest auth ls
+bunx --bun @nick3/copilot-api@latest auth ls
 
 # 列出账号并显示配额信息
-npx @nick3/copilot-api@latest auth ls -q
+bunx --bun @nick3/copilot-api@latest auth ls -q
 
 # 按索引删除账号（1-based）
-npx @nick3/copilot-api@latest auth rm 2
+bunx --bun @nick3/copilot-api@latest auth rm 2
 
 # 按 ID 删除账号（GitHub 用户名）
-npx @nick3/copilot-api@latest auth rm octocat
+bunx --bun @nick3/copilot-api@latest auth rm octocat
 
 # 在终端中查看 Copilot 用量与额度（无需启动服务）
-npx @nick3/copilot-api@latest check-usage
+bunx --bun @nick3/copilot-api@latest check-usage
 
 # 输出调试信息，便于排障
-npx @nick3/copilot-api@latest debug
+bunx --bun @nick3/copilot-api@latest debug
 
 # 以 JSON 格式输出调试信息
-npx @nick3/copilot-api@latest debug --json
+bunx --bun @nick3/copilot-api@latest debug --json
 
 # 从环境变量初始化代理（HTTP_PROXY、HTTPS_PROXY 等）
-npx @nick3/copilot-api@latest start --proxy-env
+bunx --bun @nick3/copilot-api@latest start --proxy-env
 
 # 使用 opencode GitHub Copilot 认证
-COPILOT_API_OAUTH_APP=opencode npx @nick3/copilot-api@latest start
+COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 
 # 通过命令行设置自定义 API home 目录
-npx @nick3/copilot-api@latest --api-home=/path/to/custom/dir start
+bunx --bun @nick3/copilot-api@latest --api-home=/path/to/custom/dir start
 
 # 通过命令行使用 GitHub Enterprise
-npx @nick3/copilot-api@latest --enterprise-url=company.ghe.com start
+bunx --bun @nick3/copilot-api@latest --enterprise-url=company.ghe.com start
 
 # 通过命令行使用 opencode OAuth
-npx @nick3/copilot-api@latest --oauth-app=opencode start
+bunx --bun @nick3/copilot-api@latest --oauth-app=opencode start
 
 # 组合多个全局选项
-npx @nick3/copilot-api@latest --api-home=/custom/path --oauth-app=opencode --enterprise-url=company.ghe.com start
+bunx --bun @nick3/copilot-api@latest --api-home=/custom/path --oauth-app=opencode --enterprise-url=company.ghe.com start
+```
 
-# 用 Bun 而不是 Node.js 运行已发布 CLI
-bunx --bun @nick3/copilot-api@latest start
+只有 MCP tool-search bridge 仍支持 `npx`：
+
+```sh
+npx -y @nick3/copilot-api@latest mcp
 ```
 
 ### Opencode OAuth 认证
@@ -669,14 +674,14 @@ bunx --bun @nick3/copilot-api@latest start
 export COPILOT_API_OAUTH_APP=opencode
 
 # 然后执行 start 或 auth 命令
-npx @nick3/copilot-api@latest start
-npx @nick3/copilot-api@latest auth
+bunx --bun @nick3/copilot-api@latest start
+bunx --bun @nick3/copilot-api@latest auth
 ```
 
 也可以使用内联环境变量：
 
 ```sh
-COPILOT_API_OAUTH_APP=opencode npx @nick3/copilot-api@latest start
+COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 ```
 
 ## 与 Claude Code 一起使用
@@ -690,7 +695,7 @@ COPILOT_API_OAUTH_APP=opencode npx @nick3/copilot-api@latest start
 执行带 `--claude-code` 的 `start` 命令开始：
 
 ```sh
-npx @nick3/copilot-api@latest start --claude-code
+bunx --bun @nick3/copilot-api@latest start --claude-code
 ```
 
 你会被提示选择一个主模型，以及一个用于后台任务的 “small, fast” 模型。选择完成后，会有一条命令被复制到剪贴板中。该命令会设置 Claude Code 使用该代理所需的环境变量。
@@ -748,6 +753,8 @@ GPT 模型不要设置 Claude Code 原生的 `ENABLE_TOOL_SEARCH`。这个开关
 
 如果你安装了 `tool-search@copilot-api-marketplace`，Claude Code 会自动带上这个 MCP bridge，可以跳过下面这段 Claude Code MCP 手动配置。
 
+这个 MCP bridge 很小，并且不会加载服务端或 SQLite 代码，因此仍可安全地通过 `npx` 运行。主 `start`、`auth`、`check-usage` 和 `debug` 命令请使用 Bun。
+
 请把 tool search bridge 加到 Claude Code 使用的 MCP 配置中：
 
 ```json
@@ -790,7 +797,7 @@ OpenCode 已经内置了 GitHub Copilot provider。本节适用于你希望让 O
 使用 OpenCode OAuth app 启动代理：
 
 ```sh
-npx @nick3/copilot-api@latest --oauth-app=opencode start
+bunx --bun @nick3/copilot-api@latest --oauth-app=opencode start
 ```
 
 然后让 OpenCode 通过 `@ai-sdk/anthropic` 指向该代理。
@@ -880,7 +887,7 @@ npx @nick3/copilot-api@latest --oauth-app=opencode start
 curl "http://localhost:4141/api/admin/meta"
 
 # 启用远程 Admin UI/API 访问（服务端）
-# ADMIN_TOKEN=your_admin_token_here npx @nick3/copilot-api@latest start
+# ADMIN_TOKEN=your_admin_token_here bunx --bun @nick3/copilot-api@latest start
 
 # 远程访问（需要 token）
 curl -H "x-admin-token: your_admin_token_here" "http://localhost:4141/api/admin/accounts?include_stats=1"
@@ -898,9 +905,9 @@ curl "http://localhost:4141/api/admin/requests/<requestId>"
 
 代理内置了一个随服务实例一起提供的 Admin UI。你可以用它查看代理捕获的账号状态与请求历史（模型/端点、tokens/usage、耗时以及错误摘要等）。
 
-1. 启动服务。例如使用 npx：
+1. 启动服务。例如使用 Bun：
    ```sh
-   npx @nick3/copilot-api@latest start
+   bunx --bun @nick3/copilot-api@latest start
    ```
 2. 在浏览器中打开：
    - `http://localhost:4141/admin`（如果改过端口，请替换为对应端口）

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,20 +30,19 @@ if (typeof args["enterprise-url"] === "string") {
   process.env.COPILOT_API_ENTERPRISE_URL = args["enterprise-url"]
 }
 
-// Dynamically import other modules to ensure environment variables are set
-const { auth } = await import("./auth")
-const { checkUsage } = await import("./check-usage")
-const { debug } = await import("./debug")
-const { mcp } = await import("./mcp")
-const { start } = await import("./start")
-
 const main = defineCommand({
   meta: {
     name: "copilot-api",
     description:
       "A wrapper around GitHub Copilot API to make it OpenAI compatible, making it usable for other tools.",
   },
-  subCommands: { auth, start, "check-usage": checkUsage, debug, mcp },
+  subCommands: {
+    auth: () => import("./auth").then((mod) => mod.auth),
+    start: () => import("./start").then((mod) => mod.start),
+    "check-usage": () => import("./check-usage").then((mod) => mod.checkUsage),
+    debug: () => import("./debug").then((mod) => mod.debug),
+    mcp: () => import("./mcp").then((mod) => mod.mcp),
+  },
   args: cliArgs,
 })
 

--- a/tests/main-cli-global-options.test.ts
+++ b/tests/main-cli-global-options.test.ts
@@ -48,6 +48,16 @@ const runDebugJson = (...args: Array<string>): DebugInfo => {
 }
 
 describe("root-level global CLI options", () => {
+  test("keeps subcommands lazy so MCP can start under Node", () => {
+    const source = fs.readFileSync(
+      new URL("../src/main.ts", import.meta.url),
+      "utf8",
+    )
+
+    expect(source).not.toContain('const { start } = await import("./start")')
+    expect(source).toMatch(/mcp:\s*\(\)\s*=>\s*import\("\.\/mcp"\)/)
+  })
+
   test("reports the package version", () => {
     const info = runDebugJson()
 


### PR DESCRIPTION
## Summary
- Lazy-load CLI subcommands so `mcp` can start under Node/npx without loading Bun-only server dependencies.
- Keep the GPT Tool Search MCP bridge available through `npx`.
- Document Bun as the supported runtime for server/account/debug commands while preserving `npx` for MCP bridge usage.

## Verification
- [x] `bun test "tests/main-cli-global-options.test.ts"` (6 pass, 0 fail)
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `node dist/main.js mcp` MCP initialize/tools smoke test
- [x] `npx -y --package /tmp/nick3-copilot-api-1.10.9.tgz -- copilot-api mcp` MCP initialize/tools smoke test

## Notes
- `bun:sqlite` remains a Bun-only server dependency; the fix prevents the MCP bridge path from importing that dependency under Node.
- Existing unrelated untracked files in the working tree were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Documentation**
  * 更新整个项目的 CLI 使用文档，改用 Bun 运行时的 `bunx --bun` 命令取代 npm，涵盖启动、身份验证、管理员操作和配置示例
  * 明确了不同场景（如 MCP 桥接操作）的 Node.js 运行时要求

* **性能改进**
  * 通过为子命令实现延迟加载优化 CLI 初始化，减少启动开销

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nick3/copilot-api/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->