### PR TITLE
Add Streamable HTTP MCP bridge

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64,amd64
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,18 @@ The following command line options are available for the `start` command:
 | --claude-code  | Generate a command to launch Claude Code with Copilot API config              | false      | -c    |
 | --show-token   | Show GitHub and Copilot tokens on fetch and refresh                           | false      | none  |
 | --proxy-env    | Initialize proxy from environment variables                                   | false      | none  |
+| --enable-mcp-http | Expose the unauthenticated MCP Streamable HTTP endpoint at `/mcp`          | false      | none  |
+
+### MCP Command Options
+
+The `mcp` command defaults to stdio for local Claude Code compatibility. Use `--transport http` only when your MCP client supports Streamable HTTP.
+
+| Option      | Description                         | Default   |
+| ----------- | ----------------------------------- | --------- |
+| --transport | Transport to use: `stdio` or `http` | stdio     |
+| --host      | HTTP transport host                 | 127.0.0.1 |
+| --port      | HTTP transport port                 | 4142      |
+| --path      | HTTP transport path                 | /mcp      |
 
 ### Auth Command Options
 
@@ -652,8 +664,17 @@ bunx --bun @nick3/copilot-api@latest --api-home=/custom/path --oauth-app=opencod
 For the MCP tool-search bridge only, `npx` remains supported:
 
 ```sh
+# Local stdio MCP bridge, unchanged
 npx -y @nick3/copilot-api@latest mcp
+
+# Standalone Streamable HTTP MCP bridge
+npx -y @nick3/copilot-api@latest mcp --transport http --host 127.0.0.1 --port 4142 --path /mcp
+
+# Main proxy server with /mcp explicitly enabled
+bunx --bun @nick3/copilot-api@latest start --enable-mcp-http
 ```
+
+The HTTP MCP endpoint is unauthenticated. Keep the default loopback host for standalone mode, and do not expose `/mcp` on an untrusted network unless an external proxy, firewall, or tunnel access policy protects it.
 
 ### Opencode OAuth Authentication
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ The `mcp` command defaults to stdio for local Claude Code compatibility. Use `--
 | --port      | HTTP transport port                 | 4142      |
 | --path      | HTTP transport path                 | /mcp      |
 
+MCP HTTP browser CORS is loopback-only by default. Set `COPILOT_API_MCP_HTTP_ALLOWED_ORIGINS=https://client.example.com,https://admin.example.com` to allow extra browser origins, or `*` to explicitly opt into wildcard CORS.
+
 ### Auth Command Options
 
 The `auth` command has three subcommands for managing multiple accounts:
@@ -674,7 +676,7 @@ npx -y @nick3/copilot-api@latest mcp --transport http --host 127.0.0.1 --port 41
 bunx --bun @nick3/copilot-api@latest start --enable-mcp-http
 ```
 
-The HTTP MCP endpoint is unauthenticated. Keep the default loopback host for standalone mode, and do not expose `/mcp` on an untrusted network unless an external proxy, firewall, or tunnel access policy protects it.
+The HTTP MCP endpoint is unauthenticated. Keep the default loopback host for standalone mode. Browser CORS defaults to loopback origins only; set `COPILOT_API_MCP_HTTP_ALLOWED_ORIGINS` only for trusted clients. Do not expose `/mcp` on an untrusted network unless an external proxy, firewall, or tunnel access policy protects it.
 
 ### Opencode OAuth Authentication
 

--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ If you install `tool-search@copilot-api-marketplace`, Claude Code receives this 
 
 This MCP bridge is intentionally small and does not load the server or SQLite code, so it remains safe to run through `npx`. Use Bun for the main `start`, `auth`, `check-usage`, and `debug` commands.
 
-Add the tool search bridge to the MCP config used by Claude Code:
+Add the tool search bridge to the MCP config used by Claude Code over stdio:
 
 ```json
 {
@@ -779,6 +779,33 @@ Add the tool search bridge to the MCP config used by Claude Code:
   }
 }
 ```
+
+To use Streamable HTTP instead, start the MCP HTTP bridge in one terminal:
+
+```sh
+npx -y @nick3/copilot-api@latest mcp --transport http --host 127.0.0.1 --port 4142 --path /mcp
+```
+
+Then add the HTTP MCP server to Claude Code:
+
+```sh
+claude mcp add --transport http tool_search http://127.0.0.1:4142/mcp
+```
+
+Equivalent manual MCP config:
+
+```json
+{
+  "mcpServers": {
+    "tool_search": {
+      "type": "http",
+      "url": "http://127.0.0.1:4142/mcp"
+    }
+  }
+}
+```
+
+If you prefer the main proxy process to expose the same MCP server, start it with `--enable-mcp-http` and use `http://127.0.0.1:4141/mcp` as the Claude Code MCP URL. Use either the stdio config or the HTTP config for `tool_search`, not both.
 
 Add the tool search bridge to the MCP config used by opencode:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -302,6 +302,18 @@ Copilot API 现在使用子命令结构，主要命令包括：
 | `--claude-code` | 生成一个使用 Copilot API 配置启动 Claude Code 的命令 | `false` | `-c` |
 | `--show-token` | 在获取和刷新时显示 GitHub 与 Copilot token | `false` | 无 |
 | `--proxy-env` | 从环境变量初始化代理 | `false` | 无 |
+| `--enable-mcp-http` | 在 `/mcp` 暴露未认证的 MCP Streamable HTTP 端点 | `false` | 无 |
+
+### MCP 命令选项
+
+`mcp` 命令默认使用 stdio，以保持本地 Claude Code 兼容性。只有当你的 MCP 客户端支持 Streamable HTTP 时，才使用 `--transport http`。
+
+| 选项 | 说明 | 默认值 |
+| --- | --- | --- |
+| `--transport` | 使用的 transport：`stdio` 或 `http` | `stdio` |
+| `--host` | HTTP transport host | `127.0.0.1` |
+| `--port` | HTTP transport port | `4142` |
+| `--path` | HTTP transport path | `/mcp` |
 
 ### Auth 命令选项
 
@@ -662,8 +674,17 @@ bunx --bun @nick3/copilot-api@latest --api-home=/custom/path --oauth-app=opencod
 只有 MCP tool-search bridge 仍支持 `npx`：
 
 ```sh
+# 本地 stdio MCP bridge，行为保持不变
 npx -y @nick3/copilot-api@latest mcp
+
+# 独立 Streamable HTTP MCP bridge
+npx -y @nick3/copilot-api@latest mcp --transport http --host 127.0.0.1 --port 4142 --path /mcp
+
+# 在主代理服务中显式启用 /mcp
+bunx --bun @nick3/copilot-api@latest start --enable-mcp-http
 ```
