### PR TITLE
feat: Codex-compatible Responses WebSocket transport (with multi-turn fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Compared with routing everything through plain Chat Completions compatibility, t
 ## Features
 
 - **OpenAI & Anthropic Compatibility**: Exposes GitHub Copilot as an OpenAI-compatible (`/v1/responses`, `/v1/chat/completions`, `/v1/models`, `/v1/embeddings`) and Anthropic-compatible (`/v1/messages`) API.
+- **Codex Responses WebSocket Compatibility**: Accepts Codex's preferred Responses WebSocket transport on `/v1/responses` and bridges it through the existing Responses handler.
 - **Anthropic-First Routing for Claude Models**: When a model supports Copilot's native `/v1/messages` endpoint, the proxy prefers it over `/responses` or `/chat/completions`, preserving Anthropic-style `tool_use` / `tool_result` flows and more Claude-native behavior.
 - **Fewer Unnecessary Premium Requests**: Reduces wasted premium usage by routing warmup requests to `smallModel`, merging `tool_result` follow-ups back into the tool flow, and treating resumed tool turns as continuation traffic instead of fresh premium interactions.
 - **Phase-Aware `gpt-5.4` and `gpt-5.3-codex`**: These models can emit user-friendly commentary before deeper reasoning or tool use, so long-running coding actions are easier to understand instead of appearing as a sudden tool burst.
@@ -467,7 +468,7 @@ The `<target>` can be either the account ID (GitHub login) or a 1-based index.
 - **modelRefreshIntervalHours:** Interval for refreshing account model lists in the background. Set to `0` to disable refresh. Defaults to `24`.
 - **sessionAffinityRetentionDays:** Number of days to retain session affinity bindings. Defaults to `7`.
 - **useMessagesApi:** When `true` (default), Claude-family models that support Copilot's native `/v1/messages` endpoint may use the Messages API path. Set to `false` to skip the Messages API candidate and fall back to `/responses` (if supported) or `/chat/completions`.
-- **useResponsesApiWebSocket:** When `true` (default), Responses API requests use Copilot's WebSocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable WebSocket routing.
+- **useResponsesApiWebSocket:** When `true` (default), outbound Copilot Responses API requests use Copilot's WebSocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable upstream WebSocket routing. This does not disable the inbound Codex-compatible WebSocket listener on `/v1/responses`.
 - **useResponsesApiWebSearch:** When `true` (default), `/v1/responses` keeps tools with `type: "web_search"` and forwards them upstream. Set to `false` to strip them before the Copilot request is sent.
 - **logLevel:** Controls handler file-log verbosity under `logs/*.log`. Allowed values: `error`, `warn`, `info`, `debug`. Defaults to `info`. Set it to `debug` when you need payload- or stream-level diagnostics written into file logs.
 - **anthropicApiKey:** Optional Anthropic API key used for accurate Claude token counting (see [Accurate Claude Token Counting](#accurate-claude-token-counting) below). Can also be set via the `ANTHROPIC_API_KEY` environment variable. If not set, token counting falls back to GPT tokenizer estimation.
@@ -505,6 +506,7 @@ These endpoints mimic the OpenAI API structure.
 | Endpoint                    | Method | Description                                                      |
 | --------------------------- | ------ | ---------------------------------------------------------------- |
 | `POST /v1/responses`        | `POST` | OpenAI Most advanced interface for generating model responses.          |
+| `GET /v1/responses`         | `WS`   | Codex-compatible Responses WebSocket transport.                  |
 | `POST /v1/chat/completions` | `POST` | Creates a model response for the given chat conversation.        |
 | `GET /v1/models`            | `GET`  | Lists the currently available models.                            |
 | `POST /v1/embeddings`       | `POST` | Creates an embedding vector representing the input text.         |
@@ -696,6 +698,42 @@ Or use inline environment variable:
 ```sh
 COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 ```
+
+## Using with Codex CLI
+
+Codex can use this proxy as an OpenAI-compatible Responses API provider. The proxy supports both Codex's HTTP `POST /v1/responses` path and its preferred WebSocket upgrade on `GET /v1/responses`.
+
+Start the proxy:
+
+```sh
+bunx --bun @nick3/copilot-api@latest start
+```
+
+> **Note:** The inbound Codex WebSocket listener on `GET /v1/responses` requires the Bun server runtime, so start the proxy with `bunx --bun` (or a local Bun install). The `npx` path is only supported for the lightweight MCP bridge and does not run the WebSocket listener.
+
+Add a provider to `~/.codex/config.toml`:
+
+```toml
+[model_providers.copilot-api]
+name = "copilot-api"
+base_url = "http://localhost:4141/v1"
+wire_api = "responses"
+supports_websockets = true
+
+[profiles.copilot-api]
+model_provider = "copilot-api"
+model = "gpt-5.4"
+```
+
+Then run Codex with that profile:
+
+```sh
+codex -p copilot-api
+```
+
+If you configured `auth.apiKeys`, add the same key to Codex's provider headers or bearer-token configuration so both HTTP and WebSocket requests authenticate successfully. For troubleshooting only, set `supports_websockets = false` in Codex to force its HTTP fallback path.
+
+> **Note:** When using Codex via GitHub Copilot, it is currently recommended to disable Codex multi-agent features because Copilot billing may count Codex traffic based on the final user-role message.
 
 ## Using with Claude Code
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,7 @@
 ## 功能特性
 
 - **OpenAI 与 Anthropic 双兼容**：以 OpenAI 兼容接口（`/v1/responses`、`/v1/chat/completions`、`/v1/models`、`/v1/embeddings`）和 Anthropic 兼容接口（`/v1/messages`）对外暴露 GitHub Copilot。
+- **Codex Responses WebSocket 兼容**：在 `/v1/responses` 接受 Codex 偏好的 Responses WebSocket transport，并桥接到现有 Responses handler。
 - **Claude 模型优先走 Anthropic 原生路由**：当模型支持 Copilot 原生 `/v1/messages` 端点时，代理会优先使用它，而不是 `/responses` 或 `/chat/completions`，从而保留 Anthropic 风格的 `tool_use` / `tool_result` 流程以及更原生的 Claude 行为。
 - **减少不必要的 Premium 请求**：通过把预热请求路由到 `smallModel`、将 `tool_result` 的后续消息重新并入工具流，以及把恢复的工具轮次视为延续流量而非全新高级交互，减少浪费的 premium 使用量。
 - **分阶段的 `gpt-5.4` 与 `gpt-5.3-codex`**：这些模型可以在更深入推理或调用工具前先发出面向用户的 commentary，让长时间运行的编码操作更容易理解，而不是突然开始一串工具调用。
@@ -476,7 +477,7 @@ MCP HTTP 的浏览器 CORS 默认只允许 loopback origin。可设置 `COPILOT_
 - **modelRefreshIntervalHours：** 后台刷新账号模型列表的间隔小时数。设为 `0` 可关闭自动刷新。默认值为 `24`。
 - **sessionAffinityRetentionDays：** session affinity 绑定的保留天数。默认值为 `7`。
 - **useMessagesApi：** 当为 `true`（默认）时，支持 Copilot 原生 `/v1/messages` 端点的 Claude 系模型会走 Messages API 路径。设为 `false` 时，将跳过 Messages API 候选，回退到 `/responses`（如支持）或 `/chat/completions`。
-- **useResponsesApiWebSocket：** 当为 `true`（默认）时，Responses API 请求会对声明了 `ws:/responses` 的模型使用 Copilot WebSocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用 WebSocket 路由。
+- **useResponsesApiWebSocket：** 当为 `true`（默认）时，发往上游 Copilot Responses API 的请求会对声明了 `ws:/responses` 的模型使用 Copilot WebSocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用上游 WebSocket 路由。该配置不会禁用 `/v1/responses` 上面向 Codex 的入站 WebSocket listener。
 - **useResponsesApiWebSearch：** 当为 `true`（默认）时，`/v1/responses` 会保留 `type: "web_search"` 的工具并转发到上游。设为 `false` 则会在发送 Copilot 请求之前将其剥离。
 - **logLevel：** 控制 `logs/*.log` 下 handler 文件日志的详细级别。可选值：`error`、`warn`、`info`、`debug`。默认值为 `info`。如果你需要把 payload 级或 stream 级的调试内容写入文件日志，请显式设置为 `debug`。
 - **anthropicApiKey：** 可选的 Anthropic API key，用于精确的 Claude token 计数（见下文 [精确的 Claude Token 计数](#accurate-claude-token-counting)）。也可通过环境变量 `ANTHROPIC_API_KEY` 设置。未配置时会回退到 GPT tokenizer 估算。
@@ -514,6 +515,7 @@ curl http://localhost:4141/v1/models \
 | 端点 | 方法 | 说明 |
 | --- | --- | --- |
 | `POST /v1/responses` | `POST` | OpenAI 中用于生成模型响应的高级接口。 |
+| `GET /v1/responses` | `WS` | Codex 兼容的 Responses WebSocket transport。 |
 | `POST /v1/chat/completions` | `POST` | 为给定聊天对话创建模型响应。 |
 | `GET /v1/models` | `GET` | 列出当前可用模型。 |
 | `POST /v1/embeddings` | `POST` | 创建表示输入文本的向量嵌入。 |
@@ -706,6 +708,42 @@ bunx --bun @nick3/copilot-api@latest auth
 ```sh
 COPILOT_API_OAUTH_APP=opencode bunx --bun @nick3/copilot-api@latest start
 ```
+
+## 与 Codex CLI 一起使用
+
+Codex 可以把本代理作为 OpenAI 兼容的 Responses API provider 使用。本代理同时支持 Codex 的 HTTP `POST /v1/responses` 路径，以及它偏好的 `GET /v1/responses` WebSocket upgrade。
+
+启动代理：
+
+```sh
+bunx --bun @nick3/copilot-api@latest start
+```
+
+> **注意：** `GET /v1/responses` 上的入站 Codex WebSocket listener 需要 Bun 服务端运行时，因此请使用 `bunx --bun`（或本地安装的 Bun）启动代理。`npx` 路径仅支持轻量级 MCP bridge，不会运行该 WebSocket listener。
+
+在 `~/.codex/config.toml` 中添加 provider：
+
+```toml
+[model_providers.copilot-api]
+name = "copilot-api"
+base_url = "http://localhost:4141/v1"
+wire_api = "responses"
+supports_websockets = true
+
+[profiles.copilot-api]
+model_provider = "copilot-api"
+model = "gpt-5.4"
+```
+
+然后使用该 profile 启动 Codex：
+
+```sh
+codex -p copilot-api
+```
+
+如果你配置了 `auth.apiKeys`，需要在 Codex 的 provider headers 或 bearer-token 配置里使用同一个 key，这样 HTTP 与 WebSocket 请求都能通过认证。仅在排障时，可以在 Codex 中设置 `supports_websockets = false` 来强制走 HTTP fallback。
+
+> **注意：** 通过 GitHub Copilot 使用 Codex 时，目前建议关闭 Codex multi-agent 功能，因为 Copilot 可能会根据最后一条 user-role 消息来计算 Codex 流量。
 
 ## 与 Claude Code 一起使用
 

--- a/src/lib/request-auth.ts
+++ b/src/lib/request-auth.ts
@@ -73,12 +73,16 @@ export function getConfiguredApiKeys(): Array<string> {
 }
 
 export function extractRequestApiKey(c: Context): string | null {
-  const xApiKey = c.req.header("x-api-key")?.trim()
+  return extractHeadersApiKey(c.req.raw.headers)
+}
+
+export function extractHeadersApiKey(headers: Headers): string | null {
+  const xApiKey = headers.get("x-api-key")?.trim()
   if (xApiKey) {
     return xApiKey
   }
 
-  const authorization = c.req.header("authorization")
+  const authorization = headers.get("authorization")
   if (!authorization) {
     return null
   }
@@ -90,6 +94,40 @@ export function extractRequestApiKey(c: Context): string | null {
 
   const bearerToken = rest.join(" ").trim()
   return bearerToken || null
+}
+
+export function isAuthorizedHeaders(
+  headers: Headers,
+  getApiKeys: () => Array<string> = getConfiguredApiKeys,
+): boolean {
+  const apiKeys = getApiKeys()
+  if (apiKeys.length === 0) {
+    return true
+  }
+
+  const requestApiKey = extractHeadersApiKey(headers)
+  return requestApiKey ?
+      apiKeys.some((apiKey) => timingSafeKeyCompare(requestApiKey, apiKey))
+    : false
+}
+
+export function createUnauthorizedRawResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message:
+          "Unauthorized. Provide Authorization: Bearer <key> or x-api-key.",
+        type: "unauthorized",
+      },
+    }),
+    {
+      status: 401,
+      headers: {
+        "content-type": "application/json",
+        "WWW-Authenticate": 'Bearer realm="copilot-api"',
+      },
+    },
+  )
 }
 
 function createUnauthorizedResponse(c: Context): Response {
@@ -163,17 +201,7 @@ export function createAuthMiddleware(
       return next()
     }
 
-    const apiKeys = getApiKeys()
-    if (apiKeys.length === 0) {
-      return next()
-    }
-
-    const requestApiKey = extractRequestApiKey(c)
-    const hasValidApiKey =
-      requestApiKey ?
-        apiKeys.some((apiKey) => timingSafeKeyCompare(requestApiKey, apiKey))
-      : false
-    if (!hasValidApiKey) {
+    if (!isAuthorizedHeaders(c.req.raw.headers, getApiKeys)) {
       return createUnauthorizedResponse(c)
     }
 

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -178,6 +178,11 @@ export const handleResponses = async (c: Context) => {
   request.upstreamRequestId = upstreamRequestId
   request.upstreamSessionId = upstreamSessionId
 
+  // Set by the Responses websocket bridge (src/routes/responses/websocket.ts) so
+  // the upstream pool can close the originating bridge socket when its GitHub
+  // connection is reaped while idle. Absent for plain HTTP callers.
+  const bridgeId = c.req.header("x-responses-bridge-id") ?? undefined
+
   if (streamRequested) {
     return handleStreamingResponses({
       c,
@@ -192,6 +197,7 @@ export const handleResponses = async (c: Context) => {
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       transport,
+      bridgeId,
     })
   }
 
@@ -208,6 +214,7 @@ export const handleResponses = async (c: Context) => {
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     transport,
+    bridgeId,
   })
 }
 
@@ -455,6 +462,7 @@ async function handleStreamingResponses(params: {
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   transport: ResponsesTransport
+  bridgeId: string | undefined
 }): Promise<Response> {
   const {
     c,
@@ -469,6 +477,7 @@ async function handleStreamingResponses(params: {
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     transport,
+    bridgeId,
   } = params
 
   let response: Awaited<ReturnType<typeof createResponses>>
@@ -483,6 +492,7 @@ async function handleStreamingResponses(params: {
         sessionId: request.upstreamSessionId,
         requestId: request.requestId,
         transport,
+        bridgeId,
       },
       accountCtx,
     )
@@ -804,6 +814,7 @@ async function handleNonStreamingResponses(params: {
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   transport: ResponsesTransport
+  bridgeId: string | undefined
 }): Promise<Response> {
   const {
     c,
@@ -818,6 +829,7 @@ async function handleNonStreamingResponses(params: {
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     transport,
+    bridgeId,
   } = params
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
   let usage: NormalizedUsage = {}
@@ -833,6 +845,7 @@ async function handleNonStreamingResponses(params: {
         sessionId: request.upstreamSessionId,
         requestId: request.requestId,
         transport,
+        bridgeId,
       },
       accountCtx,
     )

--- a/src/routes/responses/websocket.ts
+++ b/src/routes/responses/websocket.ts
@@ -1,0 +1,388 @@
+import consola from "consola"
+
+import {
+  createUnauthorizedRawResponse,
+  isAuthorizedHeaders,
+} from "~/lib/request-auth"
+
+const RESPONSES_WEBSOCKET_PATHS = new Set(["/responses", "/v1/responses"])
+const SSE_RECORD_SEPARATOR = /\r?\n\r?\n/u
+const FORWARDED_HEADER_NAMES = [
+  "authorization",
+  "x-api-key",
+  "user-agent",
+  "x-session-id",
+  "x-session-affinity",
+  "x-parent-session-id",
+  "x-trace-id",
+]
+
+type ServerWebSocket = Bun.ServerWebSocket<ResponsesWebSocketData>
+type AppFetch = (request: Request) => Response | Promise<Response>
+
+export type ResponsesWebSocketData = {
+  active: boolean
+  controller: AbortController | null
+  headers: Array<[string, string]>
+  url: string
+}
+
+type ResponsesWebSocketFrame = {
+  type?: unknown
+  [key: string]: unknown
+}
+
+export function createResponsesWebSocketHandler(
+  appFetch: AppFetch,
+): Bun.WebSocketHandler<ResponsesWebSocketData> {
+  return {
+    data: {} as ResponsesWebSocketData,
+    idleTimeout: 0,
+    async message(ws, message) {
+      await handleResponsesWebSocketMessage(ws, message, appFetch)
+    },
+    close(ws) {
+      // Abort any in-flight upstream Responses request so we stop consuming
+      // tokens/quota and worker time once the client disconnects.
+      ws.data.controller?.abort()
+    },
+  }
+}
+
+export function handleResponsesWebSocketUpgrade(
+  req: Request,
+  server: Bun.Server<ResponsesWebSocketData>,
+): Response | null | undefined {
+  if (!isResponsesWebSocketUpgrade(req)) {
+    return null
+  }
+
+  if (!isAuthorizedHeaders(req.headers)) {
+    return createUnauthorizedRawResponse()
+  }
+
+  const upgraded = server.upgrade(req, {
+    data: buildResponsesWebSocketData(req),
+  })
+
+  if (upgraded) {
+    return undefined
+  }
+
+  return new Response("WebSocket upgrade failed", { status: 400 })
+}
+
+export function isResponsesWebSocketUpgrade(req: Request): boolean {
+  if (req.method !== "GET") {
+    return false
+  }
+
+  const pathname = new URL(req.url).pathname
+  if (!RESPONSES_WEBSOCKET_PATHS.has(pathname)) {
+    return false
+  }
+
+  return req.headers.get("upgrade")?.toLowerCase() === "websocket"
+}
+
+export async function handleResponsesWebSocketMessage(
+  ws: ServerWebSocket,
+  message: string | ArrayBuffer | Uint8Array,
+  appFetch: AppFetch,
+): Promise<void> {
+  let frame: ResponsesWebSocketFrame
+  try {
+    frame = JSON.parse(
+      normalizeWebSocketMessage(message),
+    ) as ResponsesWebSocketFrame
+  } catch {
+    sendResponsesWebSocketError(ws, "Invalid websocket JSON frame", 400)
+    return
+  }
+
+  if (frame.type === "response.processed") {
+    return
+  }
+
+  if (frame.type !== "response.create") {
+    sendResponsesWebSocketError(ws, "Unsupported websocket frame type", 400)
+    return
+  }
+
+  if (frame.generate === false) {
+    sendResponsesWebSocketWarmupCompleted(ws)
+    return
+  }
+
+  if (ws.data.active) {
+    sendResponsesWebSocketError(
+      ws,
+      "Responses websocket request already active",
+      409,
+    )
+    return
+  }
+
+  ws.data.active = true
+  const controller = new AbortController()
+  ws.data.controller = controller
+  try {
+    await forwardResponseCreateFrame(ws, frame, appFetch, controller)
+  } catch (error) {
+    consola.warn("Responses websocket bridge failed:", error)
+    sendResponsesWebSocketError(
+      ws,
+      error instanceof Error ? error.message : String(error),
+      500,
+    )
+  } finally {
+    ws.data.active = false
+    ws.data.controller = null
+  }
+}
+
+export function parseSseRecords(chunk: string): {
+  events: Array<string>
+  remainder: string
+} {
+  const events: Array<string> = []
+  let remainder = chunk
+
+  while (true) {
+    const match = SSE_RECORD_SEPARATOR.exec(remainder)
+    if (!match) {
+      break
+    }
+
+    const record = remainder.slice(0, match.index)
+    remainder = remainder.slice(match.index + match[0].length)
+    const data = parseSseRecordData(record)
+    if (data !== null && data !== "[DONE]") {
+      events.push(data)
+    }
+  }
+
+  return { events, remainder }
+}
+
+function buildResponsesWebSocketData(req: Request): ResponsesWebSocketData {
+  return {
+    active: false,
+    controller: null,
+    headers: collectForwardedHeaders(req.headers),
+    url: req.url,
+  }
+}
+
+function collectForwardedHeaders(headers: Headers): Array<[string, string]> {
+  const forwarded: Array<[string, string]> = []
+  for (const name of FORWARDED_HEADER_NAMES) {
+    const value = headers.get(name)
+    if (value) {
+      forwarded.push([name, value])
+    }
+  }
+  return forwarded
+}
+
+async function forwardResponseCreateFrame(
+  ws: ServerWebSocket,
+  frame: ResponsesWebSocketFrame,
+  appFetch: AppFetch,
+  controller: AbortController,
+): Promise<void> {
+  const payload = { ...frame, stream: true }
+  delete payload.type
+
+  const response = await appFetch(
+    new Request(buildInternalResponsesUrl(ws.data.url), {
+      method: "POST",
+      headers: buildInternalResponsesHeaders(ws.data.headers),
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    }),
+  )
+
+  if (!response.ok) {
+    sendResponsesWebSocketError(
+      ws,
+      await readErrorResponseMessage(response),
+      response.status,
+    )
+    return
+  }
+
+  if (!response.body) {
+    sendResponsesWebSocketError(ws, "Responses stream body is empty", 500)
+    return
+  }
+
+  await streamSseResponseToWebSocket(ws, response.body, controller)
+}
+
+function buildInternalResponsesUrl(sourceUrl: string): string {
+  const url = new URL(sourceUrl)
+  url.protocol = "http:"
+  url.pathname =
+    url.pathname.startsWith("/v1/") ? "/v1/responses" : "/responses"
+  url.search = ""
+  url.hash = ""
+  return url.toString()
+}
+
+function buildInternalResponsesHeaders(
+  forwardedHeaders: Array<[string, string]>,
+): Headers {
+  const headers = new Headers(forwardedHeaders)
+  headers.set("content-type", "application/json")
+  return headers
+}
+
+async function streamSseResponseToWebSocket(
+  ws: ServerWebSocket,
+  body: ReadableStream<Uint8Array>,
+  controller: AbortController,
+): Promise<void> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  // Cancel the upstream reader as soon as the connection is aborted (client
+  // close or a failed send) so the upstream stream is torn down promptly.
+  const onAbort = () => {
+    void reader.cancel()
+  }
+  controller.signal.addEventListener("abort", onAbort)
+
+  try {
+    while (!controller.signal.aborted) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+
+      buffer += decoder.decode(value, { stream: true })
+      const parsed = parseSseRecords(buffer)
+      buffer = parsed.remainder
+      if (!relaySseEvents(ws, parsed.events, controller)) {
+        return
+      }
+    }
+
+    if (controller.signal.aborted) {
+      return
+    }
+
+    buffer += decoder.decode()
+    const parsed = parseSseRecords(`${buffer}\n\n`)
+    relaySseEvents(ws, parsed.events, controller)
+  } finally {
+    controller.signal.removeEventListener("abort", onAbort)
+    try {
+      reader.releaseLock()
+    } catch {
+      // Reader may already be released after cancellation; ignore.
+    }
+  }
+}
+
+/**
+ * Relay parsed SSE events to the client. Returns `false` if a send failed and
+ * the upstream request was aborted, signalling the caller to stop streaming.
+ */
+function relaySseEvents(
+  ws: ServerWebSocket,
+  events: Array<string>,
+  controller: AbortController,
+): boolean {
+  for (const event of events) {
+    if (controller.signal.aborted) {
+      return false
+    }
+    try {
+      ws.send(event)
+    } catch (error) {
+      consola.warn("Responses websocket send failed:", error)
+      controller.abort()
+      return false
+    }
+  }
+  return true
+}
+
+function parseSseRecordData(record: string): string | null {
+  const lines = record.split(/\r?\n/u)
+  const dataLines = lines
+    .filter((line) => line.startsWith("data:"))
+    // Per the SSE spec, strip only a single optional leading space after the
+    // colon (not arbitrary whitespace), preserving whitespace-sensitive data.
+    .map((line) => (line.startsWith("data: ") ? line.slice(6) : line.slice(5)))
+
+  if (dataLines.length === 0) {
+    return null
+  }
+
+  return dataLines.join("\n")
+}
+
+function normalizeWebSocketMessage(
+  message: string | ArrayBuffer | Uint8Array,
+): string {
+  if (typeof message === "string") {
+    return message
+  }
+
+  return new TextDecoder().decode(message)
+}
+
+function sendResponsesWebSocketError(
+  ws: ServerWebSocket,
+  message: string,
+  status: number,
+): void {
+  // Mirror the Responses stream error contract (see ResponseErrorEvent in
+  // src/services/copilot/create-responses.ts) so clients always receive the
+  // same top-level event shape regardless of where the error originates.
+  ws.send(
+    JSON.stringify({
+      code: status ? String(status) : null,
+      message,
+      param: null,
+      sequence_number: 0,
+      type: "error",
+    }),
+  )
+}
+
+function sendResponsesWebSocketWarmupCompleted(ws: ServerWebSocket): void {
+  ws.send(
+    JSON.stringify({
+      response: {
+        id: "",
+      },
+      sequence_number: 0,
+      type: "response.completed",
+    }),
+  )
+}
+
+async function readErrorResponseMessage(response: Response): Promise<string> {
+  const body = await response.text()
+  if (!body) {
+    return `Responses request failed with status ${response.status}`
+  }
+
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: unknown }
+      message?: unknown
+    }
+    const message =
+      typeof parsed.error?.message === "string" ? parsed.error.message
+      : typeof parsed.message === "string" ? parsed.message
+      : undefined
+    return message ?? body
+  } catch {
+    return body
+  }
+}

