### PR TITLE
fix(responses-websocket): wrap in-stream error events as HTTPError for rate-limit observability

### DIFF
--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1188,7 +1188,18 @@ const consumeResponsesWebSocketStream = async (
 
     const event = JSON.parse(chunk.data) as ResponseStreamEvent
     if (event.type === "error") {
-      throw new Error(event.message)
+      // The transport is WebSocket, but `event.code` carries the HTTP status
+      // from the Responses API (e.g. 429 for rate-limit). Wrap it as an
+      // HTTPError so the existing observability chain (account-failure marking,
+      // rate-limit logging) handles it identically to the HTTP path.
+      const status = event.code !== null ? parseInt(event.code, 10) : NaN
+      const httpStatus = Number.isFinite(status) && status >= 100 ? status : 500
+      throw new HTTPError(
+        event.message,
+        new Response(JSON.stringify({ error: { message: event.message } }), {
+          status: httpStatus,
+        }),
+      )
     }
 
     if (

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1192,8 +1192,10 @@ const consumeResponsesWebSocketStream = async (
       // from the Responses API (e.g. 429 for rate-limit). Wrap it as an
       // HTTPError so the existing observability chain (account-failure marking,
       // rate-limit logging) handles it identically to the HTTP path.
-      const status = event.code !== null ? parseInt(event.code, 10) : NaN
-      const httpStatus = Number.isFinite(status) && status >= 100 ? status : 500
+      const status =
+        typeof event.code === "string" ? parseInt(event.code, 10) : NaN
+      const httpStatus =
+        Number.isFinite(status) && status >= 100 && status < 600 ? status : 500
       throw new HTTPError(
         event.message,
         new Response(JSON.stringify({ error: { message: event.message } }), {


### PR DESCRIPTION
## Summary

Fixes the rate-limit error recognition gap identified in #89.

When Copilot returns a rate-limit (or other HTTP-status) failure as an in-stream WebSocket frame `{"type": "error", "code": "429", ...}`, `consumeResponsesWebSocketStream` previously threw a plain `Error`. Because `extractErrorDetails` only derives `errorStatus` from `HTTPError` instances, the existing observability chain was blind to it:

- `shouldMarkAccountFailed` never triggered for WebSocket-path 401s
- `logCopilotRateLimits` was never called on the WebSocket path

The fix wraps the in-stream error as an `HTTPError` with a synthetic `Response` carrying the correct HTTP status, so the error flows through `extractErrorObservability` / `shouldMarkAccountFailed` / rate-limit logging identically to the HTTP path.

A brief comment explains why an `HTTPError` is thrown from a WebSocket code path, as suggested by @Defiect.

## What changed

- `src/services/copilot/create-responses.ts` — `consumeResponsesWebSocketStream`: replace `throw new Error(event.message)` with `throw new HTTPError(...)` carrying the parsed HTTP status

## Notes

- Safe streaming coverage was already complete in the pool implementation (confirmed in #89) — no changes needed there.
- Existing tests: 36 pass, 0 fail across `create-responses-websocket-pool`, `create-responses`, and `codex-create-responses`.

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进实时数据流错误处理机制，现在能够返回详细的HTTP状态码和错误信息，提高故障诊断能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->