+
+HTTP MCP 端点不带认证。独立模式请尽量保持默认 loopback host；不要把 `/mcp` 暴露到不可信网络，除非外层反向代理、防火墙或 tunnel access policy 已经保护它。
 
 ### Opencode OAuth 认证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -315,6 +315,8 @@ Copilot API 现在使用子命令结构，主要命令包括：
 | `--port` | HTTP transport port | `4142` |
 | `--path` | HTTP transport path | `/mcp` |
 
+MCP HTTP 的浏览器 CORS 默认只允许 loopback origin。可设置 `COPILOT_API_MCP_HTTP_ALLOWED_ORIGINS=https://client.example.com,https://admin.example.com` 允许额外浏览器 origin，或显式设置为 `*` 启用 wildcard CORS。
+
 ### Auth 命令选项
 
 `auth` 命令提供三个子命令来管理多账号：
@@ -684,7 +686,7 @@ npx -y @nick3/copilot-api@latest mcp --transport http --host 127.0.0.1 --port 41
 bunx --bun @nick3/copilot-api@latest start --enable-mcp-http
 ```
 
-HTTP MCP 端点不带认证。独立模式请尽量保持默认 loopback host；不要把 `/mcp` 暴露到不可信网络，除非外层反向代理、防火墙或 tunnel access policy 已经保护它。
+HTTP MCP 端点不带认证。独立模式请尽量保持默认 loopback host；浏览器 CORS 默认只允许 loopback origin，仅为可信客户端设置 `COPILOT_API_MCP_HTTP_ALLOWED_ORIGINS`。不要把 `/mcp` 暴露到不可信网络，除非外层反向代理、防火墙或 tunnel access policy 已经保护它。
 
 ### Opencode OAuth 认证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -778,7 +778,7 @@ GPT 模型不要设置 Claude Code 原生的 `ENABLE_TOOL_SEARCH`。这个开关
 
 这个 MCP bridge 很小，并且不会加载服务端或 SQLite 代码，因此仍可安全地通过 `npx` 运行。主 `start`、`auth`、`check-usage` 和 `debug` 命令请使用 Bun。
 
-请把 tool search bridge 加到 Claude Code 使用的 MCP 配置中：
+通过 stdio 使用时，请把 tool search bridge 加到 Claude Code 使用的 MCP 配置中：
 
 ```json
 {
@@ -791,6 +791,33 @@ GPT 模型不要设置 Claude Code 原生的 `ENABLE_TOOL_SEARCH`。这个开关
   }
 }
 ```
+
+如果要改用 Streamable HTTP，先在一个终端中启动 MCP HTTP bridge：
+
+```sh
+npx -y @nick3/copilot-api@latest mcp --transport http --host 127.0.0.1 --port 4142 --path /mcp
+```
+
+然后把这个 HTTP MCP server 加到 Claude Code：
+
+```sh
+claude mcp add --transport http tool_search http://127.0.0.1:4142/mcp
+```
+
+等价的手动 MCP 配置如下：
+
+```json
+{
+  "mcpServers": {
+    "tool_search": {
+      "type": "http",
+      "url": "http://127.0.0.1:4142/mcp"
+    }
+  }
+}
+```
+
+如果希望由主代理进程暴露同一个 MCP server，请用 `--enable-mcp-http` 启动主服务，并在 Claude Code MCP URL 中使用 `http://127.0.0.1:4141/mcp`。`tool_search` 请在 stdio 配置和 HTTP 配置中二选一，不要同时启用。
 
 请把 tool search bridge 加到 opencode 使用的 MCP 配置中：
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,15 @@
+# TODOS
+
+## Stateful MCP session registry if real clients require it
+
+**What:** Add a stateful MCP session registry for the HTTP `tool_search` bridge if real clients require stable sessions, resumability, or server-initiated notifications.
+
+**Why:** The first Streamable HTTP release intentionally uses stateless per-request `WebStandardStreamableHTTPServerTransport` because the current `search` tool only returns a sentinel and has no server-side session state. SDK support for `sessionIdGenerator`, `onsessioninitialized`, and `onsessionclosed` remains the upgrade path if stateless mode proves insufficient.
+
+**Pros:** Preserves the future architecture path without overbuilding the first release.
+
+**Cons:** Adds no immediate user value until a real remote MCP client needs stable sessions.
+
+**Context:** `/plan-eng-review` for the Streamable HTTP MCP bridge accepted stateless per-request transport after verifying SDK 1.29.0 rejects reused stateless transports. Do not build this until client evidence shows stateless mode is insufficient.
+
+**Depends on / blocked by:** Real Claude Code remote MCP or other MCP client evidence that stateless per-request mode cannot satisfy required behavior.

--- a/src/mcp-http-config.ts
+++ b/src/mcp-http-config.ts
@@ -1,7 +1,11 @@
 export const MCP_HTTP_ENABLED_ENV = "COPILOT_API_ENABLE_MCP_HTTP"
+export const MCP_HTTP_ALLOWED_ORIGINS_ENV =
+  "COPILOT_API_MCP_HTTP_ALLOWED_ORIGINS"
 export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1"
 export const DEFAULT_MCP_HTTP_PORT = 4142
 export const DEFAULT_MCP_HTTP_PATH = "/mcp"
+
+const LOOPBACK_CORS_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"])
 
 export interface McpHttpServerOptions {
   host: string
@@ -24,4 +28,47 @@ export function isMcpHttpEnabledFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
   return isMcpHttpEnabledValue(env[MCP_HTTP_ENABLED_ENV])
+}
+
+export function parseMcpHttpAllowedOrigins(
+  value: string | undefined = process.env[MCP_HTTP_ALLOWED_ORIGINS_ENV],
+): Array<string> {
+  return (
+    value
+      ?.split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean) ?? []
+  )
+}
+
+function isLoopbackCorsOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin)
+
+    return (
+      (url.protocol === "http:" || url.protocol === "https:")
+      && LOOPBACK_CORS_HOSTS.has(url.hostname)
+    )
+  } catch {
+    return false
+  }
+}
+
+export function resolveMcpHttpCorsOrigin(
+  origin: string | undefined,
+  allowedOrigins = parseMcpHttpAllowedOrigins(),
+): string | undefined {
+  if (!origin) {
+    return undefined
+  }
+
+  if (allowedOrigins.includes("*")) {
+    return "*"
+  }
+
+  if (allowedOrigins.includes(origin) || isLoopbackCorsOrigin(origin)) {
+    return origin
+  }
+
+  return undefined
 }

