### PR TITLE
feat: wire responses handler entry-point (model mapping, provider alias, Codex subagent, image sanitization)

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -3,12 +3,18 @@ import type { Context } from "hono"
 import { streamSSE } from "hono/streaming"
 import { randomUUID } from "node:crypto"
 
+import type { SubagentMarker } from "~/lib/subagent"
+
 import {
   accountsManager,
   type AccountSelectionReason,
 } from "~/lib/accounts-manager"
 import { awaitApproval } from "~/lib/approval"
-import { getAliasTargetSet, isResponsesApiWebSearchEnabled } from "~/lib/config"
+import {
+  getAliasTargetSet,
+  isResponsesApiWebSearchEnabled,
+  resolveMappedModel,
+} from "~/lib/config"
 import {
   computeDiff,
   extractErrorObservability,
@@ -17,6 +23,7 @@ import {
   toAccountContext,
 } from "~/lib/handler-utils"
 import { createHandlerLogger, debugJson, debugJsonTail } from "~/lib/logger"
+import { parseProviderModelAlias } from "~/lib/provider-model"
 import { checkRateLimit } from "~/lib/rate-limit"
 import {
   extractResponsesUsageFromResult,
@@ -33,6 +40,7 @@ import {
   resolveAffinityKey,
   type AffinityKeySource,
 } from "~/lib/utils"
+import { handleProviderResponsesForProvider } from "~/routes/provider/responses/handler"
 import { flushPendingCapture } from "~/services/copilot/copilot-fetch"
 import {
   createResponses,
@@ -52,6 +60,7 @@ import {
   getStreamChunkFields,
   isAsyncIterable,
   removeWebSearchTool,
+  sanitizeOversizedInputImages,
 } from "./utils"
 
 const logger = createHandlerLogger("responses-handler")
@@ -60,14 +69,39 @@ const RESPONSES_ENDPOINT = "/responses"
 
 // eslint-disable-next-line max-lines-per-function
 export const handleResponses = async (c: Context) => {
+  const payload = await c.req.json<ResponsesPayload>()
+  debugJson(logger, "Responses request payload:", payload)
+
+  const requestedModel = payload.model
+  payload.model = resolveMappedModel(payload.model)
+  if (payload.model !== requestedModel) {
+    logger.debug(
+      `Resolved model mapping: ${requestedModel} -> ${payload.model}`,
+    )
+  }
+
+  const providerModelAlias = parseProviderModelAlias(payload.model)
+  if (providerModelAlias) {
+    payload.model = providerModelAlias.model
+    return await handleProviderResponsesForProvider(c, {
+      payload,
+      provider: providerModelAlias.provider,
+    })
+  }
+
+  const subagentMarker = getCodexResponsesSubagentMarker(c)
+  if (subagentMarker) {
+    debugJson(logger, "Detected Codex subagent headers:", subagentMarker)
+  }
+  const incomingSessionId =
+    subagentMarker ? getIncomingResponsesSessionId(c) : undefined
+
   await checkRateLimit(state)
 
   const store = getRequestHistoryStore()
   const request = buildRequestContext(c)
 
-  const payload = await c.req.json<ResponsesPayload>()
   const clientModel = payload.model
-  debugJson(logger, "Responses request payload:", payload)
 
   if (!isResponsesApiWebSearchEnabled()) {
     removeWebSearchTool(payload)
@@ -75,7 +109,8 @@ export const handleResponses = async (c: Context) => {
   compactInputByLatestCompaction(payload)
 
   const streamRequested = Boolean(payload.stream)
-  const { initiator: initialInitiator } = getResponsesRequestOptions(payload)
+  const { initiator: inferredInitiator } = getResponsesRequestOptions(payload)
+  const initialInitiator = subagentMarker ? "agent" : inferredInitiator
   const userId = (payload.metadata as { user_id?: string } | null | undefined)
     ?.user_id
   const requestBodyPromptCacheKey =
@@ -109,12 +144,12 @@ export const handleResponses = async (c: Context) => {
     })
   }
 
+  const headerSessionId = c.req.header("x-session-id") ?? null
   const upstreamRequestId = generateRequestIdFromPayload(
     { messages: payload.input },
-    normalizedPromptCacheKey,
+    incomingSessionId ?? normalizedPromptCacheKey,
   )
 
-  const headerSessionId = c.req.header("x-session-id") ?? null
   const affinityKey = resolveAffinityKey({
     promptCacheKey: requestBodyPromptCacheKey,
     metadataSessionId,
@@ -157,6 +192,17 @@ export const handleResponses = async (c: Context) => {
 
   const upstreamPayload = { ...payload, model: selectedModel.id }
   removeUnsupportedTools(upstreamPayload)
+
+  const sanitizedImageCount = sanitizeOversizedInputImages(
+    upstreamPayload,
+    selectedModel.capabilities.limits.vision?.max_prompt_image_size,
+  )
+  if (sanitizedImageCount > 0) {
+    logger.warn(
+      `Omitted ${sanitizedImageCount} oversized input image(s) before forwarding to Copilot Responses`,
+    )
+  }
+
   applyResponsesApiContextManagement(
     upstreamPayload,
     selectedModel.capabilities.limits.max_prompt_tokens,
@@ -167,13 +213,18 @@ export const handleResponses = async (c: Context) => {
   const premiumUnlimitedBefore = account.unlimited
 
   const transport = getResponsesTransportForModel(selectedModel) ?? "http"
-  const { vision, initiator } = getResponsesRequestOptions(upstreamPayload)
+  const { vision, initiator: inferredUpstreamInitiator } =
+    getResponsesRequestOptions(upstreamPayload)
+  const initiator = subagentMarker ? "agent" : inferredUpstreamInitiator
   request.initiator = initiator
   if (state.manualApprove) await awaitApproval()
 
   const accountCtx = toAccountContext(account)
   const upstreamSessionId = getUUID(
-    normalizedPromptCacheKey ?? headerSessionId ?? upstreamRequestId,
+    incomingSessionId
+      ?? normalizedPromptCacheKey
+      ?? headerSessionId
+      ?? upstreamRequestId,
   )
   request.upstreamRequestId = upstreamRequestId
   request.upstreamSessionId = upstreamSessionId
@@ -194,6 +245,7 @@ export const handleResponses = async (c: Context) => {
       accountCtx,
       vision,
       initiator,
+      subagentMarker,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       transport,
@@ -211,6 +263,7 @@ export const handleResponses = async (c: Context) => {
     accountCtx,
     vision,
     initiator,
+    subagentMarker,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     transport,
@@ -459,6 +512,7 @@ async function handleStreamingResponses(params: {
   accountCtx: Parameters<typeof createResponses>[2]
   vision: boolean
   initiator: "agent" | "user"
+  subagentMarker: SubagentMarker | null
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   transport: ResponsesTransport
@@ -474,6 +528,7 @@ async function handleStreamingResponses(params: {
     accountCtx,
     vision,
     initiator,
+    subagentMarker,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     transport,
@@ -488,6 +543,7 @@ async function handleStreamingResponses(params: {
       {
         vision,
         initiator,
+        subagentMarker,
         upstreamRequestId: request.upstreamRequestId,
         sessionId: request.upstreamSessionId,
         requestId: request.requestId,
@@ -811,6 +867,7 @@ async function handleNonStreamingResponses(params: {
   accountCtx: Parameters<typeof createResponses>[2]
   vision: boolean
   initiator: "agent" | "user"
+  subagentMarker: SubagentMarker | null
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   transport: ResponsesTransport
@@ -826,6 +883,7 @@ async function handleNonStreamingResponses(params: {
     accountCtx,
     vision,
     initiator,
+    subagentMarker,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     transport,
@@ -841,6 +899,7 @@ async function handleNonStreamingResponses(params: {
       {
         vision,
         initiator,
+        subagentMarker,
         upstreamRequestId: request.upstreamRequestId,
         sessionId: request.upstreamSessionId,
         requestId: request.requestId,
@@ -920,5 +979,42 @@ export const removeUnsupportedTools = (payload: ResponsesPayload): void => {
   })
   if (dropped.length > 0) {
     logger.debug("Removed unsupported tools:", dropped)
+  }
+}
+
+const getTrimmedHeader = (c: Context, name: string): string | undefined => {
+  const value = c.req.header(name)?.trim()
+  return value ? value : undefined
+}
+
+const getIncomingResponsesSessionId = (c: Context): string | undefined =>
+  getTrimmedHeader(c, "session-id") ?? getTrimmedHeader(c, "x-session-id")
+
+const codexSubagentHeaderValues = new Set([
+  "collab_spawn",
+  "compact",
+  "memory_consolidation",
+  "review",
+])
+
+const getCodexResponsesSubagentMarker = (c: Context): SubagentMarker | null => {
+  const agentType = getTrimmedHeader(c, "x-openai-subagent")
+  if (!agentType || !codexSubagentHeaderValues.has(agentType)) {
+    return null
+  }
+
+  const threadId = getTrimmedHeader(c, "thread-id")
+  const rootSessionId = getIncomingResponsesSessionId(c)
+  const parentThreadId = getTrimmedHeader(c, "x-codex-parent-thread-id")
+  if (!threadId && !rootSessionId && !parentThreadId) {
+    return null
+  }
+
+  const agentId = threadId ?? parentThreadId ?? rootSessionId ?? agentType
+
+  return {
+    agent_id: agentId,
+    agent_type: agentType,
+    session_id: threadId ?? rootSessionId ?? agentId,
   }
 }

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -1,0 +1,492 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+import "./shared-admin-db-test-home"
+
+import type { AccountRuntime } from "~/lib/types/account"
+import type { ResponsesPayload } from "~/services/copilot/create-responses"
+import type { Model } from "~/services/copilot/get-models"
+
+const [
+  { accountsManager },
+  { getAdminDb },
+  { state },
+  { setModelMappings, setProviderConfig },
+  { responsesRoutes },
+] = await Promise.all([
+  import("~/lib/accounts-manager"),
+  import("~/lib/admin-db"),
+  import("~/lib/state"),
+  import("~/lib/config"),
+  import("~/routes/responses/route"),
+])
+
+type SelectionResult = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+type SelectionOk = Extract<SelectionResult, { ok: true }>
+
+type FetchOptions = {
+  body?: unknown
+  headers?: Record<string, string>
+}
+
+const fetchHolder = globalThis as unknown as { fetch: typeof fetch }
+const originalFetch = fetchHolder.fetch
+const originalSelect =
+  accountsManager.selectAccountForRequest.bind(accountsManager)
+const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
+const originalMarkFailed =
+  accountsManager.markAccountFailed.bind(accountsManager)
+
+function buildAccount(): AccountRuntime {
+  return {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghu_test",
+    copilotToken: "copilot_test",
+    vsCodeVersion: "1.0.0",
+    premiumRemaining: 10,
+    unlimited: false,
+  }
+}
+
+function buildModel(id: string, maxPromptImageSize?: number): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+        ...(maxPromptImageSize !== undefined ?
+          { vision: { max_prompt_image_size: maxPromptImageSize } }
+        : {}),
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+        vision: maxPromptImageSize !== undefined ? true : undefined,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+
+function buildSelection(endpoint: string, modelId: string): SelectionOk {
+  return {
+    ok: true,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId),
+    endpoint,
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    affinityHit: false,
+    affinityCacheKey: "test-cache-key",
+    selectionReason: "affinity_miss",
+  }
+}
+
+function buildResponsesResult(model: string, text: string) {
+  return {
+    id: "resp_1",
+    object: "response",
+    created_at: Date.now(),
+    model,
+    output: [
+      {
+        id: "out_1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [
+          {
+            type: "output_text",
+            text,
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    output_text: text,
+    status: "completed",
+    usage: {
+      input_tokens: 1,
+      output_tokens: 1,
+      total_tokens: 2,
+    },
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    parallel_tool_calls: true,
+    temperature: 1,
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1,
+  }
+}
+
+beforeEach(() => {
+  state.manualApprove = false
+  state.verbose = false
+
+  getAdminDb().run("DELETE FROM request_log;")
+  getAdminDb().run("DELETE FROM session_affinity;")
+
+  accountsManager.finalizeQuota = () => Promise.resolve()
+  accountsManager.markAccountFailed = () => {}
+
+  setModelMappings({})
+})
+
+afterEach(() => {
+  fetchHolder.fetch = originalFetch
+  accountsManager.selectAccountForRequest = originalSelect
+  accountsManager.finalizeQuota = originalFinalize
+  accountsManager.markAccountFailed = originalMarkFailed
+
+  setModelMappings({})
+})
+
+describe("responses handler model mapping", () => {
+  test("applies modelMappings to client model before account selection", async () => {
+    setModelMappings({ "gpt-original": "gpt-mapped" })
+
+    let selectionCandidates:
+      | ReadonlyArray<{ modelId: string; endpoint: string }>
+      | undefined
+    accountsManager.selectAccountForRequest = (candidates) => {
+      selectionCandidates = candidates
+      return Promise.resolve(buildSelection("/responses", "gpt-mapped"))
+    }
+
+    const fetchMock = mock((_url: string, _opts?: FetchOptions) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-mapped", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-original",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(selectionCandidates?.[0]?.modelId).toBe("gpt-mapped")
+  })
+
+  test("leaves model unchanged when no mapping is configured", async () => {
+    let selectionCandidates:
+      | ReadonlyArray<{ modelId: string; endpoint: string }>
+      | undefined
+    accountsManager.selectAccountForRequest = (candidates) => {
+      selectionCandidates = candidates
+      return Promise.resolve(buildSelection("/responses", "gpt-original"))
+    }
+
+    const fetchMock = mock((_url: string, _opts?: FetchOptions) => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("gpt-original", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-original",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(selectionCandidates?.[0]?.modelId).toBe("gpt-original")
+  })
+})
+
+describe("responses handler provider alias routing", () => {
+  test("routes provider-prefixed models to provider responses handler", async () => {
+    setProviderConfig("acme", {
+      type: "openai-responses",
+      enabled: true,
+      baseUrl: "https://acme.example.com",
+      apiKey: "acme-key",
+      authType: "authorization",
+    })
+
+    const selectSpy = mock(() =>
+      Promise.resolve(buildSelection("/responses", "any")),
+    )
+    accountsManager.selectAccountForRequest = selectSpy
+
+    let providerForwardedUrl: string | undefined
+    const fetchMock = mock((url: string, _opts?: FetchOptions) => {
+      providerForwardedUrl = url
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("gpt-acme", "from acme")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "acme/gpt-acme",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(selectSpy).not.toHaveBeenCalled()
+    expect(providerForwardedUrl).toContain("acme.example.com")
+
+    setProviderConfig("acme", { enabled: false })
+  })
+})
+
+describe("responses handler Codex subagent detection", () => {
+  test("forces agent initiator and reuses incoming session when Codex headers present", async () => {
+    let selectionRequestId: string | undefined
+    let upstreamInteractionId: string | undefined
+    let upstreamInitiator: string | undefined
+    let upstreamInteractionType: string | undefined
+
+    accountsManager.selectAccountForRequest = (_candidates, options) => {
+      selectionRequestId = options?.requestId
+      return Promise.resolve(buildSelection("/responses", "responses-model"))
+    }
+
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      upstreamInteractionId = options?.headers?.["x-interaction-id"]
+      upstreamInitiator = options?.headers?.["x-initiator"]
+      upstreamInteractionType = options?.headers?.["x-interaction-type"]
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("responses-model", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "session-id": "root-session",
+          "thread-id": "child-thread",
+          "x-codex-parent-thread-id": "parent-thread",
+          "x-openai-subagent": "collab_spawn",
+        },
+        body: JSON.stringify({
+          model: "responses-model",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    // sessionId derived from incoming session header (root-session) for upstream interaction-id
+    expect(upstreamInitiator).toBe("agent")
+    expect(upstreamInteractionType).toBe("conversation-subagent")
+    expect(upstreamInteractionId).toBeDefined()
+    // requestId fed into account selection should be derived from the incoming session
+    expect(selectionRequestId).toBeDefined()
+  })
+
+  test("ignores unknown x-openai-subagent values", async () => {
+    let upstreamInteractionType: string | undefined
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "responses-model"))
+
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      upstreamInteractionType = options?.headers?.["x-interaction-type"]
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("responses-model", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "session-id": "root-session",
+          "thread-id": "child-thread",
+          "x-openai-subagent": "unknown_type",
+        },
+        body: JSON.stringify({
+          model: "responses-model",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upstreamInteractionType).not.toBe("conversation-subagent")
+  })
+
+  test("ignores Codex subagent header without thread/session ids", async () => {
+    let upstreamInteractionType: string | undefined
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "responses-model"))
+
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      upstreamInteractionType = options?.headers?.["x-interaction-type"]
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("responses-model", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openai-subagent": "collab_spawn",
+        },
+        body: JSON.stringify({
+          model: "responses-model",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upstreamInteractionType).not.toBe("conversation-subagent")
+  })
+})
+
+describe("responses handler oversized image sanitization", () => {
+  test("replaces oversized images with placeholder before forwarding", async () => {
+    const visionModel: Model = buildModel("vision-model", 1024)
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve({
+        ...buildSelection("/responses", "vision-model"),
+        selectedModel: visionModel,
+      })
+
+    let forwardedPayload: ResponsesPayload | undefined
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      forwardedPayload = JSON.parse(options?.body as string) as ResponsesPayload
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("vision-model", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const oversizedImageUrl = `data:image/png;base64,${"A".repeat(8192)}`
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "vision-model",
+          input: [
+            {
+              role: "user",
+              content: [
+                { type: "input_text", text: "look" },
+                {
+                  type: "input_image",
+                  detail: "low",
+                  image_url: oversizedImageUrl,
+                },
+              ],
+            },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(forwardedPayload).toBeDefined()
+    const forwardedInput = forwardedPayload?.input as Array<{
+      content: Array<{ type: string; image_url?: string }>
+    }>
+    const forwardedImage = forwardedInput[0]?.content?.[1]
+    expect(forwardedImage?.type).toBe("input_image")
+    expect(forwardedImage?.image_url).not.toBe(oversizedImageUrl)
+    expect(
+      forwardedImage?.image_url?.startsWith("data:image/png;base64,"),
+    ).toBe(true)
+  })
+})

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -155,6 +155,7 @@ afterEach(() => {
   accountsManager.markAccountFailed = originalMarkFailed
 
   setModelMappings({})
+  setProviderConfig("acme", { enabled: false })
 })
 
 describe("responses handler model mapping", () => {


### PR DESCRIPTION
## 背景

关闭 #87。

在 `caozhiyuan` → `all` 的合并过程中，上游 `responses/handler.ts` 的四项功能性增强已在 utility 层（`responses/utils.ts`、`config.ts`）完成，但 handler 入口的 wiring 调用因架构差异较大被整体跳过。本 PR 补全这些调用。

## 变更内容

### 1. Model mapping 前置（`resolveMappedModel`）

在 `handleResponses` 入口、`checkRateLimit` 之前调用 `resolveMappedModel(payload.model)`，使 `config.modelMappings` 在 `/v1/responses` 路径下同样生效。

### 2. Provider alias 路由分流（`parseProviderModelAlias`）

model 携带 `provider/model` 前缀时直接调用 `handleProviderResponsesForProvider`，跳过 Copilot 账号选择流程。支持 `codex/`、`openai-responses` 等 provider。

### 3. Codex subagent 检测 + session 复用

新增三个工具函数：
- `getCodexResponsesSubagentMarker(c)` — 从 `x-openai-subagent` 请求头解析 `SubagentMarker`
- `getIncomingResponsesSessionId(c)` — 从 `x-openai-session-id` / `x-openai-thread-id` / `x-codex-parent-thread-id` 提取 session id
- `getTrimmedHeader(c, name)` — 工具函数

命中时：强制 `initiator: "agent"`，透传 `subagentMarker` 到 `createResponses()`，让 `prepareInteractionHeaders` 写入 `x-interaction-type: conversation-subagent`；incoming session id 优先于 prompt_cache_key / header session id，保证多轮对话 session 复用。

### 4. 超大图片 sanitization（`sanitizeOversizedInputImages`）

在 `removeUnsupportedTools(upstreamPayload)` 之后、`applyResponsesApiContextManagement` 之前，调用 `sanitizeOversizedInputImages(upstreamPayload, selectedModel.capabilities.limits.vision?.max_prompt_image_size)`，把超出 `max_prompt_image_size` 限制的图片替换为占位符 PNG，提前阻止 Copilot 返回 413。

## 测试

新增 `tests/responses-handler.test.ts`（7 个测试）：

- model mapping 命中 / 未命中
- provider alias 路由（验证请求转发到 provider baseUrl，账号选择不被调用）
- Codex subagent 命中（验证 `x-initiator: agent` + `x-interaction-type: conversation-subagent`）
- 未知 `x-openai-subagent` 值被忽略
- 缺少 session/thread id 时 marker 被忽略
- 超大图片被替换为占位符

**全量验收：**
- `bun run typecheck`：通过
- `bun run lint`：通过
- `bun test`：661 通过 / 0 失败（原 654，新增 7）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新增功能**
  * 支持模型映射配置，自动转换请求中的模型标识。
  * 新增供应商别名路由，支持将特定前缀的请求转发至对应供应商。
  * 增强子代理请求识别与处理能力。
  * 实现超大图片自动清理，优化 Vision 模型的输入处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->