### PR TITLE
feat(models): add periodic refresh, manual trigger, and admin-ui diagnostics for multi-account models cache

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -97,6 +97,8 @@ export type AdminAccountItem = {
     failed?: boolean
     failureReason?: string
     enabled?: boolean
+    lastModelsFetch?: number
+    isRefreshingModels?: boolean
   }
   stats?: {
     since_ms: number
@@ -434,6 +436,12 @@ export async function getAdminModels(): Promise<AdminModelsResponse> {
 
 export async function getAdminModelDetails(): Promise<AdminModelsDetailsResponse> {
   return fetchAdminJson<AdminModelsDetailsResponse>("/api/admin/models/details")
+}
+
+export async function refreshAllModels(): Promise<{ ok: boolean }> {
+  return fetchAdminJson<{ ok: boolean }>("/api/admin/accounts/models/refresh", {
+    method: "POST",
+  })
 }
 
 export async function getAdminPremiumStats(params: {

--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -438,10 +438,16 @@ export async function getAdminModelDetails(): Promise<AdminModelsDetailsResponse
   return fetchAdminJson<AdminModelsDetailsResponse>("/api/admin/models/details")
 }
 
-export async function refreshAllModels(): Promise<{ ok: boolean }> {
-  return fetchAdminJson<{ ok: boolean }>("/api/admin/accounts/models/refresh", {
-    method: "POST",
-  })
+export async function refreshAllModels(): Promise<{
+  ok: boolean
+  failedCount: number
+}> {
+  return fetchAdminJson<{ ok: boolean; failedCount: number }>(
+    "/api/admin/accounts/models/refresh",
+    {
+      method: "POST",
+    },
+  )
 }
 
 export async function getAdminPremiumStats(params: {

--- a/admin-ui/src/lib/format.ts
+++ b/admin-ui/src/lib/format.ts
@@ -241,3 +241,28 @@ export function fmtMaybeNum(n?: number | null): string {
   if (n == null) return ""
   return String(n)
 }
+
+export function fmtRelativeTime(ms: number, locale = "en-US"): string {
+  const diffSec = Math.round((ms - Date.now()) / 1000)
+  const absSec = Math.abs(diffSec)
+
+  let value: number
+  let unit: Intl.RelativeTimeFormatUnit
+
+  if (absSec < 60) {
+    value = diffSec
+    unit = "second"
+  } else if (absSec < 3600) {
+    value = Math.round(diffSec / 60)
+    unit = "minute"
+  } else if (absSec < 86400) {
+    value = Math.round(diffSec / 3600)
+    unit = "hour"
+  } else {
+    value = Math.round(diffSec / 86400)
+    unit = "day"
+  }
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
+  return rtf.format(value, unit)
+}

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -229,7 +229,9 @@
     "toast": {
       "loadFailed": "Failed to load models",
       "refreshModelsSuccess": "Models refreshed",
-      "refreshModelsFailed": "Failed to refresh models"
+      "refreshModelsPartial": "Models refreshed ({{count}} accounts failed)",
+      "refreshModelsFailed": "Failed to refresh models",
+      "reloadFailed": "Failed to reload models list"
     },
     "columns": {
       "name": "Model",

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -157,7 +157,10 @@
       "premiumUsageAria": "Premium request usage progress",
       "premiumUnlimitedNote": "+{{count}} unlimited account(s) not included"
     },
-    "enabledToggleFailed": "Failed to update account enabled state"
+    "enabledToggleFailed": "Failed to update account enabled state",
+    "modelsLastFetched": "Models fetched",
+    "modelsNeverFetched": "Never fetched",
+    "modelsRefreshing": "Refreshing…"
   },
   "requestsPage": {
     "loadFailedTitle": "Failed to load requests",
@@ -221,8 +224,12 @@
     "searchAriaLabel": "Search models by name or ID",
     "aliasesMore": "+{{count}} more",
     "loadFailedTitle": "Failed to load models",
+    "refreshModelsButton": "Refresh models",
+    "refreshingModelsButton": "Refreshing models…",
     "toast": {
-      "loadFailed": "Failed to load models"
+      "loadFailed": "Failed to load models",
+      "refreshModelsSuccess": "Models refreshed",
+      "refreshModelsFailed": "Failed to refresh models"
     },
     "columns": {
       "name": "Model",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -157,7 +157,10 @@
       "premiumUsageAria": "Premium 请求使用进度",
       "premiumUnlimitedNote": "另有 {{count}} 个无限额度账号未计入"
     },
-    "enabledToggleFailed": "更新账号启用状态失败"
+    "enabledToggleFailed": "更新账号启用状态失败",
+    "modelsLastFetched": "模型获取",
+    "modelsNeverFetched": "从未获取",
+    "modelsRefreshing": "刷新中…"
   },
   "requestsPage": {
     "loadFailedTitle": "加载请求失败",
@@ -221,8 +224,12 @@
     "searchAriaLabel": "按名称或 ID 搜索模型",
     "aliasesMore": "+{{count}} 个",
     "loadFailedTitle": "加载模型失败",
+    "refreshModelsButton": "刷新模型",
+    "refreshingModelsButton": "刷新模型中…",
     "toast": {
-      "loadFailed": "加载模型失败"
+      "loadFailed": "加载模型失败",
+      "refreshModelsSuccess": "模型已刷新",
+      "refreshModelsFailed": "刷新模型失败"
     },
     "columns": {
       "name": "模型",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -229,7 +229,9 @@
     "toast": {
       "loadFailed": "加载模型失败",
       "refreshModelsSuccess": "模型已刷新",
-      "refreshModelsFailed": "刷新模型失败"
+      "refreshModelsPartial": "模型已刷新（{{count}} 个账号失败）",
+      "refreshModelsFailed": "刷新模型失败",
+      "reloadFailed": "重新加载模型列表失败"
     },
     "columns": {
       "name": "模型",

--- a/admin-ui/src/pages/accounts-page.tsx
+++ b/admin-ui/src/pages/accounts-page.tsx
@@ -1,4 +1,4 @@
-import { DownloadIcon, PlusIcon, RefreshCwIcon, UserPlusIcon } from "lucide-react"
+import { DownloadIcon, LoaderCircleIcon, PlusIcon, RefreshCwIcon, UserPlusIcon } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
@@ -16,7 +16,7 @@ import {
   buildAccountsCsv,
   getAccountsCsvFilename,
 } from "@/lib/accounts-export"
-import { fmtDurationSeconds, fmtLocalDateTime, fmtNum } from "@/lib/format"
+import { fmtDurationSeconds, fmtLocalDateTime, fmtNum, fmtRelativeTime } from "@/lib/format"
 import { i18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
@@ -753,6 +753,21 @@ export function AccountsPage(): React.JSX.Element {
                               {a.runtime.failureReason}
                             </div>
                           ) : null}
+                          <div className="text-muted-foreground text-xs">
+                            {a.runtime?.isRefreshingModels ? (
+                              <span className="flex items-center gap-1">
+                                <LoaderCircleIcon className="size-3 motion-safe:animate-spin" />
+                                {t("accountsPage.modelsRefreshing")}
+                              </span>
+                            ) : (
+                              <span>
+                                {t("accountsPage.modelsLastFetched")}:{" "}
+                                {a.runtime?.lastModelsFetch
+                                  ? fmtRelativeTime(a.runtime.lastModelsFetch, i18n.language)
+                                  : t("accountsPage.modelsNeverFetched")}
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </TableCell>
                       <TableCell className={cn(accountsTableColVisibility[2])}>

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -543,18 +543,30 @@ export function ModelsPage(): React.JSX.Element {
   const handleRefreshModels = useCallback(async () => {
     setRefreshing(true)
     try {
-      await refreshAllModels()
-      await load()
-      toast.success(i18n.t("modelsPage.toast.refreshModelsSuccess"))
+      const { failedCount } = await refreshAllModels()
+      toast.success(
+        failedCount > 0
+          ? t("modelsPage.toast.refreshModelsPartial", { count: failedCount })
+          : t("modelsPage.toast.refreshModelsSuccess"),
+      )
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
-      toast.error(i18n.t("modelsPage.toast.refreshModelsFailed"), {
+      toast.error(t("modelsPage.toast.refreshModelsFailed"), {
         description: msg,
       })
+      setRefreshing(false)
+      return
+    }
+
+    try {
+      await load()
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      toast.error(t("modelsPage.toast.reloadFailed"), { description: msg })
     } finally {
       setRefreshing(false)
     }
-  }, [load])
+  }, [load, t])
 
   return (
     <div className="space-y-4">

--- a/admin-ui/src/pages/models-page.tsx
+++ b/admin-ui/src/pages/models-page.tsx
@@ -8,6 +8,7 @@ import {
   AdminApiError,
   type AdminModelDetailsItem,
   getAdminModelDetails,
+  refreshAllModels,
 } from "@/lib/admin-api"
 import { i18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
@@ -398,6 +399,7 @@ export function ModelsPage(): React.JSX.Element {
   const { t } = useTranslation()
 
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [models, setModels] = useState<AdminModelDetailsItem[]>([])
 
@@ -538,6 +540,22 @@ export function ModelsPage(): React.JSX.Element {
     void load()
   }, [load])
 
+  const handleRefreshModels = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      await refreshAllModels()
+      await load()
+      toast.success(i18n.t("modelsPage.toast.refreshModelsSuccess"))
+    } catch (err) {
+      const msg = err instanceof AdminApiError ? err.message : String(err)
+      toast.error(i18n.t("modelsPage.toast.refreshModelsFailed"), {
+        description: msg,
+      })
+    } finally {
+      setRefreshing(false)
+    }
+  }, [load])
+
   return (
     <div className="space-y-4">
       {error ? (
@@ -557,19 +575,36 @@ export function ModelsPage(): React.JSX.Element {
               <CardTitle>{t("modelsPage.title")}</CardTitle>
               <CardDescription>{t("modelsPage.description")}</CardDescription>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void load()}
-              disabled={loading}
-            >
-              {loading ? (
-                <LoaderCircleIcon className="size-4 motion-safe:animate-spin" />
-              ) : (
-                <RefreshCwIcon className="size-4" />
-              )}
-              {t("common.refresh")}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleRefreshModels()}
+                disabled={loading || refreshing}
+              >
+                {refreshing ? (
+                  <LoaderCircleIcon className="size-4 motion-safe:animate-spin" />
+                ) : (
+                  <RefreshCwIcon className="size-4" />
+                )}
+                {refreshing
+                  ? t("modelsPage.refreshingModelsButton")
+                  : t("modelsPage.refreshModelsButton")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void load()}
+                disabled={loading || refreshing}
+              >
+                {loading ? (
+                  <LoaderCircleIcon className="size-4 motion-safe:animate-spin" />
+                ) : (
+                  <RefreshCwIcon className="size-4" />
+                )}
+                {t("common.refresh")}
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-3">

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -155,6 +155,8 @@ export type AccountStatusEntry = {
   failed?: boolean
   failureReason?: string
   enabled?: boolean
+  lastModelsFetch?: number
+  isRefreshingModels?: boolean
 }
 
 function getInitialSelectionReason(
@@ -311,6 +313,10 @@ export class AccountsManager {
     this.modelsRefreshIntervalMs =
       Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : 0
     this.scheduleModelsRefresh()
+  }
+
+  async refreshAllModelsNow(): Promise<void> {
+    await this.refreshAllModels()
   }
 
   getQuotaRefreshAccounts(): Array<AccountRuntime> {
@@ -1676,6 +1682,8 @@ export class AccountsManager {
         overagePermitted: this.temporaryAccount.overagePermitted,
         failed: this.temporaryAccount.failed,
         failureReason: this.temporaryAccount.failureReason,
+        lastModelsFetch: this.temporaryAccount.lastModelsFetch,
+        isRefreshingModels: this.temporaryAccount.isRefreshingModels,
       })
     }
 
@@ -1691,6 +1699,8 @@ export class AccountsManager {
           failed: account.failed,
           failureReason: account.failureReason,
           enabled: account.enabled,
+          lastModelsFetch: account.lastModelsFetch,
+          isRefreshingModels: account.isRefreshingModels,
         })
       }
     }

--- a/src/lib/accounts-manager.ts
+++ b/src/lib/accounts-manager.ts
@@ -315,8 +315,9 @@ export class AccountsManager {
     this.scheduleModelsRefresh()
   }
 
-  async refreshAllModelsNow(): Promise<void> {
-    await this.refreshAllModels()
+  async refreshAllModelsNow(): Promise<{ failedCount: number }> {
+    const failedCount = await this.refreshAllModels()
+    return { failedCount }
   }
 
   getQuotaRefreshAccounts(): Array<AccountRuntime> {
@@ -717,7 +718,7 @@ export class AccountsManager {
     await promise
   }
 
-  private async refreshAllModels(): Promise<void> {
+  private async refreshAllModels(): Promise<number> {
     const accounts: Array<AccountRuntime> = []
 
     if (this.temporaryAccount) {
@@ -732,12 +733,13 @@ export class AccountsManager {
     }
 
     if (accounts.length === 0) {
-      return
+      return 0
     }
 
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       accounts.map((account) => this.refreshModels(account)),
     )
+    return results.filter((r) => r.status === "rejected").length
   }
 
   /** Refresh quota information for an account. */

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -143,6 +143,9 @@ type AccountItem = {
     unlimited?: boolean
     failed?: boolean
     failureReason?: string
+    enabled?: boolean
+    lastModelsFetch?: number
+    isRefreshingModels?: boolean
   }
   stats?: {
     since_ms: number
@@ -1498,12 +1501,19 @@ adminApiRoutes.get("/accounts", async (c) => {
         failed: s.failed,
         failureReason: s.failureReason,
         enabled: s.enabled,
+        lastModelsFetch: s.lastModelsFetch,
+        isRefreshingModels: s.isRefreshingModels,
       },
       stats,
     }
   })
 
   return c.json({ items })
+})
+
+adminApiRoutes.post("/accounts/models/refresh", async (c) => {
+  await accountsManager.refreshAllModelsNow()
+  return c.json({ ok: true })
 })
 
 adminApiRoutes.get("/requests", (c) => {

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -1512,8 +1512,8 @@ adminApiRoutes.get("/accounts", async (c) => {
 })
 
 adminApiRoutes.post("/accounts/models/refresh", async (c) => {
-  await accountsManager.refreshAllModelsNow()
-  return c.json({ ok: true })
+  const { failedCount } = await accountsManager.refreshAllModelsNow()
+  return c.json({ ok: true, failedCount })
 })
 
 adminApiRoutes.get("/requests", (c) => {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1010,7 +1010,8 @@ const getCodexResponsesSubagentMarker = (c: Context): SubagentMarker | null => {
     return null
   }
 
-  const agentId = threadId ?? parentThreadId ?? rootSessionId ?? agentType
+  // At least one of these is non-null (checked above), so the cast is safe.
+  const agentId = (threadId ?? parentThreadId ?? rootSessionId) as string
 
   return {
     agent_id: agentId,

--- a/tests/accounts-manager-models-refresh.test.ts
+++ b/tests/accounts-manager-models-refresh.test.ts
@@ -1,0 +1,121 @@
+import { expect, mock, test } from "bun:test"
+
+import type { AccountRuntime } from "../src/lib/types/account"
+
+import { AccountsManager } from "../src/lib/accounts-manager"
+
+type ManagerInternals = {
+  accounts: Map<string, AccountRuntime>
+  accountOrder: Array<string>
+}
+
+const makeAccount = (
+  overrides: Partial<AccountRuntime> = {},
+): AccountRuntime => ({
+  id: "octocat",
+  accountType: "individual",
+  addedAt: Date.now(),
+  githubToken: "ghp_test",
+  copilotToken: "tok",
+  vsCodeVersion: "1.0.0",
+  ...overrides,
+})
+
+const setupManager = (account: AccountRuntime): AccountsManager => {
+  const manager = new AccountsManager()
+  const internals = manager as unknown as ManagerInternals
+  internals.accounts.set(account.id, account)
+  internals.accountOrder.push(account.id)
+  return manager
+}
+
+test("timer tick calls refreshAllModels and sets lastModelsFetch", async () => {
+  await mock.module("../src/services/copilot/get-models", () => ({
+    getModels: mock(() => Promise.resolve({ object: "list", data: [] })),
+  }))
+
+  const account = makeAccount()
+  const manager = setupManager(account)
+
+  manager.setModelsRefreshIntervalMs(50)
+  await new Promise<void>((resolve) => setTimeout(resolve, 150))
+  manager.setModelsRefreshIntervalMs(0)
+
+  expect(account.lastModelsFetch).toBeGreaterThan(0)
+})
+
+test("refresh failure preserves existing models cache", async () => {
+  await mock.module("../src/services/copilot/get-models", () => ({
+    getModels: mock(() => Promise.reject(new Error("network error"))),
+  }))
+
+  const fakeModel = {
+    id: "test-model",
+    object: "model",
+    billing: { is_premium: false, multiplier: 1 },
+    capabilities: {
+      family: "test",
+      limits: {},
+      object: "model_capabilities",
+      supports: {},
+      tokenizer: "test",
+      type: "test",
+    },
+    model_picker_enabled: false,
+    name: "Test",
+    preview: false,
+    supported_endpoints: [] as Array<string>,
+    vendor: "test",
+    version: "0",
+  }
+  const account = makeAccount({
+    models: { object: "list", data: [fakeModel] },
+    lastModelsFetch: 100,
+  })
+  const manager = setupManager(account)
+
+  await (
+    manager as unknown as {
+      refreshModels: (a: AccountRuntime) => Promise<void>
+    }
+  ).refreshModels(account)
+
+  expect(account.models?.data).toEqual([fakeModel])
+  expect(account.lastModelsFetch).toBe(100)
+})
+
+test("setModelsRefreshIntervalMs(0) stops scheduling", async () => {
+  const getModelsMock = mock(() =>
+    Promise.resolve({ object: "list", data: [] }),
+  )
+  await mock.module("../src/services/copilot/get-models", () => ({
+    getModels: getModelsMock,
+  }))
+
+  const account = makeAccount()
+  const manager = setupManager(account)
+
+  manager.setModelsRefreshIntervalMs(50)
+  await new Promise<void>((resolve) => setTimeout(resolve, 30))
+  manager.setModelsRefreshIntervalMs(0)
+  await new Promise<void>((resolve) => setTimeout(resolve, 150))
+
+  expect(getModelsMock).toHaveBeenCalledTimes(0)
+})
+
+test("interval <= 0 never schedules", async () => {
+  const getModelsMock = mock(() =>
+    Promise.resolve({ object: "list", data: [] }),
+  )
+  await mock.module("../src/services/copilot/get-models", () => ({
+    getModels: getModelsMock,
+  }))
+
+  const account = makeAccount()
+  const manager = setupManager(account)
+
+  manager.setModelsRefreshIntervalMs(0)
+  await new Promise<void>((resolve) => setTimeout(resolve, 100))
+
+  expect(getModelsMock).toHaveBeenCalledTimes(0)
+})


### PR DESCRIPTION
## 关联 Issue

Closes #90

## 变更内容

### 后端

- **`src/lib/accounts-manager.ts`**: 新增 `refreshAllModelsNow()` 公开方法；`AccountStatusEntry` 与 `getAccountStatus()` 暴露 `lastModelsFetch` / `isRefreshingModels` 诊断字段
- **`src/routes/admin-api/route.ts`**: 新增 `POST /api/admin/accounts/models/refresh` 手动触发刷新端点；`GET /accounts` 返回新增两个诊断字段

### 前端 admin-ui

- **`src/lib/admin-api.ts`**: `AdminAccountItem.runtime` 加诊断字段；新增 `refreshAllModels()` 客户端调用
- **`src/lib/format.ts`**: 新增 `fmtRelativeTime()`（原生 `Intl.RelativeTimeFormat`，零新依赖）
- **`src/pages/models-page.tsx`**: Header 增加 "Refresh models" 按钮，含旋转 spinner + sonner toast 反馈
- **`src/pages/accounts-page.tsx`**: Status 列追加模型最近刷新时间（"Models fetched: X ago" / "Never fetched" / "Refreshing…"）
- **`src/locales/en-US.json`**, **`src/locales/zh-CN.json`**: 双语文案同步

### 测试

- **`tests/accounts-manager-models-refresh.test.ts`**: 新增 4 个测试覆盖定时刷新、失败保留旧缓存、stop 清理、interval≤0 不排程

### 附带修复

- `src/routes/responses/handler.ts`: 补齐 CodeRabbit 建议的 `as string` 类型断言（此改动在 PR #91 合并时未包含在 `origin/all` 上）

## 测试结果

```
bun test tests/accounts-manager-models-refresh.test.ts  # 4 pass, 0 fail
bun run typecheck  # pass
bun run lint       # pass
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 新增模型刷新功能，管理员可一键刷新所有账户的模型列表
  * 在账户列表中显示模型最后获取时间和实时刷新状态

* **Bug Fixes**
  * 修复代理ID计算逻辑

* **Tests**
  * 添加模型刷新调度行为的测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->