--- a/src/mcp-http-config.ts
+++ b/src/mcp-http-config.ts
@@ -1,0 +1,27 @@
+export const MCP_HTTP_ENABLED_ENV = "COPILOT_API_ENABLE_MCP_HTTP"
+export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1"
+export const DEFAULT_MCP_HTTP_PORT = 4142
+export const DEFAULT_MCP_HTTP_PATH = "/mcp"
+
+export interface McpHttpServerOptions {
+  host: string
+  path: string
+  port: number
+}
+
+export function isMcpHttpEnabledValue(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+
+  return (
+    normalized === "1"
+    || normalized === "true"
+    || normalized === "yes"
+    || normalized === "on"
+  )
+}
+
+export function isMcpHttpEnabledFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return isMcpHttpEnabledValue(env[MCP_HTTP_ENABLED_ENV])
+}

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -1,0 +1,95 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
+import consola from "consola"
+import { Hono } from "hono"
+import { cors } from "hono/cors"
+import { serve } from "srvx"
+
+import {
+  DEFAULT_MCP_HTTP_PATH,
+  type McpHttpServerOptions,
+} from "~/mcp-http-config"
+import { createToolSearchMcpServer } from "~/mcp-server"
+
+export const mcpHttpCorsOptions = {
+  origin: "*",
+  allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+  allowHeaders: [
+    "Content-Type",
+    "Last-Event-ID",
+    "MCP-Protocol-Version",
+    "Mcp-Session-Id",
+    "mcp-protocol-version",
+    "mcp-session-id",
+  ],
+  exposeHeaders: [
+    "MCP-Protocol-Version",
+    "Mcp-Session-Id",
+    "mcp-protocol-version",
+    "mcp-session-id",
+  ],
+}
+
+export const handleStreamableHttpMcpRequest = async (
+  request: Request,
+): Promise<Response> => {
+  try {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: undefined,
+    })
+    const server = createToolSearchMcpServer()
+    server.server.onerror = (error) => {
+      consola.warn("MCP HTTP protocol error", {
+        method: request.method,
+        url: request.url,
+        message: error.message,
+      })
+    }
+
+    await server.connect(transport)
+    return await transport.handleRequest(request)
+  } catch (error) {
+    consola.error("Failed to handle MCP HTTP request", error)
+
+    return Response.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32603,
+          message: "Internal server error",
+        },
+        id: null,
+      },
+      { status: 500 },
+    )
+  }
+}
+
+export const createMcpHttpApp = (path = DEFAULT_MCP_HTTP_PATH): Hono => {
+  const app = new Hono()
+
+  app.use("*", cors(mcpHttpCorsOptions))
+  app.get("/", (c) => c.text("MCP server running"))
+  app.all(path, (c) => handleStreamableHttpMcpRequest(c.req.raw))
+
+  return app
+}
+
+export const runMcpHttpServer = (options: McpHttpServerOptions): void => {
+  const app = createMcpHttpApp(options.path)
+  const endpoint = `http://${options.host}:${options.port}${options.path}`
+
+  consola.warn(
+    "MCP Streamable HTTP is unauthenticated. Bind only to trusted networks.",
+  )
+  consola.info(`MCP endpoint: ${endpoint}`)
+
+  serve({
+    fetch: app.fetch,
+    hostname: options.host,
+    port: options.port,
+    bun: {
+      idleTimeout: 0,
+    },
+  })
+}

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -69,7 +69,9 @@ export const createMcpHttpApp = (path = DEFAULT_MCP_HTTP_PATH): Hono => {
   const app = new Hono()
 
   app.use("*", cors(mcpHttpCorsOptions))
-  app.get("/", (c) => c.text("MCP server running"))
+  if (path !== "/") {
+    app.get("/", (c) => c.text("MCP server running"))
+  }
   app.all(path, (c) => handleStreamableHttpMcpRequest(c.req.raw))
 
   return app

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -6,12 +6,13 @@ import { serve } from "srvx"
 
 import {
   DEFAULT_MCP_HTTP_PATH,
+  resolveMcpHttpCorsOrigin,
   type McpHttpServerOptions,
 } from "~/mcp-http-config"
 import { createToolSearchMcpServer } from "~/mcp-server"
 
 export const mcpHttpCorsOptions = {
-  origin: "*",
+  origin: (origin: string) => resolveMcpHttpCorsOrigin(origin),
   allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
   allowHeaders: [
     "Content-Type",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,44 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
+
+import { createMcpToolSearchSentinel } from "~/lib/tool-search"
+
+export const MCP_TOOL_SEARCH_SERVER_NAME = "tool_search"
+export const MCP_TOOL_SEARCH_SERVER_VERSION = "1.0.0"
+export const MCP_TOOL_SEARCH_TOOL_NAME = "search"
+
+export const createToolSearchMcpServer = (): McpServer => {
+  const server = new McpServer({
+    name: MCP_TOOL_SEARCH_SERVER_NAME,
+    version: MCP_TOOL_SEARCH_SERVER_VERSION,
+  })
+
+  server.registerTool(
+    MCP_TOOL_SEARCH_TOOL_NAME,
+    {
+      title: "Tool Search Bridge",
+      description:
+        "Load deferred tools by exact name through the Copilot API tool_search bridge.",
+      inputSchema: {
+        names: z
+          .string()
+          .describe(
+            'Comma-separated exact deferred tool names to load, for example "TaskList,TaskGet,mcp__fetch__fetch".',
+          ),
+      },
+      _meta: {
+        "anthropic/alwaysLoad": true,
+      },
+    },
+    ({ names }) => ({
+      content: [
+        {
+          type: "text",
+          text: createMcpToolSearchSentinel(names),
+        },
+      ],
+    }),
+  )
+
+  return server
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,57 +1,123 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { defineCommand } from "citty"
-import { z } from "zod"
+import consola from "consola"
 
-import { createMcpToolSearchSentinel } from "./lib/tool-search"
+import {
+  DEFAULT_MCP_HTTP_HOST,
+  DEFAULT_MCP_HTTP_PATH,
+  DEFAULT_MCP_HTTP_PORT,
+  type McpHttpServerOptions,
+} from "~/mcp-http-config"
+import { createToolSearchMcpServer } from "~/mcp-server"
 
-const SERVER_NAME = "tool_search"
-const SERVER_VERSION = "1.0.0"
+type McpTransport = "stdio" | "http"
+
+interface McpCommandArgs {
+  host?: string
+  path?: string
+  port?: string
+  transport?: string
+}
 
 export const runMcpServer = async (): Promise<void> => {
-  const server = new McpServer({
-    name: SERVER_NAME,
-    version: SERVER_VERSION,
-  })
-
-  server.registerTool(
-    "search",
-    {
-      title: "Tool Search Bridge",
-      description:
-        "Load deferred tools by exact name through the Copilot API tool_search bridge.",
-      inputSchema: {
-        names: z
-          .string()
-          .describe(
-            'Comma-separated exact deferred tool names to load, for example "TaskList,TaskGet,mcp__fetch__fetch".',
-          ),
-      },
-      _meta: {
-        "anthropic/alwaysLoad": true,
-      },
-    },
-    ({ names }) => ({
-      content: [
-        {
-          type: "text",
-          text: createMcpToolSearchSentinel(names),
-        },
-      ],
-    }),
-  )
+  const server = createToolSearchMcpServer()
 
   await server.connect(new StdioServerTransport())
+}
+
+function parseMcpTransport(value: string | undefined): McpTransport {
+  const transport = value ?? "stdio"
+
+  if (transport === "stdio" || transport === "http") {
+    return transport
+  }
+
+  throw new Error("--transport must be either stdio or http")
+}
+
+function parseMcpHttpPort(value: string | undefined): number {
+  const portRaw = value ?? String(DEFAULT_MCP_HTTP_PORT)
+
+  if (!/^\d+$/.test(portRaw)) {
+    throw new Error("--port must be an integer from 1 to 65535")
+  }
+
+  const port = Number.parseInt(portRaw, 10)
+  if (port < 1 || port > 65535) {
+    throw new Error("--port must be an integer from 1 to 65535")
+  }
+
+  return port
+}
+
+export function parseMcpHttpOptions(
+  args: Pick<McpCommandArgs, "host" | "path" | "port">,
+): McpHttpServerOptions {
+  const host = args.host ?? DEFAULT_MCP_HTTP_HOST
+  const path = args.path ?? DEFAULT_MCP_HTTP_PATH
+
+  if (host.trim().length === 0) {
+    throw new Error("--host must not be empty")
+  }
+
+  if (!path.startsWith("/")) {
+    throw new Error("--path must start with /")
+  }
+
+  return {
+    host,
+    path,
+    port: parseMcpHttpPort(args.port),
+  }
+}
+
+export async function runMcpCommand(args: McpCommandArgs): Promise<void> {
+  const transport = parseMcpTransport(args.transport)
+
+  if (transport === "stdio") {
+    await runMcpServer()
+    return
+  }
+
+  const options = parseMcpHttpOptions(args)
+  const { runMcpHttpServer } = await import("./mcp-http")
+  runMcpHttpServer(options)
 }
 
 export const mcp = defineCommand({
   meta: {
     name: "mcp",
-    description: "Start the Copilot API MCP tool_search bridge over stdio",
+    description:
+      "Start the Copilot API MCP tool_search bridge over stdio or Streamable HTTP",
   },
-  run() {
-    return runMcpServer()
+  args: {
+    transport: {
+      type: "string",
+      default: "stdio",
+      description: "Transport to use: stdio or http",
+    },
+    port: {
+      type: "string",
+      default: String(DEFAULT_MCP_HTTP_PORT),
+      description: "HTTP transport port",
+    },
+    host: {
+      type: "string",
+      default: DEFAULT_MCP_HTTP_HOST,
+      description: "HTTP transport host",
+    },
+    path: {
+      type: "string",
+      default: DEFAULT_MCP_HTTP_PATH,
+      description: "HTTP transport path",
+    },
+  },
+  run({ args }) {
+    return runMcpCommand(args).catch((error: unknown) => {
+      consola.error(error instanceof Error ? error.message : String(error))
+      process.exit(1)
+    })
   },
 })

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -28,7 +28,7 @@ export const runMcpServer = async (): Promise<void> => {
 }
 
 function parseMcpTransport(value: string | undefined): McpTransport {
-  const transport = value ?? "stdio"
+  const transport = (value ?? "stdio").trim()
 
   if (transport === "stdio" || transport === "http") {
     return transport
@@ -38,7 +38,7 @@ function parseMcpTransport(value: string | undefined): McpTransport {
 }
 
 function parseMcpHttpPort(value: string | undefined): number {
-  const portRaw = value ?? String(DEFAULT_MCP_HTTP_PORT)
+  const portRaw = (value ?? String(DEFAULT_MCP_HTTP_PORT)).trim()
 
   if (!/^\d+$/.test(portRaw)) {
     throw new Error("--port must be an integer from 1 to 65535")
@@ -55,10 +55,10 @@ function parseMcpHttpPort(value: string | undefined): number {
 export function parseMcpHttpOptions(
   args: Pick<McpCommandArgs, "host" | "path" | "port">,
 ): McpHttpServerOptions {
-  const host = args.host ?? DEFAULT_MCP_HTTP_HOST
-  const path = args.path ?? DEFAULT_MCP_HTTP_PATH
+  const host = (args.host ?? DEFAULT_MCP_HTTP_HOST).trim()
+  const path = (args.path ?? DEFAULT_MCP_HTTP_PATH).trim()
 
-  if (host.trim().length === 0) {
+  if (host.length === 0) {
     throw new Error("--host must not be empty")
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,11 @@ import { logger } from "hono/logger"
 
 import { createAuthMiddleware } from "~/lib/request-auth"
 import { traceIdMiddleware } from "~/lib/trace"
+import {
+  DEFAULT_MCP_HTTP_PATH,
+  isMcpHttpEnabledFromEnv,
+} from "~/mcp-http-config"
+import { handleStreamableHttpMcpRequest, mcpHttpCorsOptions } from "~/mcp-http"
 
 import { adminApiRoutes } from "./routes/admin-api/route"
 import { adminRoutes } from "./routes/admin/route"
@@ -17,41 +22,68 @@ import { responsesRoutes } from "./routes/responses/route"
 import { tokenRoute } from "./routes/token/route"
 import { usageRoute } from "./routes/usage/route"
 
-export const server = new Hono()
+export interface CreateServerOptions {
+  enableMcpHttp?: boolean
+}
 
-server.use(traceIdMiddleware)
-server.use(logger())
-server.use(cors())
-server.use(
-  "*",
-  createAuthMiddleware({
-    allowUnauthenticatedPaths: ["/"],
-    allowUnauthenticatedPathPrefixes: ["/admin", "/api/admin"],
-  }),
-)
+export function createServer(options: CreateServerOptions = {}): Hono {
+  const app = new Hono()
+  const enableMcpHttp = options.enableMcpHttp ?? isMcpHttpEnabledFromEnv()
 
-server.get("/", (c) => c.text("Server running"))
+  app.use(traceIdMiddleware)
+  app.use(logger())
+  app.use(cors())
+  app.use(
+    "*",
+    createAuthMiddleware({
+      allowUnauthenticatedPaths: ["/", DEFAULT_MCP_HTTP_PATH],
+      allowUnauthenticatedPathPrefixes: ["/admin", "/api/admin"],
+    }),
+  )
 
-server.route("/chat/completions", completionRoutes)
-server.route("/models", modelRoutes)
-server.route("/embeddings", embeddingRoutes)
-server.route("/usage", usageRoute)
-server.route("/token", tokenRoute)
-server.route("/responses", responsesRoutes)
+  app.get("/", (c) => c.text("Server running"))
 
-// Admin UI / APIs (no auth; intended for localhost/intranet)
-server.route("/admin", adminRoutes)
-server.route("/api/admin", adminApiRoutes)
+  if (enableMcpHttp) {
+    app.use(DEFAULT_MCP_HTTP_PATH, cors(mcpHttpCorsOptions))
+    app.all(DEFAULT_MCP_HTTP_PATH, (c) =>
+      handleStreamableHttpMcpRequest(c.req.raw),
+    )
+  } else {
+    app.all(DEFAULT_MCP_HTTP_PATH, (c) =>
+      c.json(
+        {
+          error: {
+            type: "mcp_http_disabled",
+            message:
+              "MCP Streamable HTTP is disabled. Start with --enable-mcp-http to expose /mcp.",
+          },
+        },
+        404,
+      ),
+    )
+  }
 
-// Compatibility with tools that expect v1/ prefix
-server.route("/v1/chat/completions", completionRoutes)
-server.route("/v1/models", modelRoutes)
-server.route("/v1/embeddings", embeddingRoutes)
-server.route("/v1/responses", responsesRoutes)
+  app.route("/chat/completions", completionRoutes)
+  app.route("/models", modelRoutes)
+  app.route("/embeddings", embeddingRoutes)
+  app.route("/usage", usageRoute)
+  app.route("/token", tokenRoute)
+  app.route("/responses", responsesRoutes)
 
-// Anthropic compatible endpoints
-server.route("/v1/messages", messageRoutes)
+  app.route("/admin", adminRoutes)
+  app.route("/api/admin", adminApiRoutes)
 
-// Provider scoped Anthropic-compatible endpoints
-server.route("/:provider/v1/messages", providerMessageRoutes)
-server.route("/:provider/v1/models", providerModelRoutes)
+  app.route("/v1/chat/completions", completionRoutes)
+  app.route("/v1/models", modelRoutes)
+  app.route("/v1/embeddings", embeddingRoutes)
+  app.route("/v1/responses", responsesRoutes)
+
+  app.route("/v1/messages", messageRoutes)
+
+  app.route("/:provider/v1/messages", providerMessageRoutes)
+  app.route("/:provider/v1/models", providerModelRoutes)
+
+  return app
+}
+
+export const server = createServer()

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,16 +32,6 @@ export function createServer(options: CreateServerOptions = {}): Hono {
 
   app.use(traceIdMiddleware)
   app.use(logger())
-  app.use(cors())
-  app.use(
-    "*",
-    createAuthMiddleware({
-      allowUnauthenticatedPaths: ["/", DEFAULT_MCP_HTTP_PATH],
-      allowUnauthenticatedPathPrefixes: ["/admin", "/api/admin"],
-    }),
-  )
-
-  app.get("/", (c) => c.text("Server running"))
 
   if (enableMcpHttp) {
     app.use(DEFAULT_MCP_HTTP_PATH, cors(mcpHttpCorsOptions))
@@ -62,6 +52,17 @@ export function createServer(options: CreateServerOptions = {}): Hono {
       ),
     )
   }
+
+  app.use(cors())
+  app.use(
+    "*",
+    createAuthMiddleware({
+      allowUnauthenticatedPaths: ["/", DEFAULT_MCP_HTTP_PATH],
+      allowUnauthenticatedPathPrefixes: ["/admin", "/api/admin"],
+    }),
+  )
+
+  app.get("/", (c) => c.text("Server running"))
 
   app.route("/chat/completions", completionRoutes)
   app.route("/models", modelRoutes)

--- a/src/start.ts
+++ b/src/start.ts
@@ -10,10 +10,7 @@ import {
   startQuotaRefreshSchedulerFromConfig,
   stopQuotaRefreshScheduler,
 } from "~/lib/quota-refresh-scheduler-runtime"
-import {
-  MCP_HTTP_ENABLED_ENV,
-  isMcpHttpEnabledFromEnv,
-} from "~/mcp-http-config"
+import { isMcpHttpEnabledFromEnv } from "~/mcp-http-config"
 
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
@@ -167,9 +164,6 @@ export async function runServer(options: RunServerOptions): Promise<void> {
     initProxyFromEnv()
   }
 
-  if (options.enableMcpHttp) {
-    process.env[MCP_HTTP_ENABLED_ENV] = "true"
-  }
   const enableMcpHttp = options.enableMcpHttp || isMcpHttpEnabledFromEnv()
   if (enableMcpHttp) {
     consola.warn(

--- a/src/start.ts
+++ b/src/start.ts
@@ -10,6 +10,10 @@ import {
   startQuotaRefreshSchedulerFromConfig,
   stopQuotaRefreshScheduler,
 } from "~/lib/quota-refresh-scheduler-runtime"
+import {
+  MCP_HTTP_ENABLED_ENV,
+  isMcpHttpEnabledFromEnv,
+} from "~/mcp-http-config"
 
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
@@ -47,6 +51,7 @@ interface RunServerOptions {
   showToken: boolean
   proxyEnv: boolean
   skipAuth: boolean
+  enableMcpHttp: boolean
 }
 
 /**
@@ -162,6 +167,16 @@ export async function runServer(options: RunServerOptions): Promise<void> {
     initProxyFromEnv()
   }
 
+  if (options.enableMcpHttp) {
+    process.env[MCP_HTTP_ENABLED_ENV] = "true"
+  }
+  const enableMcpHttp = options.enableMcpHttp || isMcpHttpEnabledFromEnv()
+  if (enableMcpHttp) {
+    consola.warn(
+      "Main server MCP endpoint is enabled and unauthenticated at /mcp.",
+    )
+  }
+
   state.verbose = options.verbose
   if (options.verbose) {
     consola.level = 5
@@ -244,7 +259,8 @@ export async function runServer(options: RunServerOptions): Promise<void> {
 
   consola.box(`🌐 Admin UI: ${serverUrl}/admin`)
 
-  const { server } = await import("./server")
+  const { createServer } = await import("./server")
+  const server = createServer({ enableMcpHttp })
 
   serve({
     fetch: server.fetch,
@@ -325,6 +341,12 @@ export const start = defineCommand({
       description:
         "Skip the initial CLI auth flow when no accounts are found. Use this to add accounts via the Admin UI instead.",
     },
+    "enable-mcp-http": {
+      type: "boolean",
+      default: false,
+      description:
+        "Expose the unauthenticated MCP Streamable HTTP endpoint at /mcp.",
+    },
   },
   run({ args }) {
     const rateLimitRaw = args["rate-limit"]
@@ -352,6 +374,7 @@ export const start = defineCommand({
       showToken: args["show-token"],
       proxyEnv: args["proxy-env"],
       skipAuth: args["skip-auth"],
+      enableMcpHttp: args["enable-mcp-http"],
     })
   },
 })

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -231,6 +231,21 @@ describe("MCP Streamable HTTP", () => {
     await getStream.body?.cancel()
   })
 
+  test("does not let the health route intercept MCP root path GET", async () => {
+    const app = createMcpHttpApp("/")
+    const response = await app.fetch(
+      new Request("http://localhost/", {
+        headers: {
+          accept: "text/event-stream",
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("text/event-stream")
+    await response.body?.cancel()
+  })
+
   test("keeps main server /mcp disabled with a clear response", async () => {
     const previousApiKey = process.env.COPILOT_API_KEY
     process.env.COPILOT_API_KEY = "secret"
@@ -291,6 +306,31 @@ describe("MCP Streamable HTTP", () => {
     )
     expect(response.headers.get("access-control-allow-headers")).toBe(
       "authorization,x-api-key",
+    )
+  })
+
+  test("main server uses MCP-specific CORS for /mcp preflight", async () => {
+    const app = createServer({ enableMcpHttp: true })
+    const response = await app.fetch(
+      new Request("http://localhost/mcp", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://example.com",
+          "access-control-request-method": "PATCH",
+          "access-control-request-headers": "content-type,mcp-protocol-version",
+        },
+      }),
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-methods")).toContain(
+      "POST",
+    )
+    expect(response.headers.get("access-control-allow-methods")).not.toContain(
+      "PATCH",
+    )
+    expect(response.headers.get("access-control-allow-headers")).toContain(
+      "mcp-protocol-version",
     )
   })
 

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -4,8 +4,12 @@ import fs from "node:fs"
 import { fileURLToPath } from "node:url"
 
 import { parseMcpToolSearchSentinel } from "~/lib/tool-search"
-import { MCP_HTTP_ENABLED_ENV } from "~/mcp-http-config"
+import {
+  MCP_HTTP_ALLOWED_ORIGINS_ENV,
+  MCP_HTTP_ENABLED_ENV,
+} from "~/mcp-http-config"
 import { createMcpHttpApp } from "~/mcp-http"
+import { parseMcpHttpOptions } from "~/mcp"
 import { createToolSearchMcpServer } from "~/mcp-server"
 import { createServer } from "~/server"
 
@@ -200,14 +204,14 @@ describe("MCP Streamable HTTP", () => {
     expect(unsupported.status).toBe(405)
   })
 
-  test("supports CORS preflight and GET event-stream headers", async () => {
+  test("supports loopback CORS preflight and GET event-stream headers", async () => {
     const app = createMcpHttpApp()
 
     const preflight = await app.fetch(
       new Request("http://localhost/mcp", {
         method: "OPTIONS",
         headers: {
-          origin: "http://example.com",
+          origin: "http://localhost:3000",
           "access-control-request-method": "POST",
           "access-control-request-headers": "content-type,mcp-protocol-version",
         },
@@ -222,13 +226,60 @@ describe("MCP Streamable HTTP", () => {
     )
 
     expect(preflight.status).toBe(204)
-    expect(preflight.headers.get("access-control-allow-origin")).toBe("*")
+    expect(preflight.headers.get("access-control-allow-origin")).toBe(
+      "http://localhost:3000",
+    )
     expect(preflight.headers.get("access-control-allow-methods")).toContain(
       "POST",
     )
     expect(getStream.status).toBe(200)
     expect(getStream.headers.get("content-type")).toContain("text/event-stream")
     await getStream.body?.cancel()
+  })
+
+  test("rejects non-loopback MCP CORS origins by default", async () => {
+    const app = createMcpHttpApp()
+    const response = await app.fetch(
+      new Request("http://localhost/mcp", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://example.com",
+          "access-control-request-method": "POST",
+        },
+      }),
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBeNull()
+  })
+
+  test("allows configured MCP CORS origins", async () => {
+    const previousValue = process.env[MCP_HTTP_ALLOWED_ORIGINS_ENV]
+    process.env[MCP_HTTP_ALLOWED_ORIGINS_ENV] = "https://mcp.example.com"
+
+    try {
+      const app = createMcpHttpApp()
+      const response = await app.fetch(
+        new Request("http://localhost/mcp", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://mcp.example.com",
+            "access-control-request-method": "POST",
+          },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+      expect(response.headers.get("access-control-allow-origin")).toBe(
+        "https://mcp.example.com",
+      )
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env[MCP_HTTP_ALLOWED_ORIGINS_ENV]
+      } else {
+        process.env[MCP_HTTP_ALLOWED_ORIGINS_ENV] = previousValue
+      }
+    }
   })
 
   test("does not let the health route intercept MCP root path GET", async () => {
@@ -315,7 +366,7 @@ describe("MCP Streamable HTTP", () => {
       new Request("http://localhost/mcp", {
         method: "OPTIONS",
         headers: {
-          origin: "http://example.com",
+          origin: "http://127.0.0.1:3000",
           "access-control-request-method": "PATCH",
           "access-control-request-headers": "content-type,mcp-protocol-version",
         },
@@ -323,6 +374,9 @@ describe("MCP Streamable HTTP", () => {
     )
 
     expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "http://127.0.0.1:3000",
+    )
     expect(response.headers.get("access-control-allow-methods")).toContain(
       "POST",
     )
@@ -354,6 +408,20 @@ describe("MCP Streamable HTTP", () => {
         process.env.COPILOT_API_KEY = previousApiKey
       }
     }
+  })
+
+  test("normalizes standalone HTTP CLI option values", () => {
+    expect(
+      parseMcpHttpOptions({
+        host: " 127.0.0.1 ",
+        path: " /mcp ",
+        port: " 4142 ",
+      }),
+    ).toEqual({
+      host: "127.0.0.1",
+      path: "/mcp",
+      port: 4142,
+    })
   })
 
   test("rejects invalid standalone HTTP CLI options", () => {

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, test } from "bun:test"
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
+import fs from "node:fs"
+import { fileURLToPath } from "node:url"
+
+import { parseMcpToolSearchSentinel } from "~/lib/tool-search"
+import { MCP_HTTP_ENABLED_ENV } from "~/mcp-http-config"
+import { createMcpHttpApp } from "~/mcp-http"
+import { createToolSearchMcpServer } from "~/mcp-server"
+import { createServer } from "~/server"
+
+interface JsonRpcResponse {
+  error?: {
+    code: number
+    message: string
+  }
+  id: number | null
+  jsonrpc: "2.0"
+  result?: unknown
+}
+
+interface ToolListResult {
+  tools: Array<{ name: string }>
+}
+
+interface ToolCallResult {
+  content: Array<{ text: string; type: string }>
+}
+
+const cwd = fileURLToPath(new URL("../", import.meta.url))
+const decoder = new TextDecoder()
+
+function createMcpRequest(method: string, params: unknown, id = 1): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    }),
+  })
+}
+
+async function readJsonRpcResponse(
+  response: Response,
+): Promise<JsonRpcResponse> {
+  return (await response.json()) as JsonRpcResponse
+}
+
+function createInitializeRequest(id = 1): Request {
+  return createMcpRequest(
+    "initialize",
+    {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: {
+        name: "copilot-api-test",
+        version: "1.0.0",
+      },
+    },
+    id,
+  )
+}
+
+function runMcpCli(...args: Array<string>) {
+  return Bun.spawnSync({
+    cmd: [process.execPath, "run", "./src/main.ts", "mcp", ...args],
+    cwd,
+    env: {
+      ...process.env,
+      COPILOT_API_HOME: "",
+      COPILOT_API_OAUTH_APP: "",
+      COPILOT_API_ENTERPRISE_URL: "",
+    },
+  })
+}
+
+describe("MCP Streamable HTTP", () => {
+  test("keeps the stdio CLI path free of static HTTP imports", () => {
+    const source = fs.readFileSync(
+      new URL("../src/mcp.ts", import.meta.url),
+      "utf8",
+    )
+
+    expect(source).not.toMatch(/from\s+["'][^"']*mcp-http["']/)
+    expect(source).toContain('await import("./mcp-http")')
+  })
+
+  test("handles initialize requests without creating a session id", async () => {
+    const app = createMcpHttpApp()
+    const response = await app.fetch(createInitializeRequest())
+    const body = await readJsonRpcResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("mcp-session-id")).toBeNull()
+    expect(body.id).toBe(1)
+    expect(body.error).toBeUndefined()
+    expect(body.result).toMatchObject({
+      serverInfo: {
+        name: "tool_search",
+        version: "1.0.0",
+      },
+    })
+  })
+
+  test("creates a fresh stateless transport for repeated clients", async () => {
+    const app = createMcpHttpApp()
+
+    const first = await app.fetch(createInitializeRequest(1))
+    const second = await app.fetch(createInitializeRequest(2))
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect((await readJsonRpcResponse(first)).id).toBe(1)
+    expect((await readJsonRpcResponse(second)).id).toBe(2)
+  })
+
+  test("SDK rejects reused stateless transports", async () => {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: undefined,
+    })
+    const server = createToolSearchMcpServer()
+
+    await server.connect(transport)
+    await transport.handleRequest(createInitializeRequest(1))
+
+    let thrown: unknown
+    try {
+      await transport.handleRequest(createInitializeRequest(2))
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toContain(
+      "Stateless transport cannot be reused across requests",
+    )
+  })
+
+  test("lists and calls the shared search tool", async () => {
+    const app = createMcpHttpApp()
+
+    const listResponse = await app.fetch(createMcpRequest("tools/list", {}, 3))
+    const listBody = await readJsonRpcResponse(listResponse)
+    const listResult = listBody.result as ToolListResult
+
+    expect(listResponse.status).toBe(200)
+    expect(listResult.tools.map((tool) => tool.name)).toContain("search")
+
+    const callResponse = await app.fetch(
+      createMcpRequest(
+        "tools/call",
+        {
+          name: "search",
+          arguments: {
+            names: "TaskList,mcp__fetch__fetch",
+          },
+        },
+        4,
+      ),
+    )
+    const callBody = await readJsonRpcResponse(callResponse)
+    const callResult = callBody.result as ToolCallResult
+    const text = callResult.content[0]?.text
+
+    expect(callResponse.status).toBe(200)
+    expect(parseMcpToolSearchSentinel(text ?? "")).toEqual({
+      type: "copilot_api_tool_search",
+      names: ["TaskList", "mcp__fetch__fetch"],
+    })
+  })
+
+  test("returns clear errors for malformed and unsupported requests", async () => {
+    const app = createMcpHttpApp()
+
+    const malformed = await app.fetch(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: "{",
+      }),
+    )
+    const unsupported = await app.fetch(
+      new Request("http://localhost/mcp", { method: "PUT" }),
+    )
+
+    expect(malformed.status).toBe(400)
+    expect((await readJsonRpcResponse(malformed)).error?.message).toContain(
+      "Parse error",
+    )
+    expect(unsupported.status).toBe(405)
+  })
+
+  test("supports CORS preflight and GET event-stream headers", async () => {
+    const app = createMcpHttpApp()
+
+    const preflight = await app.fetch(
+      new Request("http://localhost/mcp", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://example.com",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "content-type,mcp-protocol-version",
+        },
+      }),
+    )
+    const getStream = await app.fetch(
+      new Request("http://localhost/mcp", {
+        headers: {
+          accept: "text/event-stream",
+        },
+      }),
+    )
+
+    expect(preflight.status).toBe(204)
+    expect(preflight.headers.get("access-control-allow-origin")).toBe("*")
+    expect(preflight.headers.get("access-control-allow-methods")).toContain(
+      "POST",
+    )
+    expect(getStream.status).toBe(200)
+    expect(getStream.headers.get("content-type")).toContain("text/event-stream")
+    await getStream.body?.cancel()
+  })
+
+  test("keeps main server /mcp disabled with a clear response", async () => {
+    const previousApiKey = process.env.COPILOT_API_KEY
+    process.env.COPILOT_API_KEY = "secret"
+
+    try {
+      const app = createServer({ enableMcpHttp: false })
+      const response = await app.fetch(createInitializeRequest())
+      const body = (await response.json()) as {
+        error: { message: string; type: string }
+      }
+
+      expect(response.status).toBe(404)
+      expect(body.error.type).toBe("mcp_http_disabled")
+      expect(body.error.message).toContain("--enable-mcp-http")
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.COPILOT_API_KEY
+      } else {
+        process.env.COPILOT_API_KEY = previousApiKey
+      }
+    }
+  })
+
+  test("main server can enable /mcp from environment", async () => {
+    const previousValue = process.env[MCP_HTTP_ENABLED_ENV]
+    process.env[MCP_HTTP_ENABLED_ENV] = "true"
+
+    try {
+      const app = createServer()
+      const response = await app.fetch(createInitializeRequest())
+
+      expect(response.status).toBe(200)
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env[MCP_HTTP_ENABLED_ENV]
+      } else {
+        process.env[MCP_HTTP_ENABLED_ENV] = previousValue
+      }
+    }
+  })
+
+  test("main server preserves auth CORS preflight headers", async () => {
+    const app = createServer({ enableMcpHttp: true })
+    const response = await app.fetch(
+      new Request("http://localhost/v1/models", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://example.com",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "authorization,x-api-key",
+        },
+      }),
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-methods")).toContain(
+      "PATCH",
+    )
+    expect(response.headers.get("access-control-allow-headers")).toBe(
+      "authorization,x-api-key",
+    )
+  })
+
+  test("main server /mcp bypasses API key auth only when enabled", async () => {
+    const previousApiKey = process.env.COPILOT_API_KEY
+    process.env.COPILOT_API_KEY = "secret"
+
+    try {
+      const app = createServer({ enableMcpHttp: true })
+      const mcpResponse = await app.fetch(createInitializeRequest())
+      const modelsResponse = await app.fetch(
+        new Request("http://localhost/v1/models"),
+      )
+
+      expect(mcpResponse.status).toBe(200)
+      expect(modelsResponse.status).toBe(401)
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.COPILOT_API_KEY
+      } else {
+        process.env.COPILOT_API_KEY = previousApiKey
+      }
+    }
+  })
+
+  test("rejects invalid standalone HTTP CLI options", () => {
+    const invalidPort = runMcpCli("--transport", "http", "--port", "not-a-port")
+    const invalidPath = runMcpCli("--transport", "http", "--path", "mcp")
+    const stderr = `${decoder.decode(invalidPort.stderr)}\n${decoder.decode(
+      invalidPath.stderr,
+    )}`
+
+    expect(invalidPort.exitCode).not.toBe(0)
+    expect(invalidPath.exitCode).not.toBe(0)
+    expect(stderr).toContain("--port must be an integer from 1 to 65535")
+    expect(stderr).toContain("--path must start with /")
+  })
+})

--- a/tests/tool-search.test.ts
+++ b/tests/tool-search.test.ts
@@ -9,6 +9,7 @@ import {
   shouldEnableResponsesToolSearch,
 } from "~/lib/tool-search"
 import { runMcpServer } from "~/mcp"
+import { createToolSearchMcpServer } from "~/mcp-server"
 
 describe("tool search helpers", () => {
   test("detects eligible Responses tool search requests", () => {
@@ -186,7 +187,8 @@ describe("tool search helpers", () => {
     ).toBe(true)
   })
 
-  test("exports an mcp CLI command", () => {
+  test("exports MCP bridge entry points", () => {
     expect(typeof runMcpServer).toBe("function")
+    expect(typeof createToolSearchMcpServer).toBe("function")
   })
 })


### PR DESCRIPTION
## Summary
- Add a shared tool_search MCP server factory while preserving the existing stdio `mcp` command.
- Add stateless Streamable HTTP support for standalone `mcp --transport http` and explicitly enabled main-server `/mcp`.
- Document HTTP MCP usage and unauthenticated exposure risk in English and Chinese READMEs.

## Test plan
- [x] `bun test`
- [x] `bun test tests/tool-search.test.ts tests/mcp-http.test.ts tests/main-cli-global-options.test.ts`
- [x] `bun run typecheck`
- [x] `bunx eslint --ignore-pattern admin-ui "src/mcp.ts" "src/mcp-server.ts" "src/mcp-http.ts" "src/mcp-http-config.ts" "src/server.ts" "src/start.ts" "tests/tool-search.test.ts" "tests/mcp-http.test.ts"`
- [x] `bun run build`
- [x] `node dist/main.js mcp --transport http --port 47891` startup smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持在主服务或独立进程通过未鉴权的 Streamable HTTP 在 /mcp 暴露 MCP 服务，并新增 CLI 开关以启用该模式
  * MCP 桥接示例扩展为三种部署方案：本地 stdio、独立 HTTP、由主服务暴露 /mcp

* **文档**
  * 更新中/英文说明，补充 HTTP MCP 启用、CORS 默认限制、允许来源配置与安全建议

* **测试**
  * 新增端到端测试覆盖 HTTP MCP、CORS、CLI 参数与桥接行为

* **待办**
  * 新增有状态 MCP 会话注册表的规划条目

* **杂项**
  * CI 配置依赖项小幅更新 (工作流工具版本升级)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nick3/copilot-api/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->