--- a/src/routes/responses/websocket.ts
+++ b/src/routes/responses/websocket.ts
@@ -21,8 +21,15 @@ type ServerWebSocket = Bun.ServerWebSocket<ResponsesWebSocketData>
 type AppFetch = (request: Request) => Response | Promise<Response>
 
 export type ResponsesWebSocketData = {
-  active: boolean
-  controller: AbortController | null
+  // Codex keeps a single persistent websocket per session and pipelines turns
+  // over it: a turn's `response.create` can arrive before the previous turn's
+  // SSE relay has finished tearing down. Bun does not serialize async `message`
+  // callbacks, so we chain work on this promise to process frames strictly in
+  // arrival order instead of rejecting concurrent frames.
+  queue: Promise<void>
+  // In-flight upstream requests, one AbortController per active `response.create`
+  // frame, so a client disconnect can abort all of them.
+  controllers: Set<AbortController>
   headers: Array<[string, string]>
   url: string
 }
@@ -42,9 +49,12 @@ export function createResponsesWebSocketHandler(
       await handleResponsesWebSocketMessage(ws, message, appFetch)
     },
     close(ws) {
-      // Abort any in-flight upstream Responses request so we stop consuming
+      // Abort every in-flight upstream Responses request so we stop consuming
       // tokens/quota and worker time once the client disconnects.
-      ws.data.controller?.abort()
+      for (const controller of ws.data.controllers) {
+        controller.abort()
+      }
+      ws.data.controllers.clear()
     },
   }
 }
@@ -109,26 +119,38 @@ export async function handleResponsesWebSocketMessage(
     return
   }
 
+  // Chain this frame after any in-flight work so pipelined turns are processed
+  // strictly in arrival order. The assignment is synchronous, so even though Bun
+  // may dispatch overlapping `message` callbacks, the ordering reflects the order
+  // frames were received. `processResponseCreateFrame` never rejects, keeping the
+  // chain alive for subsequent turns.
+  const queued = ws.data.queue.then(() =>
+    processResponseCreateFrame(ws, frame, appFetch),
+  )
+  ws.data.queue = queued
+  await queued
+}
+
+async function processResponseCreateFrame(
+  ws: ServerWebSocket,
+  frame: ResponsesWebSocketFrame,
+  appFetch: AppFetch,
+): Promise<void> {
   if (frame.generate === false) {
     sendResponsesWebSocketWarmupCompleted(ws)
     return
   }
 
-  if (ws.data.active) {
-    sendResponsesWebSocketError(
-      ws,
-      "Responses websocket request already active",
-      409,
-    )
-    return
-  }
-
-  ws.data.active = true
   const controller = new AbortController()
-  ws.data.controller = controller
+  ws.data.controllers.add(controller)
   try {
     await forwardResponseCreateFrame(ws, frame, appFetch, controller)
   } catch (error) {
+    // A client disconnect aborts in-flight controllers; that is expected
+    // teardown, not a failure to report back to the (now gone) client.
+    if (controller.signal.aborted) {
+      return
+    }
     consola.warn("Responses websocket bridge failed:", error)
     sendResponsesWebSocketError(
       ws,
@@ -136,8 +158,7 @@ export async function handleResponsesWebSocketMessage(
       500,
     )
   } finally {
-    ws.data.active = false
-    ws.data.controller = null
+    ws.data.controllers.delete(controller)
   }
 }
 
@@ -167,8 +188,8 @@ export function parseSseRecords(chunk: string): {
 
 function buildResponsesWebSocketData(req: Request): ResponsesWebSocketData {
   return {
-    active: false,
-    controller: null,
+    queue: Promise.resolve(),
+    controllers: new Set(),
     headers: collectForwardedHeaders(req.headers),
     url: req.url,
   }

--- a/src/routes/responses/websocket.ts
+++ b/src/routes/responses/websocket.ts
@@ -147,13 +147,15 @@ export async function handleResponsesWebSocketMessage(
   // Chain this frame after any in-flight work so pipelined turns are processed
   // strictly in arrival order. The assignment is synchronous, so even though Bun
   // may dispatch overlapping `message` callbacks, the ordering reflects the order
-  // frames were received. `processResponseCreateFrame` never rejects, keeping the
-  // chain alive for subsequent turns.
-  const queued = ws.data.queue.then(() =>
-    processResponseCreateFrame(ws, frame, appFetch),
-  )
+  // frames were received. We swallow any rejection from the prior link before
+  // chaining so a single failed turn (e.g. `ws.send` throwing while the socket is
+  // closing) can never poison `ws.data.queue` and block every subsequent turn for
+  // the lifetime of the connection.
+  const queued = ws.data.queue
+    .catch(() => {})
+    .then(() => processResponseCreateFrame(ws, frame, appFetch))
   ws.data.queue = queued
-  await queued
+  await queued.catch(() => {})
 }
 
 async function processResponseCreateFrame(

--- a/src/routes/responses/websocket.ts
+++ b/src/routes/responses/websocket.ts
@@ -1,9 +1,16 @@
 import consola from "consola"
+import { randomUUID } from "node:crypto"
 
 import {
   createUnauthorizedRawResponse,
   isAuthorizedHeaders,
 } from "~/lib/request-auth"
+import {
+  registerResponsesBridge,
+  unregisterResponsesBridge,
+} from "~/services/copilot/responses-bridge-registry"
+
+const RESPONSES_BRIDGE_ID_HEADER = "x-responses-bridge-id"
 
 const RESPONSES_WEBSOCKET_PATHS = new Set(["/responses", "/v1/responses"])
 const SSE_RECORD_SEPARATOR = /\r?\n\r?\n/u
@@ -32,6 +39,12 @@ export type ResponsesWebSocketData = {
   controllers: Set<AbortController>
   headers: Array<[string, string]>
   url: string
+  // Stable id minted per bridge connection. It is forwarded to the upstream
+  // Responses pool (via `x-responses-bridge-id`) so the pool can close this exact
+  // socket when its upstream connection is reaped, forcing Codex to rebuild a
+  // fresh full-context session instead of stalling on a stale
+  // `previous_response_id`.
+  bridgeId: string
 }
 
 type ResponsesWebSocketFrame = {
@@ -45,10 +58,22 @@ export function createResponsesWebSocketHandler(
   return {
     data: {} as ResponsesWebSocketData,
     idleTimeout: 0,
+    open(ws) {
+      // Register a closer so the upstream pool can drop this socket when its
+      // GitHub connection is reaped while idle.
+      registerResponsesBridge(ws.data.bridgeId, () => {
+        try {
+          ws.close()
+        } catch (error) {
+          consola.warn("Failed to close Responses websocket bridge:", error)
+        }
+      })
+    },
     async message(ws, message) {
       await handleResponsesWebSocketMessage(ws, message, appFetch)
     },
     close(ws) {
+      unregisterResponsesBridge(ws.data.bridgeId)
       // Abort every in-flight upstream Responses request so we stop consuming
       // tokens/quota and worker time once the client disconnects.
       for (const controller of ws.data.controllers) {
@@ -192,6 +217,7 @@ function buildResponsesWebSocketData(req: Request): ResponsesWebSocketData {
     controllers: new Set(),
     headers: collectForwardedHeaders(req.headers),
     url: req.url,
+    bridgeId: randomUUID(),
   }
 }
 
@@ -218,7 +244,7 @@ async function forwardResponseCreateFrame(
   const response = await appFetch(
     new Request(buildInternalResponsesUrl(ws.data.url), {
       method: "POST",
-      headers: buildInternalResponsesHeaders(ws.data.headers),
+      headers: buildInternalResponsesHeaders(ws.data.headers, ws.data.bridgeId),
       body: JSON.stringify(payload),
       signal: controller.signal,
     }),
@@ -253,9 +279,11 @@ function buildInternalResponsesUrl(sourceUrl: string): string {
 
 function buildInternalResponsesHeaders(
   forwardedHeaders: Array<[string, string]>,
+  bridgeId: string,
 ): Headers {
   const headers = new Headers(forwardedHeaders)
   headers.set("content-type", "application/json")
+  headers.set(RESPONSES_BRIDGE_ID_HEADER, bridgeId)
   return headers
 }
 

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -26,6 +26,7 @@ import { resolveEffectiveInitiator } from "~/lib/request-initiator"
 import { accountFromState } from "~/lib/state"
 
 import { copilotFetch } from "./copilot-fetch"
+import { closeResponsesBridge } from "./responses-bridge-registry"
 
 export interface ResponsesPayload {
   model: string
@@ -448,6 +449,7 @@ interface ResponsesRequestOptions {
   requestId?: string
   fetchImpl?: typeof fetch
   transport?: ResponsesTransport
+  bridgeId?: string
 }
 
 const RESPONSES_WEBSOCKET_IDLE_TIMEOUT_MS = 60_000
@@ -464,6 +466,7 @@ export const createResponses = async (
     requestId,
     fetchImpl,
     transport = "http",
+    bridgeId,
   }: ResponsesRequestOptions,
   account?: AccountContext,
 ): Promise<CreateResponsesReturn> => {
@@ -500,6 +503,7 @@ export const createResponses = async (
         requestId: requestId ?? upstreamRequestId ?? "missing-request-id",
         sessionId,
         subagentMarker,
+        bridgeId,
       },
     )
     const stream = createPooledResponsesWebSocketStream(
@@ -566,6 +570,7 @@ interface ResponsesWebSocketRequest {
   headers: Record<string, string>
   poolKey: string
   payload: ResponsesWebSocketPayload
+  bridgeId?: string
 }
 
 type ResponsesWebSocketErrorEvent = Parameters<
@@ -580,6 +585,7 @@ export const prepareResponsesWebSocketRequest = (
     requestId: string
     sessionId?: string
     subagentMarker?: SubagentMarker | null
+    bridgeId?: string
   },
 ): ResponsesWebSocketRequest => {
   const initiator = getResponsesWebSocketInitiator(preparedHeaders)
@@ -588,6 +594,7 @@ export const prepareResponsesWebSocketRequest = (
     headers: copilotWebSocketHeaders(preparedHeaders),
     poolKey: buildResponsesWebSocketPoolKey(payload, options),
     payload: buildResponsesWebSocketPayload(payload, initiator),
+    bridgeId: options.bridgeId,
   }
 }
 
@@ -680,6 +687,11 @@ interface ResponsesWebSocketEntry {
   idleTimer: ReturnType<typeof setTimeout> | null
   requestCount: number
   websocketPromise: Promise<InstanceType<typeof WebSocket>>
+  // Bridge socket (WS #1) that originated this upstream connection, if any. When
+  // this entry is dropped while no turn is in flight, we close that bridge socket
+  // so Codex rebuilds a fresh full-context session instead of stalling on a stale
+  // `previous_response_id`.
+  bridgeId?: string
 }
 
 interface ResponsesWebSocketRequestTarget {
@@ -761,14 +773,17 @@ const createResponsesWebSocketEntry = (
       headers: request.headers,
       url: buildResponsesWebSocketUrl(baseUrl),
     }),
+    bridgeId: request.bridgeId,
   }
 
   entry.websocketPromise
     .then((websocket) => {
       websocket.addEventListener("close", () => {
+        maybeCloseResponsesBridgeForReapedEntry(request.poolKey, entry)
         removeResponsesWebSocketPoolEntry(request.poolKey, entry)
       })
       websocket.addEventListener("error", () => {
+        maybeCloseResponsesBridgeForReapedEntry(request.poolKey, entry)
         removeResponsesWebSocketPoolEntry(request.poolKey, entry)
       })
     })
@@ -777,6 +792,32 @@ const createResponsesWebSocketEntry = (
     })
 
   return entry
+}
+
+// Close the originating bridge socket (WS #1) when the upstream connection it was
+// keyed to is dropped while the session is idle, so Codex rebuilds a fresh
+// full-context request on its next turn instead of stalling ~5 minutes on a stale
+// `previous_response_id`.
+//
+// Gated to fire only for the live pooled entry (`responsesWebSocketPool` still
+// points at it) with no in-flight turn (`requestCount === 0`). This excludes:
+//   - throwaway non-pooled entries (never in the pool map), whose normal teardown
+//     would otherwise close the bridge after a concurrent turn, and
+//   - mid-turn upstream drops (`requestCount > 0`), which the active request's
+//     existing error path already surfaces to Codex.
+const maybeCloseResponsesBridgeForReapedEntry = (
+  poolKey: string,
+  entry: ResponsesWebSocketEntry,
+): void => {
+  if (
+    entry.bridgeId === undefined
+    || entry.requestCount > 0
+    || responsesWebSocketPool.get(poolKey) !== entry
+  ) {
+    return
+  }
+
+  closeResponsesBridge(entry.bridgeId)
 }
 
 const acquireResponsesWebSocketEntry = (
@@ -848,6 +889,7 @@ const scheduleResponsesWebSocketIdleClose = (
 ): void => {
   clearResponsesWebSocketIdleTimer(entry)
   entry.idleTimer = setTimeout(() => {
+    maybeCloseResponsesBridgeForReapedEntry(poolKey, entry)
     removeResponsesWebSocketPoolEntry(poolKey, entry)
   }, RESPONSES_WEBSOCKET_IDLE_TIMEOUT_MS)
   unrefTimer(entry.idleTimer)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -747,6 +747,13 @@ const getResponsesWebSocketRequestTarget = (
   const existing = responsesWebSocketPool.get(request.poolKey)
   if (existing && !existing.closed) {
     clearResponsesWebSocketIdleTimer(existing)
+    // A Codex client can reconnect for the same session (minting a fresh bridge,
+    // hence a fresh bridgeId) before this pooled upstream entry is reaped. Rebind
+    // the entry to the currently connected bridge so a later idle reap closes the
+    // live WS #1, not the original now-unregistered one — otherwise the multi-turn
+    // recovery would target a dead bridge and the next turn could still stall on a
+    // stale `previous_response_id`.
+    existing.bridgeId = request.bridgeId
     return {
       entry: existing,
       pooled: true,

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -498,6 +498,7 @@ export const createResponses = async (
       {
         copilotToken: ctx.copilotToken,
         requestId: requestId ?? upstreamRequestId ?? "missing-request-id",
+        sessionId,
         subagentMarker,
       },
     )
@@ -577,6 +578,7 @@ export const prepareResponsesWebSocketRequest = (
   options: {
     copilotToken?: string
     requestId: string
+    sessionId?: string
     subagentMarker?: SubagentMarker | null
   },
 ): ResponsesWebSocketRequest => {
@@ -594,10 +596,12 @@ export const buildResponsesWebSocketPoolKey = (
   {
     copilotToken,
     requestId,
+    sessionId,
     subagentMarker,
   }: {
     copilotToken?: string
     requestId: string
+    sessionId?: string
     subagentMarker?: SubagentMarker | null
   },
 ): string => {
@@ -614,7 +618,15 @@ export const buildResponsesWebSocketPoolKey = (
       ].join(":")
     : "main"
 
-  return [tokenFingerprint, payload.model, requestId, subagentKey]
+  // Key the upstream websocket on the session, not the per-request id. Copilot
+  // stores Responses conversation state (referenced by `previous_response_id`)
+  // per upstream connection, so every turn of a session must reuse the same
+  // socket. Codex derives a stable `prompt_cache_key` (its thread id) per
+  // session, which upstream callers turn into `sessionId`. Fall back to
+  // `requestId` when no session id is available (e.g. one-off HTTP callers).
+  const connectionAffinityKey = sessionId ?? requestId
+
+  return [tokenFingerprint, payload.model, connectionAffinityKey, subagentKey]
     .map(encodePoolKeyPart)
     .join("|")
 }

--- a/src/services/copilot/responses-bridge-registry.ts
+++ b/src/services/copilot/responses-bridge-registry.ts
@@ -1,0 +1,54 @@
+import consola from "consola"
+
+// Cross-layer side-channel between the Codex-facing Responses websocket bridge
+// (WS #1, `src/routes/responses/websocket.ts`) and the upstream GitHub Responses
+// websocket pool (WS #2, `src/services/copilot/create-responses.ts`).
+//
+// The pool reaps an idle upstream connection after
+// `RESPONSES_WEBSOCKET_IDLE_TIMEOUT_MS`. Once that happens the conversation state
+// GitHub keyed to that connection (referenced by `previous_response_id`) is gone,
+// so the next incremental turn Codex sends over the still-open bridge socket would
+// reference a `previous_response_id` the fresh upstream connection has never seen.
+// Codex cannot recover from that quickly (it silently waits out its 5 minute
+// `stream_idle_timeout` before retrying).
+//
+// To force a clean, immediate recovery we close the bridge socket (WS #1) whenever
+// its upstream connection is dropped while idle. Codex then notices its cached
+// session is closed at the start of the next turn and transparently rebuilds a
+// fresh full-context request (no `previous_response_id`).
+//
+// The bridge cannot be looked up by `sessionId` because the pool key derives that
+// value via `getUUID(...)` in the handler, which the bridge layer does not cheaply
+// reproduce. Instead the bridge mints a `bridgeId`, registers a closer here, and
+// threads the id down to the pool entry so the pool can close the exact socket.
+
+type BridgeCloser = () => void
+
+const bridgeClosers = new Map<string, BridgeCloser>()
+
+export const registerResponsesBridge = (
+  bridgeId: string,
+  closer: BridgeCloser,
+): void => {
+  bridgeClosers.set(bridgeId, closer)
+}
+
+export const unregisterResponsesBridge = (bridgeId: string): void => {
+  bridgeClosers.delete(bridgeId)
+}
+
+// Close the bridge socket associated with `bridgeId`, if one is still registered.
+// Idempotent and safe to call for unknown ids: the bridge may have already closed
+// (e.g. Codex disconnected) and unregistered itself.
+export const closeResponsesBridge = (bridgeId: string): void => {
+  const closer = bridgeClosers.get(bridgeId)
+  if (!closer) {
+    return
+  }
+
+  try {
+    closer()
+  } catch (error) {
+    consola.warn("Failed to close Responses websocket bridge:", error)
+  }
+}

--- a/src/start.ts
+++ b/src/start.ts
@@ -3,7 +3,6 @@
 import { defineCommand } from "citty"
 import clipboard from "clipboardy"
 import consola from "consola"
-import { serve } from "srvx"
 
 import {
   registerQuotaRefreshSchedulerShutdownCleanup,
@@ -11,6 +10,10 @@ import {
   stopQuotaRefreshScheduler,
 } from "~/lib/quota-refresh-scheduler-runtime"
 import { isMcpHttpEnabledFromEnv } from "~/mcp-http-config"
+import {
+  createResponsesWebSocketHandler,
+  handleResponsesWebSocketUpgrade,
+} from "~/routes/responses/websocket"
 
 import { accountsManager } from "./lib/accounts-manager"
 import { addAccountToRegistry, saveAccountToken } from "./lib/accounts-registry"
@@ -255,13 +258,25 @@ export async function runServer(options: RunServerOptions): Promise<void> {
 
   const { createServer } = await import("./server")
   const server = createServer({ enableMcpHttp })
+  const responsesWebSocketHandler = createResponsesWebSocketHandler(
+    server.fetch,
+  )
 
-  serve({
-    fetch: server.fetch,
+  Bun.serve({
     port: options.port,
-    bun: {
-      idleTimeout: 0,
+    idleTimeout: 0,
+    fetch: (request, bunServer) => {
+      const websocketResponse = handleResponsesWebSocketUpgrade(
+        request,
+        bunServer,
+      )
+      if (websocketResponse !== null) {
+        return websocketResponse
+      }
+
+      return server.fetch(request)
     },
+    websocket: responsesWebSocketHandler,
   })
 }
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -153,6 +153,17 @@ async function setupClaudeCode(
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
+  // Fail fast before any config merge, account init, interactive auth, or quota
+  // scheduler work: the server relies on Bun.serve for the Responses WebSocket
+  // transport, so running under Node would otherwise crash with
+  // "ReferenceError: Bun is not defined" only after all that setup.
+  if (typeof Bun === "undefined") {
+    consola.error(
+      "The Responses WebSocket transport requires the Bun runtime. Start the proxy with 'bun' or 'bunx --bun' instead of Node.",
+    )
+    process.exit(1)
+  }
+
   // Work around unjs/consola#357 until a release includes PR #359.
   consola.options.throttle = 0
 
@@ -261,13 +272,6 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   const responsesWebSocketHandler = createResponsesWebSocketHandler(
     server.fetch,
   )
-
-  if (typeof Bun === "undefined") {
-    consola.error(
-      "The Responses WebSocket transport requires the Bun runtime. Start the proxy with 'bun' or 'bunx --bun' instead of Node.",
-    )
-    process.exit(1)
-  }
 
   Bun.serve({
     port: options.port,

--- a/src/start.ts
+++ b/src/start.ts
@@ -262,6 +262,13 @@ export async function runServer(options: RunServerOptions): Promise<void> {
     server.fetch,
   )
 
+  if (typeof Bun === "undefined") {
+    consola.error(
+      "The Responses WebSocket transport requires the Bun runtime. Start the proxy with 'bun' or 'bunx --bun' instead of Node.",
+    )
+    process.exit(1)
+  }
+
   Bun.serve({
     port: options.port,
     idleTimeout: 0,

--- a/tests/create-responses-websocket-pool.test.ts
+++ b/tests/create-responses-websocket-pool.test.ts
@@ -657,6 +657,38 @@ test("does not close the bridge for a throwaway concurrent (non-pooled) connecti
   await firstIterator.next()
 })
 
+test("rebinds a reused pooled entry to the reconnecting bridge so the idle reap closes the live bridge", async () => {
+  let oldBridgeClosed = 0
+  let newBridgeClosed = 0
+  trackResponsesBridge("bridge-old", () => {
+    oldBridgeClosed += 1
+  })
+  trackResponsesBridge("bridge-new", () => {
+    newBridgeClosed += 1
+  })
+
+  // Turn 1 over the original bridge. The upstream entry returns to the pool with
+  // requestCount === 0 and is keyed to "bridge-old".
+  await collectResponsesStreamWithBridge("request-1", "bridge-old")
+
+  // Codex reconnects for the same session (a fresh bridge, hence "bridge-new")
+  // BEFORE the pooled upstream entry is reaped. The pool reuses the existing
+  // connection, so it must be rebound to the currently connected bridge.
+  await collectResponsesStreamWithBridge("request-1", "bridge-new")
+
+  expect(MockWebSocket.instances).toHaveLength(1)
+  expect(oldBridgeClosed).toBe(0)
+  expect(newBridgeClosed).toBe(0)
+
+  // The idle reap now closes the LIVE bridge ("bridge-new"), not the original
+  // now-unregistered one. Without the rebind, the reap would target "bridge-old"
+  // and leave the connected bridge stalled on a stale previous_response_id.
+  MockWebSocket.instances[0]?.close()
+
+  expect(newBridgeClosed).toBe(1)
+  expect(oldBridgeClosed).toBe(0)
+})
+
 const collectResponsesStream = async (requestId: string): Promise<void> => {
   const response = await createResponses(
     {

--- a/tests/create-responses-websocket-pool.test.ts
+++ b/tests/create-responses-websocket-pool.test.ts
@@ -3,6 +3,11 @@ import { afterEach, beforeEach, expect, mock, test } from "bun:test"
 import type { AccountContext } from "../src/lib/types/account"
 import type { ResponsesResult } from "../src/services/copilot/create-responses"
 
+import {
+  registerResponsesBridge,
+  unregisterResponsesBridge,
+} from "../src/services/copilot/responses-bridge-registry"
+
 type ListenerEvent = {
   data?: string
   error?: unknown
@@ -190,6 +195,15 @@ const createResponsesResult = (
   usage: null,
 })
 
+// Bridge ids registered during a test, unregistered in afterEach so the shared
+// registry map does not leak closers between tests.
+const registeredTestBridges = new Set<string>()
+
+const trackResponsesBridge = (bridgeId: string, closer: () => void): void => {
+  registeredTestBridges.add(bridgeId)
+  registerResponsesBridge(bridgeId, closer)
+}
+
 beforeEach(() => {
   MockWebSocket.autoComplete = true
   MockWebSocket.closeAfterComplete = false
@@ -211,6 +225,11 @@ afterEach(() => {
   for (const websocket of MockWebSocket.instances) {
     websocket.close()
   }
+
+  for (const bridgeId of registeredTestBridges) {
+    unregisterResponsesBridge(bridgeId)
+  }
+  registeredTestBridges.clear()
 
   state.accountType = originalState.accountType
   state.copilotApiUrl = originalState.copilotApiUrl
@@ -548,6 +567,96 @@ test("Responses websocket uses the proxy-env dispatcher when initialized", async
   }
 })
 
+test("closes the originating bridge when its pooled upstream connection drops while idle", async () => {
+  let bridgeClosed = 0
+  trackResponsesBridge("bridge-idle", () => {
+    bridgeClosed += 1
+  })
+
+  // Complete a turn so the entry returns to the pool with requestCount === 0.
+  await collectResponsesStreamWithBridge("request-1", "bridge-idle")
+
+  expect(MockWebSocket.instances).toHaveLength(1)
+  expect(bridgeClosed).toBe(0)
+
+  // The upstream connection being reaped/dropped while idle must close the
+  // originating bridge socket so Codex rebuilds a fresh full-context session.
+  MockWebSocket.instances[0]?.close()
+
+  expect(bridgeClosed).toBe(1)
+})
+
+test("leaves the bridge open when the upstream connection drops mid-turn", async () => {
+  MockWebSocket.autoComplete = false
+  let bridgeClosed = 0
+  trackResponsesBridge("bridge-midturn", () => {
+    bridgeClosed += 1
+  })
+
+  const streamPromise = collectResponsesStreamWithBridge(
+    "request-1",
+    "bridge-midturn",
+  )
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  // Drop the socket while the turn is still in flight (requestCount > 0). The
+  // active request's own error path surfaces this to Codex, so the bridge must
+  // NOT be force-closed here.
+  MockWebSocket.instances[0]?.emitError({
+    error: new Error("socket hang up"),
+  })
+
+  await streamPromise.catch(() => {})
+
+  expect(bridgeClosed).toBe(0)
+})
+
+test("does not close the bridge for a throwaway concurrent (non-pooled) connection", async () => {
+  MockWebSocket.autoComplete = false
+  let keptBridgeClosed = 0
+  let throwawayBridgeClosed = 0
+  trackResponsesBridge("bridge-keep", () => {
+    keptBridgeClosed += 1
+  })
+  trackResponsesBridge("bridge-throwaway", () => {
+    throwawayBridgeClosed += 1
+  })
+
+  // First request owns the pooled entry for this pool key.
+  const firstIterator = await openResponsesStreamWithBridge(
+    "request-1",
+    "bridge-keep",
+  )
+  const firstChunk = firstIterator.next()
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  // Concurrent request with the same pool key bypasses the pool and gets a
+  // dedicated, non-pooled connection.
+  const secondPromise = collectResponsesStreamWithBridge(
+    "request-1",
+    "bridge-throwaway",
+  )
+  await waitFor(
+    () =>
+      MockWebSocket.instances.length === 2
+      && MockWebSocket.instances[1]?.sent.length === 1,
+  )
+
+  // Finish and drop the throwaway connection. It was never the live pooled
+  // entry, so its bridge must NOT be closed.
+  MockWebSocket.instances[1]?.completeLatestResponse()
+  await secondPromise
+  MockWebSocket.instances[1]?.close()
+
+  expect(throwawayBridgeClosed).toBe(0)
+  expect(keptBridgeClosed).toBe(0)
+
+  // Drain the still-pooled first request.
+  MockWebSocket.instances[0]?.completeLatestResponse()
+  await firstChunk
+  await firstIterator.next()
+})
+
 const collectResponsesStream = async (requestId: string): Promise<void> => {
   const response = await createResponses(
     {
@@ -566,6 +675,42 @@ const collectResponsesStream = async (requestId: string): Promise<void> => {
 
   for await (const _chunk of response as AsyncIterable<unknown>) {
     // consume stream
+  }
+}
+
+const openResponsesStreamWithBridge = async (
+  requestId: string,
+  bridgeId: string,
+): Promise<AsyncIterableIterator<unknown>> => {
+  const response = await createResponses(
+    {
+      input: "hello",
+      model: "gpt-test",
+      stream: true,
+    },
+    {
+      bridgeId,
+      initiator: "user",
+      requestId,
+      transport: "websocket",
+      vision: false,
+    },
+    account,
+  )
+
+  return (response as AsyncIterable<unknown>)[
+    Symbol.asyncIterator
+  ]() as AsyncIterableIterator<unknown>
+}
+
+const collectResponsesStreamWithBridge = async (
+  requestId: string,
+  bridgeId: string,
+): Promise<void> => {
+  const iterator = await openResponsesStreamWithBridge(requestId, bridgeId)
+  let next = await iterator.next()
+  while (!next.done) {
+    next = await iterator.next()
   }
 }
 

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -382,6 +382,27 @@ describe("createResponses websocket helpers", () => {
     expect(request.headers["x-interaction-id"]).toBeUndefined()
   })
 
+  test("websocket request carries the bridge id through to the pool entry", () => {
+    const preparedHeaders = {
+      ...copilotHeaders(account, false, "request-1"),
+      "x-initiator": "user",
+    }
+
+    const withBridge = prepareResponsesWebSocketRequest(
+      { input: "hello", model: "gpt-test", stream: true },
+      preparedHeaders,
+      { requestId: "request-1", bridgeId: "bridge-123" },
+    )
+    expect(withBridge.bridgeId).toBe("bridge-123")
+
+    const withoutBridge = prepareResponsesWebSocketRequest(
+      { input: "hello", model: "gpt-test", stream: true },
+      preparedHeaders,
+      { requestId: "request-1" },
+    )
+    expect(withoutBridge.bridgeId).toBeUndefined()
+  })
+
   test("websocket pool key separates account token model request and subagent context", () => {
     const basePayload: ResponsesPayload = {
       input: "hello",

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -421,4 +421,33 @@ describe("createResponses websocket helpers", () => {
     expect(mainKey).toContain("gpt-test")
     expect(mainKey).toContain("request-1")
   })
+
+  test("websocket pool key is stable per session across turns", () => {
+    const basePayload: ResponsesPayload = {
+      input: "hello",
+      model: "gpt-test",
+    }
+
+    // Same session, different per-request ids (pipelined codex turns) must share
+    // a pool key so the upstream connection — and its server-side
+    // previous_response_id state — is reused.
+    const turnOne = buildResponsesWebSocketPoolKey(basePayload, {
+      copilotToken: "token-a",
+      requestId: "request-1",
+      sessionId: "session-abc",
+    })
+    const turnTwo = buildResponsesWebSocketPoolKey(basePayload, {
+      copilotToken: "token-a",
+      requestId: "request-2",
+      sessionId: "session-abc",
+    })
+    const otherSession = buildResponsesWebSocketPoolKey(basePayload, {
+      copilotToken: "token-a",
+      requestId: "request-3",
+      sessionId: "session-xyz",
+    })
+
+    expect(turnOne).toBe(turnTwo)
+    expect(turnOne).not.toBe(otherSession)
+  })
 })

--- a/tests/request-auth.test.ts
+++ b/tests/request-auth.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test"
 import { Hono } from "hono"
 
-import { createAuthMiddleware } from "../src/lib/request-auth"
+import {
+  createAuthMiddleware,
+  extractHeadersApiKey,
+  isAuthorizedHeaders,
+} from "~/lib/request-auth"
 
 function createTestApp() {
   const app = new Hono()
@@ -56,6 +60,49 @@ test("authenticated route requires valid key", async () => {
     }),
   )
   expect(authorized.status).toBe(200)
+})
+
+test("raw headers auth supports x-api-key and bearer tokens", () => {
+  expect(
+    isAuthorizedHeaders(
+      new Headers({
+        "x-api-key": "k",
+      }),
+      () => ["k"],
+    ),
+  ).toBe(true)
+
+  expect(
+    isAuthorizedHeaders(
+      new Headers({
+        authorization: "Bearer k",
+      }),
+      () => ["k"],
+    ),
+  ).toBe(true)
+
+  expect(
+    isAuthorizedHeaders(
+      new Headers({
+        authorization: "Bearer wrong",
+      }),
+      () => ["k"],
+    ),
+  ).toBe(false)
+})
+
+test("raw headers auth allows requests when no keys are configured", () => {
+  expect(isAuthorizedHeaders(new Headers(), () => [])).toBe(true)
+})
+
+test("extractHeadersApiKey ignores unsupported authorization schemes", () => {
+  expect(
+    extractHeadersApiKey(
+      new Headers({
+        authorization: "Basic k",
+      }),
+    ),
+  ).toBe(null)
 })
 
 test("server keeps admin routes outside request auth middleware", async () => {

--- a/tests/responses-bridge-registry.test.ts
+++ b/tests/responses-bridge-registry.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+
+import {
+  closeResponsesBridge,
+  registerResponsesBridge,
+  unregisterResponsesBridge,
+} from "~/services/copilot/responses-bridge-registry"
+
+test("closeResponsesBridge invokes the registered closer", () => {
+  let closed = 0
+  registerResponsesBridge("bridge-a", () => {
+    closed += 1
+  })
+
+  closeResponsesBridge("bridge-a")
+
+  expect(closed).toBe(1)
+})
+
+test("closeResponsesBridge is a no-op for unknown bridge ids", () => {
+  expect(() => closeResponsesBridge("missing-bridge")).not.toThrow()
+})
+
+test("unregisterResponsesBridge stops the closer from firing", () => {
+  let closed = 0
+  registerResponsesBridge("bridge-b", () => {
+    closed += 1
+  })
+  unregisterResponsesBridge("bridge-b")
+
+  closeResponsesBridge("bridge-b")
+
+  expect(closed).toBe(0)
+})
+
+test("a closer only fires once: a second close after teardown is a no-op", () => {
+  let closed = 0
+  registerResponsesBridge("bridge-c", () => {
+    closed += 1
+    // Real bridges unregister themselves on close.
+    unregisterResponsesBridge("bridge-c")
+  })
+
+  closeResponsesBridge("bridge-c")
+  closeResponsesBridge("bridge-c")
+
+  expect(closed).toBe(1)
+})
+
+test("closeResponsesBridge swallows errors thrown by the closer", () => {
+  registerResponsesBridge("bridge-d", () => {
+    throw new Error("boom")
+  })
+
+  expect(() => closeResponsesBridge("bridge-d")).not.toThrow()
+})

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -18,8 +18,8 @@ function createMockWebSocket(): MockWebSocket {
   const sent: Array<string> = []
   return {
     data: {
-      active: false,
-      controller: null,
+      queue: Promise.resolve(),
+      controllers: new Set(),
       headers: [],
       url: "http://localhost:4141/v1/responses",
     },
@@ -215,6 +215,78 @@ test("relays upstream errors as spec-shaped error frames", async () => {
   })
 })
 
+test("serializes pipelined response.create frames instead of rejecting them", async () => {
+  // Reproduces the codex multi-turn bug: codex reuses one websocket and can
+  // send turn 2's `response.create` before turn 1's SSE relay has finished.
+  // The bridge must queue turn 2 (not reject it with a 409) and forward both.
+  const ws = createMockWebSocket()
+  const fetchOrder: Array<string> = []
+  let releaseTurnOne: (() => void) | undefined
+
+  const handler = createResponsesWebSocketHandler(() => {
+    const order = fetchOrder.length
+    fetchOrder.push(`fetch-${order}`)
+
+    if (order === 0) {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          releaseTurnOne = () => {
+            controller.enqueue(
+              new TextEncoder().encode(
+                'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-1"}}\n\n',
+              ),
+            )
+            controller.close()
+          }
+        },
+      })
+      return Promise.resolve(
+        new Response(stream, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      )
+    }
+
+    return Promise.resolve(
+      new Response(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-2"}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    )
+  })
+
+  const turnOne = handler.message(
+    ws as never,
+    JSON.stringify({
+      input: "one",
+      model: "gpt-test",
+      type: "response.create",
+    }),
+  )
+  const turnTwo = handler.message(
+    ws as never,
+    JSON.stringify({
+      input: "two",
+      model: "gpt-test",
+      previous_response_id: "resp-1",
+      type: "response.create",
+    }),
+  )
+
+  // Turn 2 must wait: only turn 1 has reached the upstream fetch so far.
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  expect(fetchOrder).toEqual(["fetch-0"])
+
+  releaseTurnOne?.()
+  await Promise.all([turnOne, turnTwo])
+
+  expect(fetchOrder).toEqual(["fetch-0", "fetch-1"])
+  expect(ws.sent).toEqual([
+    '{"type":"response.completed","response":{"id":"resp-1"}}',
+    '{"type":"response.completed","response":{"id":"resp-2"}}',
+  ])
+})
+
 test("aborts the upstream stream when the client disconnects", async () => {
   const ws = createMockWebSocket()
   let cancelled = false
@@ -252,12 +324,12 @@ test("aborts the upstream stream when the client disconnects", async () => {
   // Let the first SSE event flow through before disconnecting.
   await new Promise((resolve) => setTimeout(resolve, 10))
   expect(ws.sent).toContain('{"type":"response.created"}')
-  expect(ws.data.controller).not.toBeNull()
+  expect(ws.data.controllers.size).toBe(1)
 
   // Simulate the client closing the websocket.
   void handler.close?.(ws as never, 1000, "client closed")
   await messagePromise
 
   expect(cancelled).toBe(true)
-  expect(ws.data.controller).toBeNull()
+  expect(ws.data.controllers.size).toBe(0)
 })

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -22,6 +22,7 @@ function createMockWebSocket(): MockWebSocket {
       controllers: new Set(),
       headers: [],
       url: "http://localhost:4141/v1/responses",
+      bridgeId: "test-bridge-id",
     },
     sent,
     send(message: string) {
@@ -164,6 +165,33 @@ test("forwards response.create to app fetch and relays SSE events", async () => 
   expect(ws.sent).toEqual([
     '{"type":"response.completed","response":{"id":"resp-1"}}',
   ])
+})
+
+test("forwards the bridge id so the upstream pool can reap the right socket", async () => {
+  const ws = createMockWebSocket()
+  let capturedRequest: Request | undefined
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({
+      input: "hello",
+      model: "gpt-test",
+      type: "response.create",
+    }),
+    (request) => {
+      capturedRequest = request
+      return Promise.resolve(
+        new Response(
+          'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-1"}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      )
+    },
+  )
+
+  expect(capturedRequest?.headers.get("x-responses-bridge-id")).toBe(
+    "test-bridge-id",
+  )
 })
 
 test("preserves a single leading space in SSE data per spec", () => {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -14,6 +14,19 @@ type MockWebSocket = {
   send: (message: string) => number
 }
 
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function createDeferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 function createMockWebSocket(): MockWebSocket {
   const sent: Array<string> = []
   return {
@@ -250,6 +263,7 @@ test("serializes pipelined response.create frames instead of rejecting them", as
   const ws = createMockWebSocket()
   const fetchOrder: Array<string> = []
   let releaseTurnOne: (() => void) | undefined
+  const turnOneFetchStarted = createDeferred()
 
   const handler = createResponsesWebSocketHandler(() => {
     const order = fetchOrder.length
@@ -268,6 +282,7 @@ test("serializes pipelined response.create frames instead of rejecting them", as
           }
         },
       })
+      turnOneFetchStarted.resolve()
       return Promise.resolve(
         new Response(stream, {
           headers: { "content-type": "text/event-stream" },
@@ -302,7 +317,7 @@ test("serializes pipelined response.create frames instead of rejecting them", as
   )
 
   // Turn 2 must wait: only turn 1 has reached the upstream fetch so far.
-  await new Promise((resolve) => setTimeout(resolve, 10))
+  await turnOneFetchStarted.promise
   expect(fetchOrder).toEqual(["fetch-0"])
 
   releaseTurnOne?.()
@@ -344,13 +359,27 @@ test("aborts the upstream stream when the client disconnects", async () => {
     ),
   )
 
+  // Resolve once the bridge relays its first SSE event to the client, so we wait
+  // on the real signal instead of a fixed delay.
+  const firstEventSent = createDeferred()
+  const originalSend = ws.send.bind(ws)
+  let sendCount = 0
+  ws.send = (message: string) => {
+    const result = originalSend(message)
+    sendCount += 1
+    if (sendCount === 1) {
+      firstEventSent.resolve()
+    }
+    return result
+  }
+
   const messagePromise = handler.message(
     ws as never,
     JSON.stringify({ input: "hi", model: "gpt-test", type: "response.create" }),
   )
 
   // Let the first SSE event flow through before disconnecting.
-  await new Promise((resolve) => setTimeout(resolve, 10))
+  await firstEventSent.promise
   expect(ws.sent).toContain('{"type":"response.created"}')
   expect(ws.data.controllers.size).toBe(1)
 
@@ -360,4 +389,62 @@ test("aborts the upstream stream when the client disconnects", async () => {
 
   expect(cancelled).toBe(true)
   expect(ws.data.controllers.size).toBe(0)
+})
+
+test("a failed turn does not poison the queue for subsequent turns", async () => {
+  // If processing one frame rejects (e.g. `ws.send` throws while the socket is
+  // closing), the shared `ws.data.queue` promise must not stay rejected and
+  // silently drop every later frame for the lifetime of the connection.
+  const ws = createMockWebSocket()
+  let fetchCount = 0
+
+  // While turn 1 is processing, every send throws (simulating a socket that is
+  // tearing down): the relay send throws AND the fallback error send throws, so
+  // processing rejects and would poison `ws.data.queue` without the guard.
+  let failSends = true
+  ws.send = (message: string) => {
+    if (failSends) {
+      throw new Error("send failed during teardown")
+    }
+    ws.sent.push(message)
+    return message.length
+  }
+
+  const handler = createResponsesWebSocketHandler(() => {
+    fetchCount += 1
+    const id = fetchCount
+    return Promise.resolve(
+      new Response(
+        `event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-${id}"}}\n\n`,
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    )
+  })
+
+  // Turn 1: every send throws -> processing rejects internally.
+  await handler.message(
+    ws as never,
+    JSON.stringify({
+      input: "one",
+      model: "gpt-test",
+      type: "response.create",
+    }),
+  )
+
+  // The socket has recovered; turn 2 must still be processed and forwarded.
+  failSends = false
+  await handler.message(
+    ws as never,
+    JSON.stringify({
+      input: "two",
+      model: "gpt-test",
+      previous_response_id: "resp-1",
+      type: "response.create",
+    }),
+  )
+
+  expect(fetchCount).toBe(2)
+  expect(ws.sent).toContain(
+    '{"type":"response.completed","response":{"id":"resp-2"}}',
+  )
 })

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1,0 +1,263 @@
+import { expect, test } from "bun:test"
+
+import {
+  createResponsesWebSocketHandler,
+  handleResponsesWebSocketMessage,
+  isResponsesWebSocketUpgrade,
+  parseSseRecords,
+  type ResponsesWebSocketData,
+} from "~/routes/responses/websocket"
+
+type MockWebSocket = {
+  data: ResponsesWebSocketData
+  sent: Array<string>
+  send: (message: string) => number
+}
+
+function createMockWebSocket(): MockWebSocket {
+  const sent: Array<string> = []
+  return {
+    data: {
+      active: false,
+      controller: null,
+      headers: [],
+      url: "http://localhost:4141/v1/responses",
+    },
+    sent,
+    send(message: string) {
+      sent.push(message)
+      return message.length
+    },
+  }
+}
+
+test("detects Responses websocket upgrade requests", () => {
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/v1/responses", {
+        headers: {
+          upgrade: "websocket",
+        },
+      }),
+    ),
+  ).toBe(true)
+
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/responses", {
+        headers: {
+          upgrade: "WebSocket",
+        },
+      }),
+    ),
+  ).toBe(true)
+
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/v1/models", {
+        headers: {
+          upgrade: "websocket",
+        },
+      }),
+    ),
+  ).toBe(false)
+})
+
+test("does not treat normal Responses HTTP requests as websocket upgrades", () => {
+  expect(
+    isResponsesWebSocketUpgrade(
+      new Request("http://localhost:4141/v1/responses", {
+        method: "POST",
+      }),
+    ),
+  ).toBe(false)
+})
+
+test("parses SSE records into websocket payloads", () => {
+  const parsed = parseSseRecords(
+    'event: response.created\ndata: {"type":"response.created"}\n\n'
+      + 'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+  )
+
+  expect(parsed).toEqual({
+    events: ['{"type":"response.created"}', '{"type":"response.completed"}'],
+    remainder: "",
+  })
+})
+
+test("keeps incomplete SSE records as remainder", () => {
+  const parsed = parseSseRecords(
+    'event: response.created\ndata: {"type":"response.created"}\n\nevent:',
+  )
+
+  expect(parsed).toEqual({
+    events: ['{"type":"response.created"}'],
+    remainder: "event:",
+  })
+})
+
+test("ignores SSE done markers", () => {
+  expect(parseSseRecords("data: [DONE]\n\n")).toEqual({
+    events: [],
+    remainder: "",
+  })
+})
+
+test("responds to websocket warmup without calling app fetch", async () => {
+  const ws = createMockWebSocket()
+  let fetchCalled = false
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({
+      generate: false,
+      model: "gpt-test",
+      type: "response.create",
+    }),
+    () => {
+      fetchCalled = true
+      return Promise.resolve(new Response(null, { status: 500 }))
+    },
+  )
+
+  expect(fetchCalled).toBe(false)
+  expect(ws.sent.map((item) => JSON.parse(item) as unknown)).toEqual([
+    {
+      response: {
+        id: "",
+      },
+      sequence_number: 0,
+      type: "response.completed",
+    },
+  ])
+})
+
+test("forwards response.create to app fetch and relays SSE events", async () => {
+  const ws = createMockWebSocket()
+  let requestBody: unknown
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({
+      input: "hello",
+      model: "gpt-test",
+      type: "response.create",
+    }),
+    async (request) => {
+      requestBody = await request.json()
+      return new Response(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-1"}}\n\n',
+        {
+          headers: {
+            "content-type": "text/event-stream",
+          },
+        },
+      )
+    },
+  )
+
+  expect(requestBody).toEqual({
+    input: "hello",
+    model: "gpt-test",
+    stream: true,
+  })
+  expect(ws.sent).toEqual([
+    '{"type":"response.completed","response":{"id":"resp-1"}}',
+  ])
+})
+
+test("preserves a single leading space in SSE data per spec", () => {
+  expect(parseSseRecords('data:  {"value":"x"}\n\n')).toEqual({
+    events: [' {"value":"x"}'],
+    remainder: "",
+  })
+})
+
+test("emits a spec-shaped error frame for invalid JSON", async () => {
+  const ws = createMockWebSocket()
+
+  await handleResponsesWebSocketMessage(ws as never, "{not valid", () =>
+    Promise.resolve(new Response(null, { status: 500 })),
+  )
+
+  expect(ws.sent.map((item) => JSON.parse(item) as unknown)).toEqual([
+    {
+      code: "400",
+      message: "Invalid websocket JSON frame",
+      param: null,
+      sequence_number: 0,
+      type: "error",
+    },
+  ])
+})
+
+test("relays upstream errors as spec-shaped error frames", async () => {
+  const ws = createMockWebSocket()
+
+  await handleResponsesWebSocketMessage(
+    ws as never,
+    JSON.stringify({ input: "hi", model: "gpt-test", type: "response.create" }),
+    () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: { message: "boom" } }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+  )
+
+  expect(JSON.parse(ws.sent[0]) as unknown).toEqual({
+    code: "429",
+    message: "boom",
+    param: null,
+    sequence_number: 0,
+    type: "error",
+  })
+})
+
+test("aborts the upstream stream when the client disconnects", async () => {
+  const ws = createMockWebSocket()
+  let cancelled = false
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          'event: response.created\ndata: {"type":"response.created"}\n\n',
+        ),
+      )
+    },
+    // Never resolves on its own; only torn down via cancel().
+    pull() {
+      return new Promise<void>(() => {})
+    },
+    cancel() {
+      cancelled = true
+    },
+  })
+
+  const handler = createResponsesWebSocketHandler(() =>
+    Promise.resolve(
+      new Response(stream, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    ),
+  )
+
+  const messagePromise = handler.message(
+    ws as never,
+    JSON.stringify({ input: "hi", model: "gpt-test", type: "response.create" }),
+  )
+
+  // Let the first SSE event flow through before disconnecting.
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  expect(ws.sent).toContain('{"type":"response.created"}')
+  expect(ws.data.controller).not.toBeNull()
+
+  // Simulate the client closing the websocket.
+  void handler.close?.(ws as never, 1000, "client closed")
+  await messagePromise
+
+  expect(cancelled).toBe(true)
+  expect(ws.data.controller).toBeNull()
+})


### PR DESCRIPTION
## Summary

This PR adds **Codex CLI compatibility for the Responses WebSocket transport** and bundles the **multi-turn fix** that the previous attempt was missing.

Codex prefers opening a WebSocket with `GET /v1/responses` before falling back to HTTP `POST /v1/responses`. Previously `copilot-api` only exposed the HTTP route, so Codex saw repeated `404 Not Found` WebSocket upgrade failures before eventually falling back to HTTP. This change adds a Bun-native inbound WebSocket bridge for `/responses` and `/v1/responses` while keeping the existing Responses handler as the single source of truth for model routing, account selection, quota handling, request history, and upstream transport selection.

> ### Supersedes #83
> This replaces my earlier PR #83, which I closed after discovering a bug where **multi-turn conversations would stall** when reused over a single Codex WebSocket. #83 was also opened from my fork's default branch, which made it messy to iterate on. This PR is opened from a dedicated `feat/codex-responses-websocket` branch and contains **the original feature, all of the review feedback that was addressed in #83, and the new multi-turn fix**. The fork's `all` branch has been re-synced to match upstream `all`, so the diff here is exactly the WebSocket work.

## Why

Without the inbound bridge, Codex users see repeated reconnect attempts like:

```text
Unexpected status 404 Not Found: 404 Not Found, url: ws://localhost:4141/v1/responses
```

Codex eventually falls back to HTTP, but the UX is slow and noisy. Supporting the preferred WebSocket transport removes the reconnect delay and lets Codex use its normal Responses transport path.

## The multi-turn bug that closed #83 (now fixed)

The feature works for a single turn, but Codex reuses one long-lived WebSocket (`WS #1`: Codex ⇆ copilot-api) across an entire conversation, while each upstream GitHub Copilot Responses connection (`WS #2`: copilot-api ⇆ GitHub) is pooled and **reaped after 60s of inactivity between turns**. GitHub keys the conversation state (referenced by `previous_response_id`) to that specific `WS #2` connection.

So when more than ~60s elapses between turns:

1. The idle `WS #2` is reaped; GitHub discards the conversation state tied to it.
2. Codex's next incremental turn (over the still-open `WS #1`) references a `previous_response_id` that the freshly-opened `WS #2` has never seen.
3. The upstream rejects it, but in a form Codex cannot recover from quickly — Codex silently waits out its full 5-minute `stream_idle_timeout` before retrying with full history.

The net effect was a turn that appeared to **deadlock for ~5 minutes** after any conversational pause longer than a minute. (Reproduced and timed against the real Codex client: turn 2 stalled ~5m02s before silently recovering.)

### The fix

When the pool drops an idle upstream connection (`WS #2`) that still has a live originating bridge socket (`WS #1`) **with no turn in flight**, we proactively **close the bridge socket**. Codex then notices its cached session is closed at the start of its next turn and transparently rebuilds a fresh full-context request (no stale `previous_response_id`) — recovering immediately instead of stalling.

Mechanically:

- A small cross-layer registry (`responses-bridge-registry.ts`) maps an explicit `bridgeId` (minted per bridge connection) to a closer callback. An explicit id is used because the pool's `sessionId` is derived via `getUUID(...)` in the handler and can't be cheaply reproduced by the bridge layer.
- The bridge mints a `bridgeId`, registers a closer on `open` / unregisters on `close`, and forwards the id to the internal Responses request via an `x-responses-bridge-id` header.
- The pool threads `bridgeId` onto its entry and, when that entry is dropped (idle-reap timer, or upstream `close`/`error`), closes the bridge **only** when it is the live pooled entry with `requestCount === 0`. This deliberately excludes mid-turn drops (the active request's own error path already surfaces those to Codex) and throwaway non-pooled connections used for concurrent turns.

Verified end-to-end with the real Codex client: a ~65s gap between turns now returns the correct answer in ~2s with no "Reconnecting" message, instead of the prior ~5-minute stall.

## What changed

**Inbound WebSocket bridge (the feature)**
- Add a Bun WebSocket bridge for `GET /responses` and `GET /v1/responses`.
- Authenticate WebSocket upgrade requests with the same `auth.apiKeys` / `COPILOT_API_KEY` / legacy `apiKey` behavior as the HTTP routes (auth header logic was extracted into reusable `extractHeadersApiKey` / `isAuthorizedHeaders` / `createUnauthorizedRawResponse` helpers).
- Forward Codex `response.create` frames into the existing internal `POST /responses` / `POST /v1/responses` handler with `stream: true`, and relay SSE `data:` payloads back to Codex as WebSocket text frames.
- Handle Codex `generate: false` warmup frames locally so startup prewarm does not block the real prompt; treat `response.processed` as a no-op.
- Switch server startup to `Bun.serve` (wired on the `createServer({ enableMcpHttp })` factory) so the project can use Bun's native WebSocket support, preserving the previous `idleTimeout: 0` behavior so long-lived streams aren't cut.

**Lifecycle & error handling (addressed from #83 review)**
- **Abort on disconnect:** an `AbortController` stored on `ws.data` is passed to the internal Responses fetch; the `close` handler aborts it and the SSE reader is `cancel()`-ed, and a failed `ws.send` aborts the upstream request — so we stop burning tokens/quota after a client disconnects.
- **Spec-shaped error frames:** errors emit the same top-level shape as `ResponseErrorEvent` from `create-responses.ts` (`{ code, message, param, sequence_number, type: "error" }`) across JSON-parse, conflict, and upstream 4xx/5xx paths (HTTP status preserved in `code`).
- SSE `data:` parsing strips only a single optional leading space (spec-compliant); `parseSseRecords` separator guard simplified; new `src/*` imports use the `~/*` alias.

**Multi-turn fix (new in this PR)**
- New `src/services/copilot/responses-bridge-registry.ts` cross-layer side-channel.
- Bridge mints/forwards `bridgeId`; pool threads it onto the entry and closes the originating bridge socket when its idle upstream connection is reaped (gated to the live pooled entry with no in-flight turn).

**Docs**
- Document Codex CLI setup and the new inbound WebSocket endpoint in both READMEs, including a note that the inbound listener requires the Bun server runtime (`bunx --bun ...`; `npx` remains documented only for the lightweight MCP bridge), and clarify that `useResponsesApiWebSocket` controls only *outbound* upstream routing and does not disable the inbound listener.

## Notes

- The existing `/v1/responses` POST route remains the main implementation path for model routing, account selection, quota handling, request history, stream error handling, and upstream Copilot transport selection.
- `useResponsesApiWebSocket` continues to control outbound Copilot WebSocket routing for models that advertise `ws:/responses`; it does not disable the inbound Codex-compatible WebSocket listener.
- `response.processed` is currently ignored because it is an acknowledgement/optimization frame and is not required for correctness.
- The Chinese (`README.zh-CN.md`) entries were generated with model assistance — I don't read Chinese, so a native review of that wording would be welcome.

## Testing

```sh
bun test            # 620 pass, 1 fail (pre-existing, unrelated — see below)
bun run typecheck   # clean
bun run lint        # clean
```

WebSocket-feature coverage (37 tests across the relevant files):
- `tests/responses-websocket.test.ts` (13) — upgrade detection, SSE parsing/relay (remainder, `[DONE]`, single leading space), warmup, `response.create` forwarding, spec-shaped error frames, abort-on-disconnect, and bridge-id forwarding.
- `tests/create-responses-websocket-pool.test.ts` (13) — upstream pool lifecycle, plus new behavioral tests asserting the fix's gating: bridge **closed** on idle reap, **left open** mid-turn, and **not closed** for throwaway non-pooled connections.
- `tests/responses-bridge-registry.test.ts` (5) — the cross-layer registry (register/unregister/close, idempotency, error-swallowing).
- `tests/request-auth.test.ts` (6) — the extracted header-auth helpers shared by the HTTP and WebSocket paths.

Also manually verified against the real Codex CLI: no `404` WebSocket upgrade errors, single-turn responses work, and multi-turn conversations with a >60s pause now recover in ~2s instead of stalling ~5 minutes.

> The single failing test (`getConsumptionFromSnapshots computes daily consumption from remaining deltas`) is a pre-existing, date-dependent failure on `all` and is unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发版说明

* **新功能**
  * 新增 Responses API WebSocket 支持，与 Codex 兼容
  * 增加了 Codex CLI 集成，支持通过 Codex 调用本服务

* **文档**
  * 更新了配置说明，涵盖新 WebSocket 选项
  * 新增"与 Codex CLI 一起使用"指南，包括配置示例与故障排除建议

* **改进**
  * 加强了请求认证机制，支持更灵活的 API 密钥验证

<!-- end of auto-generated comment: release notes by coderabbit.ai -->