### PR TITLE
feat: expose Responses API context management settings

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -159,6 +159,7 @@ export type AdminConfig = {
   /** @deprecated */
   apiKey?: string
   anthropicApiKey?: string
+  /** @deprecated use useResponsesApiContextManagement */
   responsesApiContextManagementModels?: Array<string>
   modelReasoningEfforts?: Record<string, ReasoningEffort>
   modelResponsesApiCompactThresholds?: Record<string, number>
@@ -172,6 +173,7 @@ export type AdminConfig = {
   useMessagesApi?: boolean
   useResponsesApiWebSocket?: boolean
   useResponsesApiWebSearch?: boolean
+  useResponsesApiContextManagement?: boolean
 }
 
 export type AdminConfigResponse = AdminConfig & {
@@ -443,6 +445,7 @@ const ADMIN_CONFIG_KEYS = new Set<keyof AdminConfig>([
   "useMessagesApi",
   "useResponsesApiWebSocket",
   "useResponsesApiWebSearch",
+  "useResponsesApiContextManagement",
 ])
 
 export async function updateAdminConfig(

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -477,10 +477,10 @@
       "general": "General",
       "accountAffinity": "Account Affinity",
       "reasoning": "Reasoning",
-      "compactThresholds": "Compact Thresholds",
       "aliases": "Aliases",
       "prompts": "Prompts",
       "advanced": "Advanced",
+      "responsesApi": "Responses API",
       "devMode": "Developer Mode",
       "providers": "Providers"
     },
@@ -580,6 +580,24 @@
       "blockOriginal": "Block original model ID",
       "emptyState": "No model aliases configured.",
       "addButton": "Add alias"
+    },
+    "responsesApi": {
+      "title": "Responses API",
+      "description": "Configure Responses API transport, web tools, and context management.",
+      "transportGroupTitle": "Transport",
+      "contextManagementGroupTitle": "Context management",
+      "useResponsesApiWebSocketLabel": "Enable Responses API WebSocket",
+      "useResponsesApiWebSocketHint": "When enabled, models advertising ws:/responses use Copilot's WebSocket transport; HTTP remains available for /responses-only models.",
+      "useResponsesApiWebSearchLabel": "Enable Responses API WebSearch",
+      "useResponsesApiWebSearchHint": "When enabled, /v1/responses keeps web_search tools and forwards them upstream.",
+      "useResponsesApiContextManagementLabel": "Enable Responses API context management",
+      "useResponsesApiContextManagementHint": "Default: enabled. When enabled, the proxy automatically adds context_management compaction instructions for long Responses API tasks.",
+      "contextManagementInactiveTitle": "Context management is disabled",
+      "contextManagementInactiveHint": "This legacy list is saved but does not take effect while context management is disabled.",
+      "compactThresholdsInactiveHint": "Compact threshold overrides are saved but do not take effect while context management is disabled.",
+      "responsesApiContextManagementModelsLabel": "Legacy context management models",
+      "responsesApiContextManagementModelsPlaceholder": "one model id per line",
+      "responsesApiContextManagementModelsDeprecatedHint": "Deprecated legacy allowlist. Prefer the global Responses API context management switch."
     },
     "devMode": {
       "title": "Developer Mode",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -477,10 +477,10 @@
       "general": "通用",
       "accountAffinity": "账号亲和性",
       "reasoning": "推理",
-      "compactThresholds": "压缩阈值",
       "aliases": "别名",
       "prompts": "提示词",
       "advanced": "高级",
+      "responsesApi": "Responses API",
       "devMode": "开发者模式",
       "providers": "上游提供方"
     },
@@ -580,6 +580,24 @@
       "blockOriginal": "阻止原始模型 ID",
       "emptyState": "未配置模型别名。",
       "addButton": "添加别名"
+    },
+    "responsesApi": {
+      "title": "Responses API",
+      "description": "配置 Responses API transport、web 工具和上下文管理。",
+      "transportGroupTitle": "Transport",
+      "contextManagementGroupTitle": "上下文管理",
+      "useResponsesApiWebSocketLabel": "启用 Responses API WebSocket",
+      "useResponsesApiWebSocketHint": "启用后，声明 ws:/responses 的模型会使用 Copilot WebSocket transport；仅支持 /responses 的模型仍走 HTTP。",
+      "useResponsesApiWebSearchLabel": "启用 Responses API WebSearch",
+      "useResponsesApiWebSearchHint": "启用后，/v1/responses 会保留 web_search 工具并继续向上游转发。",
+      "useResponsesApiContextManagementLabel": "启用 Responses API 上下文管理",
+      "useResponsesApiContextManagementHint": "默认启用。启用后，代理会为长任务自动附加 context_management 压缩指令。",
+      "contextManagementInactiveTitle": "上下文管理已关闭",
+      "contextManagementInactiveHint": "该旧模型列表会被保存，但在上下文管理关闭时不会生效。",
+      "compactThresholdsInactiveHint": "压缩阈值覆盖会被保存，但在上下文管理关闭时不会生效。",
+      "responsesApiContextManagementModelsLabel": "旧版上下文管理模型",
+      "responsesApiContextManagementModelsPlaceholder": "每行一个 model id",
+      "responsesApiContextManagementModelsDeprecatedHint": "已弃用的旧 allowlist。推荐使用全局 Responses API 上下文管理开关。"
     },
     "devMode": {
       "title": "开发者模式",

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -57,7 +57,7 @@ import {
 const SETTINGS_SECTION_IDS = [
   "general",
   "reasoning",
-  "compactThresholds",
+  "responsesApi",
   "aliases",
   "prompts",
   "advanced",
@@ -1584,6 +1584,8 @@ type CompactThresholdsCardProps = {
   jsonIssue: string | null
   items: Array<CompactThresholdItem>
   models: Array<string>
+  contextManagementEnabled?: boolean
+  embedded?: boolean
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -1597,6 +1599,8 @@ function CompactThresholdsCard({
   jsonIssue,
   items,
   models,
+  contextManagementEnabled = true,
+  embedded = false,
   onToggleMode,
   onJsonChange,
   onAddItem,
@@ -1607,6 +1611,164 @@ function CompactThresholdsCard({
   const hasModels = models.length > 0
   const { t } = useTranslation()
 
+  const formBody = (
+    <div className="space-y-2">
+      {items.length === 0 ? (
+        <div className="text-muted-foreground text-sm">
+          {t("settingsPage.compactThresholds.emptyState")}
+        </div>
+      ) : (
+        items.map((item) => {
+          const modelValue = item.model || defaultModelValue
+          const showCustomModel =
+            modelValue !== defaultModelValue
+            && !models.includes(modelValue)
+          const disableModelSelect = !hasModels && !showCustomModel
+          const trimmed = item.threshold.trim()
+          const numericValue = trimmed === "" ? NaN : Number(trimmed)
+          const itemInvalid =
+            trimmed !== ""
+            && (!Number.isFinite(numericValue) || numericValue <= 0)
+
+          return (
+            <div
+              key={item.id}
+              className="grid gap-2 rounded-lg border p-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Select
+                  value={modelValue}
+                  onValueChange={(value) =>
+                    onUpdateItem(item.id, {
+                      model: value === defaultModelValue ? "" : value,
+                    })
+                  }
+                  disabled={disableModelSelect}
+                >
+                  <SelectTrigger className="min-w-[220px]">
+                    <SelectValue
+                      placeholder={
+                        hasModels
+                          ? t("settingsPage.common.selectModelPlaceholder")
+                          : t("settingsPage.common.noModelsAvailable")
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={defaultModelValue}>
+                      {t("settingsPage.common.defaultOption")}
+                    </SelectItem>
+                    {showCustomModel ? (
+                      <SelectItem value={modelValue}>
+                        {t("settingsPage.common.customModel", {
+                          value: modelValue,
+                        })}
+                      </SelectItem>
+                    ) : null}
+                    {models.map((model) => (
+                      <SelectItem key={model} value={model}>
+                        {model}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  className="w-40"
+                  value={item.threshold}
+                  placeholder={t(
+                    "settingsPage.compactThresholds.thresholdPlaceholder",
+                  )}
+                  onChange={(e) =>
+                    onUpdateItem(item.id, { threshold: e.target.value })
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onRemoveItem(item.id)}
+                >
+                  {t("settingsPage.common.remove")}
+                </Button>
+              </div>
+              {itemInvalid ? (
+                <div className="text-destructive text-xs">
+                  {t("settingsPage.compactThresholds.itemInvalid")}
+                </div>
+              ) : (
+                <div className="text-muted-foreground text-xs">
+                  {t("settingsPage.compactThresholds.itemHint")}
+                </div>
+              )}
+            </div>
+          )
+        })
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onAddItem}
+      >
+        {t("settingsPage.compactThresholds.addButton")}
+      </Button>
+    </div>
+  )
+
+  const content = (
+    <>
+      {!contextManagementEnabled ? (
+        <InlineAlert
+          variant="warning"
+          title={t("settingsPage.responsesApi.contextManagementInactiveTitle")}
+          description={t(
+            "settingsPage.responsesApi.compactThresholdsInactiveHint",
+          )}
+        />
+      ) : null}
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-muted-foreground text-xs">
+          {t("settingsPage.compactThresholds.hint")}
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
+          <Label className="text-muted-foreground text-xs">
+            {t("settingsPage.common.jsonMode")}
+          </Label>
+        </div>
+      </div>
+
+      {mode === "json" ? (
+        <div className="space-y-2">
+          <Textarea
+            value={json}
+            onChange={(e) => onJsonChange(e.target.value)}
+            className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
+            placeholder={t("settingsPage.compactThresholds.jsonPlaceholder")}
+          />
+          {jsonIssue ? (
+            <InlineAlert
+              variant="warning"
+              title={t("settingsPage.common.invalidJsonTitle")}
+              description={jsonIssue}
+            />
+          ) : null}
+        </div>
+      ) : (
+        formBody
+      )}
+    </>
+  )
+
+  if (embedded) {
+    return <div className="space-y-3">{content}</div>
+  }
+
   return (
     <Card className="gap-4 py-4">
       <CardHeader className="px-4">
@@ -1615,144 +1777,7 @@ function CompactThresholdsCard({
           {t("settingsPage.compactThresholds.description")}
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-3 px-4">
-        <div className="flex items-center justify-between gap-3">
-          <div className="text-muted-foreground text-xs">
-            {t("settingsPage.compactThresholds.hint")}
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
-            <Label className="text-muted-foreground text-xs">
-              {t("settingsPage.common.jsonMode")}
-            </Label>
-          </div>
-        </div>
-
-        {mode === "json" ? (
-          <div className="space-y-2">
-            <Textarea
-              value={json}
-              onChange={(e) => onJsonChange(e.target.value)}
-              className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
-              placeholder={t("settingsPage.compactThresholds.jsonPlaceholder")}
-            />
-            {jsonIssue ? (
-              <InlineAlert
-                variant="warning"
-                title={t("settingsPage.common.invalidJsonTitle")}
-                description={jsonIssue}
-              />
-            ) : null}
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {items.length === 0 ? (
-              <div className="text-muted-foreground text-sm">
-                {t("settingsPage.compactThresholds.emptyState")}
-              </div>
-            ) : (
-              items.map((item) => {
-                const modelValue = item.model || defaultModelValue
-                const showCustomModel =
-                  modelValue !== defaultModelValue
-                  && !models.includes(modelValue)
-                const disableModelSelect = !hasModels && !showCustomModel
-                const trimmed = item.threshold.trim()
-                const numericValue = trimmed === "" ? NaN : Number(trimmed)
-                const itemInvalid =
-                  trimmed !== ""
-                  && (!Number.isFinite(numericValue) || numericValue <= 0)
-
-                return (
-                  <div
-                    key={item.id}
-                    className="grid gap-2 rounded-lg border p-3"
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Select
-                        value={modelValue}
-                        onValueChange={(value) =>
-                          onUpdateItem(item.id, {
-                            model: value === defaultModelValue ? "" : value,
-                          })
-                        }
-                        disabled={disableModelSelect}
-                      >
-                        <SelectTrigger className="min-w-[220px]">
-                          <SelectValue
-                            placeholder={
-                              hasModels
-                                ? t("settingsPage.common.selectModelPlaceholder")
-                                : t("settingsPage.common.noModelsAvailable")
-                            }
-                          />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value={defaultModelValue}>
-                            {t("settingsPage.common.defaultOption")}
-                          </SelectItem>
-                          {showCustomModel ? (
-                            <SelectItem value={modelValue}>
-                              {t("settingsPage.common.customModel", {
-                                value: modelValue,
-                              })}
-                            </SelectItem>
-                          ) : null}
-                          {models.map((model) => (
-                            <SelectItem key={model} value={model}>
-                              {model}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        type="number"
-                        inputMode="numeric"
-                        min={1}
-                        step={1}
-                        className="w-40"
-                        value={item.threshold}
-                        placeholder={t(
-                          "settingsPage.compactThresholds.thresholdPlaceholder",
-                        )}
-                        onChange={(e) =>
-                          onUpdateItem(item.id, { threshold: e.target.value })
-                        }
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => onRemoveItem(item.id)}
-                      >
-                        {t("settingsPage.common.remove")}
-                      </Button>
-                    </div>
-                    {itemInvalid ? (
-                      <div className="text-destructive text-xs">
-                        {t("settingsPage.compactThresholds.itemInvalid")}
-                      </div>
-                    ) : (
-                      <div className="text-muted-foreground text-xs">
-                        {t("settingsPage.compactThresholds.itemHint")}
-                      </div>
-                    )}
-                  </div>
-                )
-              })
-            )}
-
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={onAddItem}
-            >
-              {t("settingsPage.compactThresholds.addButton")}
-            </Button>
-          </div>
-        )}
-      </CardContent>
+      <CardContent className="space-y-3 px-4">{content}</CardContent>
     </Card>
   )
 }
@@ -2184,6 +2209,180 @@ function ModelAliasesCard({
   )
 }
 
+type ResponsesApiSettingsCardProps = {
+  useResponsesApiWebSocket: boolean
+  useResponsesApiWebSearch: boolean
+  useResponsesApiContextManagement: boolean
+  responsesApiContextManagementModelsValue: string
+  compactThresholdsMode: JsonMode
+  compactThresholdsJson: string
+  compactThresholdsJsonIssue: string | null
+  compactThresholdsItems: Array<CompactThresholdItem>
+  models: Array<string>
+  onToggleUseResponsesApiWebSocket: (value: boolean) => void
+  onToggleUseResponsesApiWebSearch: (value: boolean) => void
+  onToggleUseResponsesApiContextManagement: (value: boolean) => void
+  onResponsesApiContextManagementModelsChange: (value: string) => void
+  onCompactThresholdsToggleMode: (next: boolean) => void
+  onCompactThresholdsJsonChange: (value: string) => void
+  onCompactThresholdsAddItem: () => void
+  onCompactThresholdsRemoveItem: (id: string) => void
+  onCompactThresholdsUpdateItem: (
+    id: string,
+    patch: Partial<CompactThresholdItem>,
+  ) => void
+}
+
+export function ResponsesApiSettingsCard({
+  useResponsesApiWebSocket,
+  useResponsesApiWebSearch,
+  useResponsesApiContextManagement,
+  responsesApiContextManagementModelsValue,
+  compactThresholdsMode,
+  compactThresholdsJson,
+  compactThresholdsJsonIssue,
+  compactThresholdsItems,
+  models,
+  onToggleUseResponsesApiWebSocket,
+  onToggleUseResponsesApiWebSearch,
+  onToggleUseResponsesApiContextManagement,
+  onResponsesApiContextManagementModelsChange,
+  onCompactThresholdsToggleMode,
+  onCompactThresholdsJsonChange,
+  onCompactThresholdsAddItem,
+  onCompactThresholdsRemoveItem,
+  onCompactThresholdsUpdateItem,
+}: ResponsesApiSettingsCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>{t("settingsPage.responsesApi.title")}</CardTitle>
+        <CardDescription className="hidden sm:block">
+          {t("settingsPage.responsesApi.description")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 px-4">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {t("settingsPage.responsesApi.transportGroupTitle")}
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.responsesApi.useResponsesApiWebSocketLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.useResponsesApiWebSocketHint")}
+            </div>
+          </div>
+          <Switch
+            checked={useResponsesApiWebSocket}
+            onCheckedChange={onToggleUseResponsesApiWebSocket}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.responsesApi.useResponsesApiWebSearchLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.useResponsesApiWebSearchHint")}
+            </div>
+          </div>
+          <Switch
+            checked={useResponsesApiWebSearch}
+            onCheckedChange={onToggleUseResponsesApiWebSearch}
+          />
+        </div>
+
+        <hr className="border-t" />
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {t("settingsPage.responsesApi.contextManagementGroupTitle")}
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t(
+                "settingsPage.responsesApi.useResponsesApiContextManagementLabel",
+              )}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t(
+                "settingsPage.responsesApi.useResponsesApiContextManagementHint",
+              )}
+            </div>
+          </div>
+          <Switch
+            checked={useResponsesApiContextManagement}
+            onCheckedChange={onToggleUseResponsesApiContextManagement}
+          />
+        </div>
+
+        <div className="rounded-lg border p-3 space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.compactThresholds.title")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.compactThresholds.description")}
+            </div>
+          </div>
+          <CompactThresholdsCard
+            embedded
+            contextManagementEnabled={useResponsesApiContextManagement}
+            mode={compactThresholdsMode}
+            json={compactThresholdsJson}
+            jsonIssue={compactThresholdsJsonIssue}
+            items={compactThresholdsItems}
+            models={models}
+            onToggleMode={onCompactThresholdsToggleMode}
+            onJsonChange={onCompactThresholdsJsonChange}
+            onAddItem={onCompactThresholdsAddItem}
+            onRemoveItem={onCompactThresholdsRemoveItem}
+            onUpdateItem={onCompactThresholdsUpdateItem}
+          />
+        </div>
+
+        <hr className="border-t" />
+        <div className="grid gap-2 rounded-lg border border-dashed p-3">
+          <div className="space-y-1">
+            <Label className="text-muted-foreground text-xs">
+              {t(
+                "settingsPage.responsesApi.responsesApiContextManagementModelsLabel",
+              )}
+            </Label>
+            <div className="text-muted-foreground text-xs">
+              {t(
+                "settingsPage.responsesApi.responsesApiContextManagementModelsDeprecatedHint",
+              )}
+            </div>
+            {!useResponsesApiContextManagement ? (
+              <div className="text-muted-foreground text-xs">
+                {t("settingsPage.responsesApi.contextManagementInactiveHint")}
+              </div>
+            ) : null}
+          </div>
+          <Textarea
+            autoComplete="off"
+            placeholder={t(
+              "settingsPage.responsesApi.responsesApiContextManagementModelsPlaceholder",
+            )}
+            value={responsesApiContextManagementModelsValue}
+            onChange={(e) =>
+              onResponsesApiContextManagementModelsChange(e.target.value)
+            }
+            className="min-h-[96px] font-mono text-xs"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 type DeveloperModeCardProps = {
   devMode: DevModeState
   saving: boolean
@@ -2293,9 +2492,6 @@ type AdvancedSettingsCardProps = {
   compactUseSmallModel: boolean
   messageStartInputTokensFallback: boolean
   useMessagesApi: boolean
-  useResponsesApiWebSocket: boolean
-  useResponsesApiWebSearch: boolean
-  responsesApiContextManagementModelsValue: string
   onToggleAccountAffinity: (value: boolean) => void
   onModelRefreshIntervalChange: (value: string) => void
   onSessionAffinityRetentionChange: (value: string) => void
@@ -2304,9 +2500,6 @@ type AdvancedSettingsCardProps = {
   onToggleCompactUseSmallModel: (value: boolean) => void
   onToggleMessageStartInputTokensFallback: (value: boolean) => void
   onToggleUseMessagesApi: (value: boolean) => void
-  onToggleUseResponsesApiWebSocket: (value: boolean) => void
-  onToggleUseResponsesApiWebSearch: (value: boolean) => void
-  onResponsesApiContextManagementModelsChange: (value: string) => void
 }
 
 export function AdvancedSettingsCard({
@@ -2320,9 +2513,6 @@ export function AdvancedSettingsCard({
   compactUseSmallModel,
   messageStartInputTokensFallback,
   useMessagesApi,
-  useResponsesApiWebSocket,
-  useResponsesApiWebSearch,
-  responsesApiContextManagementModelsValue,
   onToggleAccountAffinity,
   onModelRefreshIntervalChange,
   onSessionAffinityRetentionChange,
@@ -2331,9 +2521,6 @@ export function AdvancedSettingsCard({
   onToggleCompactUseSmallModel,
   onToggleMessageStartInputTokensFallback,
   onToggleUseMessagesApi,
-  onToggleUseResponsesApiWebSocket,
-  onToggleUseResponsesApiWebSearch,
-  onResponsesApiContextManagementModelsChange,
 }: AdvancedSettingsCardProps): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -2409,56 +2596,6 @@ export function AdvancedSettingsCard({
             </div>
           </div>
           <Switch checked={useMessagesApi} onCheckedChange={onToggleUseMessagesApi} />
-        </div>
-
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
-            <div className="text-sm font-medium">
-              {t("settingsPage.advanced.useResponsesApiWebSocketLabel")}
-            </div>
-            <div className="text-muted-foreground text-xs">
-              {t("settingsPage.advanced.useResponsesApiWebSocketHint")}
-            </div>
-          </div>
-          <Switch
-            checked={useResponsesApiWebSocket}
-            onCheckedChange={onToggleUseResponsesApiWebSocket}
-          />
-        </div>
-
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
-            <div className="text-sm font-medium">
-              {t("settingsPage.advanced.useResponsesApiWebSearchLabel")}
-            </div>
-            <div className="text-muted-foreground text-xs">
-              {t("settingsPage.advanced.useResponsesApiWebSearchHint")}
-            </div>
-          </div>
-          <Switch
-            checked={useResponsesApiWebSearch}
-            onCheckedChange={onToggleUseResponsesApiWebSearch}
-          />
-        </div>
-
-        <div className="grid gap-2">
-          <Label className="text-muted-foreground text-xs">
-            {t("settingsPage.advanced.responsesApiContextManagementModelsLabel")}
-          </Label>
-          <Textarea
-            autoComplete="off"
-            placeholder={t(
-              "settingsPage.advanced.responsesApiContextManagementModelsPlaceholder",
-            )}
-            value={responsesApiContextManagementModelsValue}
-            onChange={(e) =>
-              onResponsesApiContextManagementModelsChange(e.target.value)
-            }
-            className="min-h-[96px] font-mono text-xs"
-          />
-          <div className="text-muted-foreground text-xs">
-            {t("settingsPage.advanced.responsesApiContextManagementModelsHint")}
-          </div>
         </div>
 
         {/* — Model & Tokens — */}
@@ -2971,10 +3108,12 @@ type SettingsPageViewProps = {
   useMessagesApi: boolean
   useResponsesApiWebSocket: boolean
   useResponsesApiWebSearch: boolean
+  useResponsesApiContextManagement: boolean
   responsesApiContextManagementModelsValue: string
   onUseMessagesApiToggle: (value: boolean) => void
   onUseResponsesApiWebSocketToggle: (value: boolean) => void
   onUseResponsesApiWebSearchToggle: (value: boolean) => void
+  onUseResponsesApiContextManagementToggle: (value: boolean) => void
   onResponsesApiContextManagementModelsChange: (value: string) => void
   providersItems: Array<ProviderItem>
   providersIssue: string | null
@@ -3361,6 +3500,13 @@ function useSettingsPageState(): SettingsPageViewProps {
     [setDraft],
   )
 
+  const handleUseResponsesApiContextManagementToggle = useCallback(
+    (value: boolean) => {
+      setDraft((prev) => ({ ...prev, useResponsesApiContextManagement: value }))
+    },
+    [setDraft],
+  )
+
   const handleResponsesApiContextManagementModelsChange = useCallback(
     (value: string) => {
       setResponsesApiContextManagementModelsValue(value)
@@ -3467,6 +3613,8 @@ function useSettingsPageState(): SettingsPageViewProps {
   const useMessagesApi = draft.useMessagesApi ?? true
   const useResponsesApiWebSocket = draft.useResponsesApiWebSocket ?? true
   const useResponsesApiWebSearch = draft.useResponsesApiWebSearch ?? true
+  const useResponsesApiContextManagement =
+    draft.useResponsesApiContextManagement ?? true
 
   return {
     loading,
@@ -3544,10 +3692,12 @@ function useSettingsPageState(): SettingsPageViewProps {
     useMessagesApi,
     useResponsesApiWebSocket,
     useResponsesApiWebSearch,
+    useResponsesApiContextManagement,
     responsesApiContextManagementModelsValue,
     onUseMessagesApiToggle: handleUseMessagesApiToggle,
     onUseResponsesApiWebSocketToggle: handleUseResponsesApiWebSocketToggle,
     onUseResponsesApiWebSearchToggle: handleUseResponsesApiWebSearchToggle,
+    onUseResponsesApiContextManagementToggle: handleUseResponsesApiContextManagementToggle,
     onResponsesApiContextManagementModelsChange:
       handleResponsesApiContextManagementModelsChange,
     providersItems,
@@ -3643,10 +3793,12 @@ function SettingsPageView({
   useMessagesApi,
   useResponsesApiWebSocket,
   useResponsesApiWebSearch,
+  useResponsesApiContextManagement,
   responsesApiContextManagementModelsValue,
   onUseMessagesApiToggle,
   onUseResponsesApiWebSocketToggle,
   onUseResponsesApiWebSearchToggle,
+  onUseResponsesApiContextManagementToggle,
   onResponsesApiContextManagementModelsChange,
   providersItems,
   providersIssue,
@@ -3667,10 +3819,7 @@ function SettingsPageView({
     return [
       { id: "general", label: t("settingsPage.sections.general") },
       { id: "reasoning", label: t("settingsPage.sections.reasoning") },
-      {
-        id: "compactThresholds",
-        label: t("settingsPage.sections.compactThresholds"),
-      },
+      { id: "responsesApi", label: t("settingsPage.sections.responsesApi") },
       { id: "aliases", label: t("settingsPage.sections.aliases") },
       { id: "prompts", label: t("settingsPage.sections.prompts") },
       { id: "advanced", label: t("settingsPage.sections.advanced") },
@@ -3824,24 +3973,38 @@ function SettingsPageView({
             />
           </SettingsSectionCard>
 
-          {/* Compact Thresholds */}
+          {/* Responses API */}
           <SettingsSectionCard
-            id="compactThresholds"
-            isActive={activeSection === "compactThresholds"}
-            ref={(el) => registerSection("compactThresholds", el)}
+            id="responsesApi"
+            isActive={activeSection === "responsesApi"}
+            ref={(el) => registerSection("responsesApi", el)}
             style={{ animationDelay: "90ms" }}
           >
-            <CompactThresholdsCard
-              mode={compactThresholdsMode}
-              json={compactThresholdsJson}
-              jsonIssue={compactThresholdsJsonIssue}
-              items={compactThresholdsItems}
+            <ResponsesApiSettingsCard
+              useResponsesApiWebSocket={useResponsesApiWebSocket}
+              useResponsesApiWebSearch={useResponsesApiWebSearch}
+              useResponsesApiContextManagement={useResponsesApiContextManagement}
+              responsesApiContextManagementModelsValue={
+                responsesApiContextManagementModelsValue
+              }
+              compactThresholdsMode={compactThresholdsMode}
+              compactThresholdsJson={compactThresholdsJson}
+              compactThresholdsJsonIssue={compactThresholdsJsonIssue}
+              compactThresholdsItems={compactThresholdsItems}
               models={models}
-              onToggleMode={onCompactThresholdsToggleMode}
-              onJsonChange={onCompactThresholdsJsonChange}
-              onAddItem={onCompactThresholdsAddItem}
-              onRemoveItem={onCompactThresholdsRemoveItem}
-              onUpdateItem={onCompactThresholdsUpdateItem}
+              onToggleUseResponsesApiWebSocket={onUseResponsesApiWebSocketToggle}
+              onToggleUseResponsesApiWebSearch={onUseResponsesApiWebSearchToggle}
+              onToggleUseResponsesApiContextManagement={
+                onUseResponsesApiContextManagementToggle
+              }
+              onResponsesApiContextManagementModelsChange={
+                onResponsesApiContextManagementModelsChange
+              }
+              onCompactThresholdsToggleMode={onCompactThresholdsToggleMode}
+              onCompactThresholdsJsonChange={onCompactThresholdsJsonChange}
+              onCompactThresholdsAddItem={onCompactThresholdsAddItem}
+              onCompactThresholdsRemoveItem={onCompactThresholdsRemoveItem}
+              onCompactThresholdsUpdateItem={onCompactThresholdsUpdateItem}
             />
           </SettingsSectionCard>
 
@@ -3908,11 +4071,6 @@ function SettingsPageView({
               compactUseSmallModel={compactUseSmallModel}
               messageStartInputTokensFallback={messageStartInputTokensFallback}
               useMessagesApi={useMessagesApi}
-              useResponsesApiWebSocket={useResponsesApiWebSocket}
-              useResponsesApiWebSearch={useResponsesApiWebSearch}
-              responsesApiContextManagementModelsValue={
-                responsesApiContextManagementModelsValue
-              }
               onToggleAccountAffinity={onAccountAffinityToggle}
               onModelRefreshIntervalChange={onModelRefreshIntervalChange}
               onSessionAffinityRetentionChange={
@@ -3927,15 +4085,6 @@ function SettingsPageView({
                 onMessageStartInputTokensFallbackToggle
               }
               onToggleUseMessagesApi={onUseMessagesApiToggle}
-              onToggleUseResponsesApiWebSocket={
-                onUseResponsesApiWebSocketToggle
-              }
-              onToggleUseResponsesApiWebSearch={
-                onUseResponsesApiWebSearchToggle
-              }
-              onResponsesApiContextManagementModelsChange={
-                onResponsesApiContextManagementModelsChange
-              }
             />
           </SettingsSectionCard>
 

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -355,7 +355,11 @@ function reasoningRecordFromItems(
   return record
 }
 
-function compactThresholdRecordFromItems(
+function isPositiveInteger(value: number): boolean {
+  return Number.isFinite(value) && Number.isInteger(value) && value > 0
+}
+
+export function compactThresholdRecordFromItems(
   items: Array<CompactThresholdItem>,
 ): Record<string, number> {
   const record: Record<string, number> = {}
@@ -365,7 +369,7 @@ function compactThresholdRecordFromItems(
     const trimmed = item.threshold.trim()
     if (!trimmed) continue
     const value = Number(trimmed)
-    if (!Number.isFinite(value) || value <= 0) continue
+    if (!isPositiveInteger(value)) continue
     record[key] = value
   }
   return record
@@ -770,7 +774,7 @@ function parseReasoningJson(
   }
 }
 
-function parseCompactThresholdsJson(
+export function parseCompactThresholdsJson(
   value: string,
 ): ParseResult<Record<string, number>> {
   if (!value.trim()) return { record: {} }
@@ -790,9 +794,9 @@ function parseCompactThresholdsJson(
           error: `modelResponsesApiCompactThresholds.${key} must be a number.`,
         }
       }
-      if (!Number.isFinite(threshold) || threshold <= 0) {
+      if (!isPositiveInteger(threshold)) {
         return {
-          error: `modelResponsesApiCompactThresholds.${key} must be a positive finite number.`,
+          error: `modelResponsesApiCompactThresholds.${key} must be a positive integer.`,
         }
       }
       record[key] = threshold
@@ -1626,9 +1630,7 @@ function CompactThresholdsCard({
           const disableModelSelect = !hasModels && !showCustomModel
           const trimmed = item.threshold.trim()
           const numericValue = trimmed === "" ? NaN : Number(trimmed)
-          const itemInvalid =
-            trimmed !== ""
-            && (!Number.isFinite(numericValue) || numericValue <= 0)
+          const itemInvalid = trimmed !== "" && !isPositiveInteger(numericValue)
 
           return (
             <div

--- a/admin-ui/tests/settings-page.test.tsx
+++ b/admin-ui/tests/settings-page.test.tsx
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test"
 import { renderToStaticMarkup } from "react-dom/server"
 
-import { ResponsesApiSettingsCard } from "../src/pages/settings-page"
+import {
+  ResponsesApiSettingsCard,
+  compactThresholdRecordFromItems,
+  parseCompactThresholdsJson,
+} from "../src/pages/settings-page"
 
 test("Responses API settings exposes transport toggles and context management", () => {
   const html = renderToStaticMarkup(
@@ -62,4 +66,54 @@ test("Responses API settings marks dependent fields inactive when context manage
   expect(html).toContain("Context management is disabled")
   expect(html).toContain("Compact threshold overrides are saved")
   expect(html).toContain("gpt-5.4")
+})
+
+test("compact threshold form validation rejects decimals", () => {
+  const html = renderToStaticMarkup(
+    <ResponsesApiSettingsCard
+      useResponsesApiContextManagement
+      useResponsesApiWebSearch
+      useResponsesApiWebSocket
+      responsesApiContextManagementModelsValue=""
+      compactThresholdsMode="form"
+      compactThresholdsJson="{}"
+      compactThresholdsJsonIssue={null}
+      compactThresholdsItems={[
+        {
+          id: "threshold-1",
+          model: "gpt-5.4",
+          threshold: "1.5",
+        },
+      ]}
+      models={["gpt-5.4"]}
+      onCompactThresholdsAddItem={() => {}}
+      onCompactThresholdsJsonChange={() => {}}
+      onCompactThresholdsRemoveItem={() => {}}
+      onCompactThresholdsToggleMode={() => {}}
+      onCompactThresholdsUpdateItem={() => {}}
+      onResponsesApiContextManagementModelsChange={() => {}}
+      onToggleUseResponsesApiContextManagement={() => {}}
+      onToggleUseResponsesApiWebSearch={() => {}}
+      onToggleUseResponsesApiWebSocket={() => {}}
+    />,
+  )
+
+  expect(html).toContain("Threshold must be a positive integer.")
+})
+
+test("compact threshold JSON validation rejects decimals", () => {
+  const result = parseCompactThresholdsJson('{ "gpt-5.4": 1.5 }')
+
+  expect(result).toEqual({
+    error: "modelResponsesApiCompactThresholds.gpt-5.4 must be a positive integer.",
+  })
+})
+
+test("compact threshold form record skips decimals", () => {
+  const record = compactThresholdRecordFromItems([
+    { id: "threshold-1", model: "gpt-5.4", threshold: "1.5" },
+    { id: "threshold-2", model: "gpt-5.5", threshold: "2" },
+  ])
+
+  expect(record).toEqual({ "gpt-5.5": 2 })
 })

--- a/admin-ui/tests/settings-page.test.tsx
+++ b/admin-ui/tests/settings-page.test.tsx
@@ -1,33 +1,27 @@
 import { expect, test } from "bun:test"
 import { renderToStaticMarkup } from "react-dom/server"
 
-import { AdvancedSettingsCard } from "../src/pages/settings-page"
+import { ResponsesApiSettingsCard } from "../src/pages/settings-page"
 
-test("Advanced settings exposes Responses API WebSocket toggle", () => {
+test("Responses API settings exposes transport toggles and context management", () => {
   const html = renderToStaticMarkup(
-    <AdvancedSettingsCard
-      accountAffinityEnabled
-      allowOriginalModelNamesForAliases={false}
-      compactUseSmallModel={false}
-      forceAgent={false}
-      messageStartInputTokensFallback={false}
-      modelRefreshIntervalInput=""
-      modelRefreshIntervalIssue={null}
-      responsesApiContextManagementModelsValue=""
-      sessionAffinityRetentionInput=""
-      sessionAffinityRetentionIssue={null}
-      useMessagesApi
+    <ResponsesApiSettingsCard
+      useResponsesApiContextManagement
       useResponsesApiWebSearch
       useResponsesApiWebSocket={false}
-      onModelRefreshIntervalChange={() => {}}
+      responsesApiContextManagementModelsValue=""
+      compactThresholdsMode="form"
+      compactThresholdsJson="{}"
+      compactThresholdsJsonIssue={null}
+      compactThresholdsItems={[]}
+      models={[]}
+      onCompactThresholdsAddItem={() => {}}
+      onCompactThresholdsJsonChange={() => {}}
+      onCompactThresholdsRemoveItem={() => {}}
+      onCompactThresholdsToggleMode={() => {}}
+      onCompactThresholdsUpdateItem={() => {}}
       onResponsesApiContextManagementModelsChange={() => {}}
-      onSessionAffinityRetentionChange={() => {}}
-      onToggleAccountAffinity={() => {}}
-      onToggleAllowOriginalModelNamesForAliases={() => {}}
-      onToggleCompactUseSmallModel={() => {}}
-      onToggleForceAgent={() => {}}
-      onToggleMessageStartInputTokensFallback={() => {}}
-      onToggleUseMessagesApi={() => {}}
+      onToggleUseResponsesApiContextManagement={() => {}}
       onToggleUseResponsesApiWebSearch={() => {}}
       onToggleUseResponsesApiWebSocket={() => {}}
     />,
@@ -35,5 +29,37 @@ test("Advanced settings exposes Responses API WebSocket toggle", () => {
 
   expect(html).toContain("Enable Responses API WebSocket")
   expect(html).toContain("ws:/responses")
+  expect(html).toContain("Enable Responses API context management")
+  expect(html).toContain("Default: enabled")
+  expect(html).toContain("Legacy context management models")
   expect(html).toContain('aria-checked="false"')
+})
+
+test("Responses API settings marks dependent fields inactive when context management is off", () => {
+  const html = renderToStaticMarkup(
+    <ResponsesApiSettingsCard
+      useResponsesApiContextManagement={false}
+      useResponsesApiWebSearch
+      useResponsesApiWebSocket
+      responsesApiContextManagementModelsValue="gpt-5.4"
+      compactThresholdsMode="form"
+      compactThresholdsJson="{}"
+      compactThresholdsJsonIssue={null}
+      compactThresholdsItems={[]}
+      models={[]}
+      onCompactThresholdsAddItem={() => {}}
+      onCompactThresholdsJsonChange={() => {}}
+      onCompactThresholdsRemoveItem={() => {}}
+      onCompactThresholdsToggleMode={() => {}}
+      onCompactThresholdsUpdateItem={() => {}}
+      onResponsesApiContextManagementModelsChange={() => {}}
+      onToggleUseResponsesApiContextManagement={() => {}}
+      onToggleUseResponsesApiWebSearch={() => {}}
+      onToggleUseResponsesApiWebSocket={() => {}}
+    />,
+  )
+
+  expect(html).toContain("Context management is disabled")
+  expect(html).toContain("Compact threshold overrides are saved")
+  expect(html).toContain("gpt-5.4")
 })

--- a/docs/superpowers/plans/2026-06-06-admin-ui-settings-page-optimization-implementation.md
+++ b/docs/superpowers/plans/2026-06-06-admin-ui-settings-page-optimization-implementation.md
@@ -1,0 +1,1332 @@
+# Admin-UI 设置页优化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not create git commits unless the user explicitly asks for commits.
+
+**Goal:** Admin-UI 能配置 `useResponsesApiContextManagement`，并把 Responses API 相关设置集中到独立 section，同时保留旧配置兼容与测试覆盖。
+
+**Architecture:** 后端沿用现有 Admin config patch pipeline，只把新 boolean 字段加入白名单和 handler。前端新增 `ResponsesApiSettingsCard` 并新增 `responsesApi` section，复用现有 compact threshold editor 与 legacy textarea 状态，不引入 schema-driven 表单或新表单库。
+
+**Tech Stack:** Bun test runner、TypeScript strict、React 19、react-i18next、Hono Admin API、现有 shadcn-style UI components。
+
+---
+
+## File Structure
+
+### Backend
+
+- Modify: `src/routes/admin-api/route.ts`
+  - Add `useResponsesApiContextManagement` to `CONFIG_KEYS`.
+  - Extend `applyOptionalBoolean()` accepted key union.
+  - Add a `CONFIG_PATCH_HANDLERS` entry using existing boolean parser semantics.
+- Modify: `tests/admin-config.test.ts`
+  - Add Admin API tests for false, true, null clear, and invalid type.
+
+### Runtime behavior tests
+
+- Modify: `tests/responses-handler.test.ts`
+  - Add tests under `describe("responses handler context management", ...)` using `responsesUtilsDependencies` to force enabled/disabled states.
+  - Restore dependency overrides in `afterEach()`.
+
+### Frontend API typing
+
+- Modify: `admin-ui/src/lib/admin-api.ts`
+  - Add `useResponsesApiContextManagement?: boolean` to `AdminConfig`.
+  - Add field to `ADMIN_CONFIG_KEYS` so `updateAdminConfig()` does not filter it.
+
+### Frontend settings UI
+
+- Modify: `admin-ui/src/pages/settings-page.tsx`
+  - Add `responsesApi` section id.
+  - Export new `ResponsesApiSettingsCard` for tests.
+  - Move `useResponsesApiWebSocket`, `useResponsesApiWebSearch`, `useResponsesApiContextManagement`, `modelResponsesApiCompactThresholds`, and `responsesApiContextManagementModels` into the new card.
+  - Keep `AdvancedSettingsCard` focused on routing/model/global advanced settings.
+- Modify: `admin-ui/src/locales/en-US.json`
+  - Add `settingsPage.sections.responsesApi`.
+  - Add `settingsPage.responsesApi.*` copy.
+  - Remove or stop using Responses API copy under `settingsPage.advanced.*` after UI migration.
+- Modify: `admin-ui/src/locales/zh-CN.json`
+  - Mirror English locale keys in Simplified Chinese.
+- Modify: `admin-ui/tests/settings-page.test.tsx`
+  - Update tests to render `ResponsesApiSettingsCard` instead of expecting Responses API controls inside `AdvancedSettingsCard`.
+
+### Verification
+
+- Run targeted tests:
+  - `bun test tests/admin-config.test.ts tests/responses-handler.test.ts`
+  - `bun test admin-ui/tests/settings-page.test.tsx`
+- Run quality checks when targeted tests pass:
+  - `bun run typecheck`
+  - `bun run typecheck:admin`
+  - `bun run lint`
+  - `bun run lint:admin`
+
+---
+
+## Task 1: Backend Admin API accepts `useResponsesApiContextManagement`
+
+**Files:**
+- Modify: `src/routes/admin-api/route.ts`
+- Test: `tests/admin-config.test.ts`
+
+- [ ] **Step 1: Write failing Admin API tests**
+
+Append these tests after the existing `responsesApiContextManagementModels` tests in `tests/admin-config.test.ts`:
+
+```ts
+test("POST /api/admin/config updates useResponsesApiContextManagement", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const falseRes = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ useResponsesApiContextManagement: false }),
+      }),
+    )
+
+    expect(falseRes.status).toBe(200)
+
+    const falseBody = (await falseRes.json()) as {
+      useResponsesApiContextManagement?: boolean
+    }
+    expect(falseBody.useResponsesApiContextManagement).toBe(false)
+
+    const trueRes = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ useResponsesApiContextManagement: true }),
+      }),
+    )
+
+    expect(trueRes.status).toBe(200)
+
+    const trueBody = (await trueRes.json()) as {
+      useResponsesApiContextManagement?: boolean
+    }
+    expect(trueBody.useResponsesApiContextManagement).toBe(true)
+  })
+})
+
+test("POST /api/admin/config clears useResponsesApiContextManagement to default", async () => {
+  await withConfig({ useResponsesApiContextManagement: false }, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ useResponsesApiContextManagement: null }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      useResponsesApiContextManagement?: boolean
+    }
+    expect(body.useResponsesApiContextManagement).toBe(true)
+  })
+})
+
+test("POST /api/admin/config rejects invalid useResponsesApiContextManagement", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ useResponsesApiContextManagement: "false" }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain(
+      "useResponsesApiContextManagement must be a boolean",
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test tests/admin-config.test.ts
+```
+
+Expected before implementation:
+
+- The new update/clear tests fail with `Unknown config key: useResponsesApiContextManagement`, or equivalent 400 response.
+- Existing tests should still pass.
+
+- [ ] **Step 3: Implement minimal backend support**
+
+In `src/routes/admin-api/route.ts`, update `CONFIG_KEYS`:
+
+```ts
+const CONFIG_KEYS = new Set<keyof AppConfig>([
+  "auth",
+  "extraPrompts",
+  "smallModel",
+  "logLevel",
+  "accountAffinity",
+  "apiKey",
+  "anthropicApiKey",
+  "providers",
+  "responsesApiContextManagementModels",
+  "useResponsesApiContextManagement",
+  "modelReasoningEfforts",
+  "modelAliases",
+  "allowOriginalModelNamesForAliases",
+  "forceAgent",
+  "compactUseSmallModel",
+  "messageStartInputTokensFallback",
+  "modelRefreshIntervalHours",
+  "sessionAffinityRetentionDays",
+  "useMessagesApi",
+  "useResponsesApiWebSocket",
+  "useResponsesApiWebSearch",
+  "devMode",
+  "quotaRefresh",
+])
+```
+
+Extend the `applyOptionalBoolean()` key union:
+
+```ts
+function applyOptionalBoolean(
+  next: AppConfig,
+  key:
+    | "accountAffinity"
+    | "forceAgent"
+    | "useMessagesApi"
+    | "useResponsesApiWebSocket"
+    | "useResponsesApiWebSearch"
+    | "useResponsesApiContextManagement"
+    | "compactUseSmallModel"
+    | "messageStartInputTokensFallback"
+    | "allowOriginalModelNamesForAliases",
+  value: unknown,
+): string | undefined {
+  const parsed = parseOptionalBoolean(value, key)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    next[key] = undefined
+    return undefined
+  }
+  next[key] = parsed.value
+  return undefined
+}
+```
+
+Add the patch handler near the other Responses API handlers:
+
+```ts
+const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
+  auth: applyAuthConfig,
+  extraPrompts: applyExtraPrompts,
+  smallModel: (next, value) => applyOptionalString(next, "smallModel", value),
+  logLevel: applyLogLevel,
+  accountAffinity: (next, value) =>
+    applyOptionalBoolean(next, "accountAffinity", value),
+  apiKey: (next, value) => applyOptionalString(next, "apiKey", value),
+  anthropicApiKey: (next, value) =>
+    applyOptionalString(next, "anthropicApiKey", value),
+  providers: applyProvidersConfig,
+  responsesApiContextManagementModels: applyResponsesApiContextManagementModels,
+  useResponsesApiContextManagement: (next, value) =>
+    applyOptionalBoolean(next, "useResponsesApiContextManagement", value),
+  modelReasoningEfforts: applyReasoningEfforts,
+  modelAliases: applyModelAliases,
+  allowOriginalModelNamesForAliases: (next, value) =>
+    applyOptionalBoolean(next, "allowOriginalModelNamesForAliases", value),
+  forceAgent: (next, value) => applyOptionalBoolean(next, "forceAgent", value),
+  compactUseSmallModel: (next, value) =>
+    applyOptionalBoolean(next, "compactUseSmallModel", value),
+  messageStartInputTokensFallback: (next, value) =>
+    applyOptionalBoolean(next, "messageStartInputTokensFallback", value),
+  modelRefreshIntervalHours: (next, value) =>
+    applyOptionalNumber(next, "modelRefreshIntervalHours", value),
+  sessionAffinityRetentionDays: (next, value) =>
+    applyOptionalNumber(next, "sessionAffinityRetentionDays", value),
+  useMessagesApi: (next, value) =>
+    applyOptionalBoolean(next, "useMessagesApi", value),
+  useResponsesApiWebSocket: (next, value) =>
+    applyOptionalBoolean(next, "useResponsesApiWebSocket", value),
+  useResponsesApiWebSearch: (next, value) =>
+    applyOptionalBoolean(next, "useResponsesApiWebSearch", value),
+  devMode: applyDevModeConfig,
+  quotaRefresh: applyQuotaRefreshConfig,
+}
+```
+
+Keep surrounding existing entries not shown here if the file has changed. Do not add a new parser.
+
+- [ ] **Step 4: Run Admin API tests**
+
+Run:
+
+```bash
+bun test tests/admin-config.test.ts
+```
+
+Expected:
+
+- PASS for all existing tests.
+- PASS for the three new `useResponsesApiContextManagement` tests.
+
+---
+
+## Task 2: Runtime behavior is verified for enabled and disabled context management
+
+**Files:**
+- Modify: `tests/responses-handler.test.ts`
+
+- [ ] **Step 1: Import Responses utils dependency override**
+
+In `tests/responses-handler.test.ts`, extend the top-level `Promise.all` import tuple from:
+
+```ts
+const [
+  { accountsManager },
+  { getAdminDb },
+  { state },
+  { setModelMappings, setProviderConfig },
+  { responsesRoutes },
+] = await Promise.all([
+  import("~/lib/accounts-manager"),
+  import("~/lib/admin-db"),
+  import("~/lib/state"),
+  import("~/lib/config"),
+  import("~/routes/responses/route"),
+])
+```
+
+to:
+
+```ts
+const [
+  { accountsManager },
+  { getAdminDb },
+  { state },
+  { setModelMappings, setProviderConfig },
+  { responsesRoutes },
+  { responsesUtilsDependencies },
+] = await Promise.all([
+  import("~/lib/accounts-manager"),
+  import("~/lib/admin-db"),
+  import("~/lib/state"),
+  import("~/lib/config"),
+  import("~/routes/responses/route"),
+  import("~/routes/responses/utils"),
+])
+```
+
+After the existing `originalMarkFailed` constant, add originals for the dependency hooks:
+
+```ts
+const originalContextManagementEnabled =
+  responsesUtilsDependencies.isResponsesApiContextManagementEnabled
+const originalModelCompactThreshold =
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold
+```
+
+In `afterEach()`, restore them:
+
+```ts
+afterEach(() => {
+  fetchHolder.fetch = originalFetch
+  accountsManager.selectAccountForRequest = originalSelect
+  accountsManager.finalizeQuota = originalFinalize
+  accountsManager.markAccountFailed = originalMarkFailed
+
+  responsesUtilsDependencies.isResponsesApiContextManagementEnabled =
+    originalContextManagementEnabled
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold =
+    originalModelCompactThreshold
+
+  setModelMappings({})
+  setProviderConfig("acme", { enabled: false })
+})
+```
+
+- [ ] **Step 2: Add runtime tests**
+
+Inside the existing `describe("responses handler context management", () => { ... })`, after the current compact threshold test, add:
+
+```ts
+test("does not add context_management when disabled", async () => {
+  responsesUtilsDependencies.isResponsesApiContextManagementEnabled = () => false
+
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/responses", "gpt-5.4"))
+
+  let forwardedPayload: ResponsesPayload | undefined
+  const fetchMock = mock((_url: string, options?: FetchOptions) => {
+    forwardedPayload = JSON.parse(options?.body as string) as ResponsesPayload
+    return Promise.resolve(
+      new Response(JSON.stringify(buildResponsesResult("gpt-5.4", "ok")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  })
+
+  // @ts-expect-error test mock only implements the used subset
+  fetchHolder.fetch = fetchMock
+
+  const response = await responsesRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4",
+        input: "hello",
+      }),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect(forwardedPayload?.context_management).toBeUndefined()
+})
+
+test("preserves request-provided context_management", async () => {
+  responsesUtilsDependencies.isResponsesApiContextManagementEnabled = () => true
+
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/responses", "gpt-5.4"))
+
+  let forwardedPayload: ResponsesPayload | undefined
+  const fetchMock = mock((_url: string, options?: FetchOptions) => {
+    forwardedPayload = JSON.parse(options?.body as string) as ResponsesPayload
+    return Promise.resolve(
+      new Response(JSON.stringify(buildResponsesResult("gpt-5.4", "ok")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  })
+
+  // @ts-expect-error test mock only implements the used subset
+  fetchHolder.fetch = fetchMock
+
+  const contextManagement = [
+    {
+      type: "compaction" as const,
+      compact_threshold: 12345,
+    },
+  ]
+
+  const response = await responsesRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4",
+        input: "hello",
+        context_management: contextManagement,
+      }),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect(forwardedPayload?.context_management).toEqual(contextManagement)
+})
+```
+
+- [ ] **Step 3: Run Responses handler tests**
+
+Run:
+
+```bash
+bun test tests/responses-handler.test.ts
+```
+
+Expected:
+
+- PASS for existing responses handler tests.
+- PASS for the new disabled and preserve-request tests.
+
+If TypeScript rejects the `contextManagement` literal shape, inline the array directly in `JSON.stringify()` and assert the numeric threshold:
+
+```ts
+expect(forwardedPayload?.context_management?.[0]?.compact_threshold).toBe(12345)
+```
+
+---
+
+## Task 3: Frontend Admin API type and save whitelist include the new field
+
+**Files:**
+- Modify: `admin-ui/src/lib/admin-api.ts`
+
+- [ ] **Step 1: Add frontend config type field**
+
+In `admin-ui/src/lib/admin-api.ts`, update `AdminConfig` near the existing Responses API fields:
+
+```ts
+export type AdminConfig = {
+  auth?: {
+    apiKeys?: Array<string>
+  }
+  providers?: Record<string, ProviderConfig>
+  extraPrompts?: Record<string, string>
+  smallModel?: string
+  accountAffinity?: boolean
+  /** @deprecated */
+  apiKey?: string
+  anthropicApiKey?: string
+  /** @deprecated use useResponsesApiContextManagement */
+  responsesApiContextManagementModels?: Array<string>
+  useResponsesApiContextManagement?: boolean
+  modelReasoningEfforts?: Record<string, ReasoningEffort>
+  modelResponsesApiCompactThresholds?: Record<string, number>
+  modelAliases?: Record<string, ModelAliasSpec | string>
+  allowOriginalModelNamesForAliases?: boolean
+  forceAgent?: boolean
+  compactUseSmallModel?: boolean
+  messageStartInputTokensFallback?: boolean
+  modelRefreshIntervalHours?: number
+  sessionAffinityRetentionDays?: number
+  useMessagesApi?: boolean
+  useResponsesApiWebSocket?: boolean
+  useResponsesApiWebSearch?: boolean
+}
+```
+
+- [ ] **Step 2: Add field to frontend POST whitelist**
+
+Update `ADMIN_CONFIG_KEYS`:
+
+```ts
+const ADMIN_CONFIG_KEYS = new Set<keyof AdminConfig>([
+  "auth",
+  "providers",
+  "extraPrompts",
+  "smallModel",
+  "accountAffinity",
+  "apiKey",
+  "anthropicApiKey",
+  "responsesApiContextManagementModels",
+  "useResponsesApiContextManagement",
+  "modelReasoningEfforts",
+  "modelResponsesApiCompactThresholds",
+  "modelAliases",
+  "allowOriginalModelNamesForAliases",
+  "forceAgent",
+  "compactUseSmallModel",
+  "messageStartInputTokensFallback",
+  "modelRefreshIntervalHours",
+  "sessionAffinityRetentionDays",
+  "useMessagesApi",
+  "useResponsesApiWebSocket",
+  "useResponsesApiWebSearch",
+])
+```
+
+- [ ] **Step 3: Run admin-ui typecheck**
+
+Run:
+
+```bash
+bun run typecheck:admin
+```
+
+Expected:
+
+- PASS.
+- If later UI tasks are not implemented yet, this task should still pass because the type only adds an optional field.
+
+---
+
+## Task 4: Add `ResponsesApiSettingsCard` and move Responses API controls out of Advanced
+
+**Files:**
+- Modify: `admin-ui/src/pages/settings-page.tsx`
+
+- [ ] **Step 1: Add the section id**
+
+Update `SETTINGS_SECTION_IDS`:
+
+```ts
+const SETTINGS_SECTION_IDS = [
+  "general",
+  "reasoning",
+  "responsesApi",
+  "aliases",
+  "prompts",
+  "advanced",
+  "providers",
+  "devMode",
+] as const
+```
+
+Remove `"compactThresholds"` from this list because compact thresholds move under Responses API.
+
+- [ ] **Step 2: Extend `CompactThresholdsCard` props for inactive context**
+
+Update `CompactThresholdsCardProps`:
+
+```ts
+type CompactThresholdsCardProps = {
+  mode: JsonMode
+  json: string
+  jsonIssue: string | null
+  items: Array<CompactThresholdItem>
+  models: Array<string>
+  contextManagementEnabled?: boolean
+  embedded?: boolean
+  onToggleMode: (next: boolean) => void
+  onJsonChange: (value: string) => void
+  onAddItem: () => void
+  onRemoveItem: (id: string) => void
+  onUpdateItem: (id: string, patch: Partial<CompactThresholdItem>) => void
+}
+```
+
+Update the function signature:
+
+```ts
+function CompactThresholdsCard({
+  mode,
+  json,
+  jsonIssue,
+  items,
+  models,
+  contextManagementEnabled = true,
+  embedded = false,
+  onToggleMode,
+  onJsonChange,
+  onAddItem,
+  onRemoveItem,
+  onUpdateItem,
+}: CompactThresholdsCardProps): React.JSX.Element {
+```
+
+Inside the return, change the wrapper from a hard-coded `Card` to a conditional wrapper. Replace:
+
+```tsx
+return (
+  <Card className="gap-4 py-4">
+    <CardHeader className="px-4">
+      <CardTitle>{t("settingsPage.compactThresholds.title")}</CardTitle>
+      <CardDescription className="hidden sm:block">
+        {t("settingsPage.compactThresholds.description")}
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-3 px-4">
+      ...
+    </CardContent>
+  </Card>
+)
+```
+
+with this structure:
+
+```tsx
+const content = (
+  <>
+    {!contextManagementEnabled ? (
+      <InlineAlert
+        variant="warning"
+        title={t("settingsPage.responsesApi.contextManagementInactiveTitle")}
+        description={t("settingsPage.responsesApi.compactThresholdsInactiveHint")}
+      />
+    ) : null}
+    <div className="flex items-center justify-between gap-3">
+      <div className="text-muted-foreground text-xs">
+        {t("settingsPage.compactThresholds.hint")}
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch checked={mode === "json"} onCheckedChange={onToggleMode} />
+        <Label className="text-muted-foreground text-xs">
+          {t("settingsPage.common.jsonMode")}
+        </Label>
+      </div>
+    </div>
+
+    {mode === "json" ? (
+      <div className="space-y-2">
+        <Textarea
+          value={json}
+          onChange={(e) => onJsonChange(e.target.value)}
+          className="min-h-[160px] lg:min-h-[120px] max-h-[36vh] overflow-auto font-mono text-xs"
+          placeholder={t("settingsPage.compactThresholds.jsonPlaceholder")}
+        />
+        {jsonIssue ? (
+          <InlineAlert
+            variant="warning"
+            title={t("settingsPage.common.invalidJsonTitle")}
+            description={jsonIssue}
+          />
+        ) : null}
+      </div>
+    ) : (
+      <div className="space-y-2">
+        {/* keep the existing form-mode body unchanged */}
+      </div>
+    )}
+  </>
+)
+
+if (embedded) {
+  return <div className="space-y-3">{content}</div>
+}
+
+return (
+  <Card className="gap-4 py-4">
+    <CardHeader className="px-4">
+      <CardTitle>{t("settingsPage.compactThresholds.title")}</CardTitle>
+      <CardDescription className="hidden sm:block">
+        {t("settingsPage.compactThresholds.description")}
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-3 px-4">{content}</CardContent>
+  </Card>
+)
+```
+
+When applying this step, move the existing form-mode body exactly as-is into the `content` fragment. Do not rewrite validation logic.
+
+- [ ] **Step 3: Add `ResponsesApiSettingsCard` props and component**
+
+Place this after `CompactThresholdsCard` and before `ExtraPromptsCard`:
+
+```ts
+type ResponsesApiSettingsCardProps = {
+  useResponsesApiWebSocket: boolean
+  useResponsesApiWebSearch: boolean
+  useResponsesApiContextManagement: boolean
+  responsesApiContextManagementModelsValue: string
+  compactThresholdsMode: JsonMode
+  compactThresholdsJson: string
+  compactThresholdsJsonIssue: string | null
+  compactThresholdsItems: Array<CompactThresholdItem>
+  models: Array<string>
+  onToggleUseResponsesApiWebSocket: (value: boolean) => void
+  onToggleUseResponsesApiWebSearch: (value: boolean) => void
+  onToggleUseResponsesApiContextManagement: (value: boolean) => void
+  onResponsesApiContextManagementModelsChange: (value: string) => void
+  onCompactThresholdsToggleMode: (next: boolean) => void
+  onCompactThresholdsJsonChange: (value: string) => void
+  onCompactThresholdsAddItem: () => void
+  onCompactThresholdsRemoveItem: (id: string) => void
+  onCompactThresholdsUpdateItem: (
+    id: string,
+    patch: Partial<CompactThresholdItem>,
+  ) => void
+}
+
+export function ResponsesApiSettingsCard({
+  useResponsesApiWebSocket,
+  useResponsesApiWebSearch,
+  useResponsesApiContextManagement,
+  responsesApiContextManagementModelsValue,
+  compactThresholdsMode,
+  compactThresholdsJson,
+  compactThresholdsJsonIssue,
+  compactThresholdsItems,
+  models,
+  onToggleUseResponsesApiWebSocket,
+  onToggleUseResponsesApiWebSearch,
+  onToggleUseResponsesApiContextManagement,
+  onResponsesApiContextManagementModelsChange,
+  onCompactThresholdsToggleMode,
+  onCompactThresholdsJsonChange,
+  onCompactThresholdsAddItem,
+  onCompactThresholdsRemoveItem,
+  onCompactThresholdsUpdateItem,
+}: ResponsesApiSettingsCardProps): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card className="gap-4 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>{t("settingsPage.responsesApi.title")}</CardTitle>
+        <CardDescription className="hidden sm:block">
+          {t("settingsPage.responsesApi.description")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 px-4">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {t("settingsPage.responsesApi.transportGroupTitle")}
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.responsesApi.useResponsesApiWebSocketLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.useResponsesApiWebSocketHint")}
+            </div>
+          </div>
+          <Switch
+            checked={useResponsesApiWebSocket}
+            onCheckedChange={onToggleUseResponsesApiWebSocket}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.responsesApi.useResponsesApiWebSearchLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.useResponsesApiWebSearchHint")}
+            </div>
+          </div>
+          <Switch
+            checked={useResponsesApiWebSearch}
+            onCheckedChange={onToggleUseResponsesApiWebSearch}
+          />
+        </div>
+
+        <hr className="border-t" />
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {t("settingsPage.responsesApi.contextManagementGroupTitle")}
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.responsesApi.useResponsesApiContextManagementLabel")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.useResponsesApiContextManagementHint")}
+            </div>
+          </div>
+          <Switch
+            checked={useResponsesApiContextManagement}
+            onCheckedChange={onToggleUseResponsesApiContextManagement}
+          />
+        </div>
+
+        <div className="rounded-lg border p-3 space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settingsPage.compactThresholds.title")}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.compactThresholds.description")}
+            </div>
+          </div>
+          <CompactThresholdsCard
+            embedded
+            contextManagementEnabled={useResponsesApiContextManagement}
+            mode={compactThresholdsMode}
+            json={compactThresholdsJson}
+            jsonIssue={compactThresholdsJsonIssue}
+            items={compactThresholdsItems}
+            models={models}
+            onToggleMode={onCompactThresholdsToggleMode}
+            onJsonChange={onCompactThresholdsJsonChange}
+            onAddItem={onCompactThresholdsAddItem}
+            onRemoveItem={onCompactThresholdsRemoveItem}
+            onUpdateItem={onCompactThresholdsUpdateItem}
+          />
+        </div>
+
+        <hr className="border-t" />
+        <div className="grid gap-2 rounded-lg border border-dashed p-3">
+          <div className="space-y-1">
+            <Label className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.responsesApiContextManagementModelsLabel")}
+            </Label>
+            <div className="text-muted-foreground text-xs">
+              {t("settingsPage.responsesApi.responsesApiContextManagementModelsDeprecatedHint")}
+            </div>
+            {!useResponsesApiContextManagement ? (
+              <div className="text-muted-foreground text-xs">
+                {t("settingsPage.responsesApi.contextManagementInactiveHint")}
+              </div>
+            ) : null}
+          </div>
+          <Textarea
+            autoComplete="off"
+            placeholder={t(
+              "settingsPage.responsesApi.responsesApiContextManagementModelsPlaceholder",
+            )}
+            value={responsesApiContextManagementModelsValue}
+            onChange={(e) =>
+              onResponsesApiContextManagementModelsChange(e.target.value)
+            }
+            className="min-h-[96px] font-mono text-xs"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 4: Remove Responses API props from `AdvancedSettingsCard`**
+
+In `AdvancedSettingsCardProps`, remove these fields:
+
+```ts
+useResponsesApiWebSocket: boolean
+useResponsesApiWebSearch: boolean
+responsesApiContextManagementModelsValue: string
+onToggleUseResponsesApiWebSocket: (value: boolean) => void
+onToggleUseResponsesApiWebSearch: (value: boolean) => void
+onResponsesApiContextManagementModelsChange: (value: string) => void
+```
+
+In `AdvancedSettingsCard` parameters, remove the same names.
+
+In the JSX body, remove the two switch blocks for:
+
+- `settingsPage.advanced.useResponsesApiWebSocketLabel`
+- `settingsPage.advanced.useResponsesApiWebSearchLabel`
+
+Remove the textarea block for:
+
+- `settingsPage.advanced.responsesApiContextManagementModelsLabel`
+
+Keep `useMessagesApi` in Advanced.
+
+- [ ] **Step 5: Extend `SettingsPageViewProps` and state return values**
+
+In `SettingsPageViewProps`, add:
+
+```ts
+useResponsesApiContextManagement: boolean
+onUseResponsesApiContextManagementToggle: (value: boolean) => void
+```
+
+Keep existing compact threshold props; they will now feed `ResponsesApiSettingsCard` instead of the standalone section.
+
+In `useSettingsPageState()`, after existing `handleUseResponsesApiWebSearchToggle`, add:
+
+```ts
+const handleUseResponsesApiContextManagementToggle = useCallback(
+  (value: boolean) => {
+    setDraft((prev) => ({ ...prev, useResponsesApiContextManagement: value }))
+  },
+  [setDraft],
+)
+```
+
+Near other derived booleans, add:
+
+```ts
+const useResponsesApiContextManagement =
+  draft.useResponsesApiContextManagement ?? true
+```
+
+In the returned object, add:
+
+```ts
+useResponsesApiContextManagement,
+onUseResponsesApiContextManagementToggle:
+  handleUseResponsesApiContextManagementToggle,
+```
+
+- [ ] **Step 6: Render the new section**
+
+Update `sections` in `SettingsPageView`:
+
+```ts
+const sections = useMemo<Array<SettingsSection>>(() => {
+  return [
+    { id: "general", label: t("settingsPage.sections.general") },
+    { id: "reasoning", label: t("settingsPage.sections.reasoning") },
+    { id: "responsesApi", label: t("settingsPage.sections.responsesApi") },
+    { id: "aliases", label: t("settingsPage.sections.aliases") },
+    { id: "prompts", label: t("settingsPage.sections.prompts") },
+    { id: "advanced", label: t("settingsPage.sections.advanced") },
+    { id: "providers", label: t("settingsPage.sections.providers") },
+    { id: "devMode", label: t("settingsPage.sections.devMode") },
+  ]
+}, [t])
+```
+
+Replace the standalone `CompactThresholds` `SettingsSectionCard` block with a new `Responses API` section:
+
+```tsx
+{/* Responses API */}
+<SettingsSectionCard
+  id="responsesApi"
+  isActive={activeSection === "responsesApi"}
+  ref={(el) => registerSection("responsesApi", el)}
+  style={{ animationDelay: "90ms" }}
+>
+  <ResponsesApiSettingsCard
+    useResponsesApiWebSocket={useResponsesApiWebSocket}
+    useResponsesApiWebSearch={useResponsesApiWebSearch}
+    useResponsesApiContextManagement={useResponsesApiContextManagement}
+    responsesApiContextManagementModelsValue={
+      responsesApiContextManagementModelsValue
+    }
+    compactThresholdsMode={compactThresholdsMode}
+    compactThresholdsJson={compactThresholdsJson}
+    compactThresholdsJsonIssue={compactThresholdsJsonIssue}
+    compactThresholdsItems={compactThresholdsItems}
+    models={models}
+    onToggleUseResponsesApiWebSocket={onUseResponsesApiWebSocketToggle}
+    onToggleUseResponsesApiWebSearch={onUseResponsesApiWebSearchToggle}
+    onToggleUseResponsesApiContextManagement={
+      onUseResponsesApiContextManagementToggle
+    }
+    onResponsesApiContextManagementModelsChange={
+      onResponsesApiContextManagementModelsChange
+    }
+    onCompactThresholdsToggleMode={onCompactThresholdsToggleMode}
+    onCompactThresholdsJsonChange={onCompactThresholdsJsonChange}
+    onCompactThresholdsAddItem={onCompactThresholdsAddItem}
+    onCompactThresholdsRemoveItem={onCompactThresholdsRemoveItem}
+    onCompactThresholdsUpdateItem={onCompactThresholdsUpdateItem}
+  />
+</SettingsSectionCard>
+```
+
+Update the `AdvancedSettingsCard` call to remove Responses API props and callbacks.
+
+- [ ] **Step 7: Run admin-ui typecheck to reveal wiring mistakes**
+
+Run:
+
+```bash
+bun run typecheck:admin
+```
+
+Expected before locale/test updates:
+
+- Typecheck should pass or only report missing destructured props if a wiring step was missed.
+- Fix any missing prop/destructure errors before continuing.
+
+---
+
+## Task 5: Add i18n copy for Responses API section
+
+**Files:**
+- Modify: `admin-ui/src/locales/en-US.json`
+- Modify: `admin-ui/src/locales/zh-CN.json`
+
+- [ ] **Step 1: Add section label in English**
+
+In `admin-ui/src/locales/en-US.json`, under `settingsPage.sections`, change the section block from including `compactThresholds` to including `responsesApi`:
+
+```json
+"sections": {
+  "general": "General",
+  "reasoning": "Reasoning",
+  "responsesApi": "Responses API",
+  "aliases": "Aliases",
+  "prompts": "Prompts",
+  "advanced": "Advanced",
+  "providers": "Providers",
+  "devMode": "Dev Mode"
+}
+```
+
+- [ ] **Step 2: Add English Responses API copy**
+
+In the same `settingsPage` object, add a new sibling object before `advanced`:
+
+```json
+"responsesApi": {
+  "title": "Responses API",
+  "description": "Configure Responses API transport, web tools, and context management.",
+  "transportGroupTitle": "Transport",
+  "contextManagementGroupTitle": "Context management",
+  "useResponsesApiWebSocketLabel": "Enable Responses API WebSocket",
+  "useResponsesApiWebSocketHint": "When enabled, models advertising ws:/responses use Copilot's WebSocket transport; HTTP remains available for /responses-only models.",
+  "useResponsesApiWebSearchLabel": "Enable Responses API WebSearch",
+  "useResponsesApiWebSearchHint": "When enabled, /v1/responses keeps web_search tools and forwards them upstream.",
+  "useResponsesApiContextManagementLabel": "Enable Responses API context management",
+  "useResponsesApiContextManagementHint": "Default: enabled. When enabled, the proxy automatically adds context_management compaction instructions for long Responses API tasks.",
+  "contextManagementInactiveTitle": "Context management is disabled",
+  "contextManagementInactiveHint": "This legacy list is saved but does not take effect while context management is disabled.",
+  "compactThresholdsInactiveHint": "Compact threshold overrides are saved but do not take effect while context management is disabled.",
+  "responsesApiContextManagementModelsLabel": "Legacy context management models",
+  "responsesApiContextManagementModelsPlaceholder": "one model id per line",
+  "responsesApiContextManagementModelsDeprecatedHint": "Deprecated legacy allowlist. Prefer the global Responses API context management switch."
+}
+```
+
+Keep existing `settingsPage.compactThresholds` copy because `CompactThresholdsCard` still uses it.
+
+- [ ] **Step 3: Add section label in Chinese**
+
+In `admin-ui/src/locales/zh-CN.json`, under `settingsPage.sections`, use:
+
+```json
+"sections": {
+  "general": "通用",
+  "reasoning": "推理强度",
+  "responsesApi": "Responses API",
+  "aliases": "别名",
+  "prompts": "提示词",
+  "advanced": "高级",
+  "providers": "Providers",
+  "devMode": "开发者模式"
+}
+```
+
+- [ ] **Step 4: Add Chinese Responses API copy**
+
+Add a new sibling object before `advanced`:
+
+```json
+"responsesApi": {
+  "title": "Responses API",
+  "description": "配置 Responses API transport、web 工具和上下文管理。",
+  "transportGroupTitle": "Transport",
+  "contextManagementGroupTitle": "上下文管理",
+  "useResponsesApiWebSocketLabel": "启用 Responses API WebSocket",
+  "useResponsesApiWebSocketHint": "启用后，声明 ws:/responses 的模型会使用 Copilot WebSocket transport；仅支持 /responses 的模型仍走 HTTP。",
+  "useResponsesApiWebSearchLabel": "启用 Responses API WebSearch",
+  "useResponsesApiWebSearchHint": "启用后，/v1/responses 会保留 web_search 工具并继续向上游转发。",
+  "useResponsesApiContextManagementLabel": "启用 Responses API 上下文管理",
+  "useResponsesApiContextManagementHint": "默认启用。启用后，代理会为长任务自动附加 context_management 压缩指令。",
+  "contextManagementInactiveTitle": "上下文管理已关闭",
+  "contextManagementInactiveHint": "该旧模型列表会被保存，但在上下文管理关闭时不会生效。",
+  "compactThresholdsInactiveHint": "压缩阈值覆盖会被保存，但在上下文管理关闭时不会生效。",
+  "responsesApiContextManagementModelsLabel": "旧版上下文管理模型",
+  "responsesApiContextManagementModelsPlaceholder": "每行一个 model id",
+  "responsesApiContextManagementModelsDeprecatedHint": "已弃用的旧 allowlist。推荐使用全局 Responses API 上下文管理开关。"
+}
+```
+
+Keep existing `settingsPage.advanced.useResponsesApi*` keys until a later cleanup pass if they are no longer referenced. Removing unused locale keys is optional and not required for this implementation.
+
+- [ ] **Step 5: Validate JSON and typecheck**
+
+Run:
+
+```bash
+bun run typecheck:admin
+```
+
+Expected:
+
+- PASS.
+- If JSON syntax is invalid, TypeScript/Vite import will fail; fix commas and object placement.
+
+---
+
+## Task 6: Update settings page tests for the new Responses API card
+
+**Files:**
+- Modify: `admin-ui/tests/settings-page.test.tsx`
+
+- [ ] **Step 1: Replace import**
+
+Change:
+
+```ts
+import { AdvancedSettingsCard } from "../src/pages/settings-page"
+```
+
+to:
+
+```ts
+import { ResponsesApiSettingsCard } from "../src/pages/settings-page"
+```
+
+- [ ] **Step 2: Replace the existing test with Responses API card tests**
+
+Replace the file body after imports with:
+
+```ts
+test("Responses API settings exposes transport toggles and context management", () => {
+  const html = renderToStaticMarkup(
+    <ResponsesApiSettingsCard
+      useResponsesApiContextManagement
+      useResponsesApiWebSearch
+      useResponsesApiWebSocket={false}
+      responsesApiContextManagementModelsValue=""
+      compactThresholdsMode="form"
+      compactThresholdsJson="{}"
+      compactThresholdsJsonIssue={null}
+      compactThresholdsItems={[]}
+      models={[]}
+      onCompactThresholdsAddItem={() => {}}
+      onCompactThresholdsJsonChange={() => {}}
+      onCompactThresholdsRemoveItem={() => {}}
+      onCompactThresholdsToggleMode={() => {}}
+      onCompactThresholdsUpdateItem={() => {}}
+      onResponsesApiContextManagementModelsChange={() => {}}
+      onToggleUseResponsesApiContextManagement={() => {}}
+      onToggleUseResponsesApiWebSearch={() => {}}
+      onToggleUseResponsesApiWebSocket={() => {}}
+    />,
+  )
+
+  expect(html).toContain("Enable Responses API WebSocket")
+  expect(html).toContain("ws:/responses")
+  expect(html).toContain("Enable Responses API context management")
+  expect(html).toContain("Default: enabled")
+  expect(html).toContain("Legacy context management models")
+  expect(html).toContain('aria-checked="false"')
+})
+
+test("Responses API settings marks dependent fields inactive when context management is off", () => {
+  const html = renderToStaticMarkup(
+    <ResponsesApiSettingsCard
+      useResponsesApiContextManagement={false}
+      useResponsesApiWebSearch
+      useResponsesApiWebSocket
+      responsesApiContextManagementModelsValue="gpt-5.4"
+      compactThresholdsMode="form"
+      compactThresholdsJson="{}"
+      compactThresholdsJsonIssue={null}
+      compactThresholdsItems={[]}
+      models={[]}
+      onCompactThresholdsAddItem={() => {}}
+      onCompactThresholdsJsonChange={() => {}}
+      onCompactThresholdsRemoveItem={() => {}}
+      onCompactThresholdsToggleMode={() => {}}
+      onCompactThresholdsUpdateItem={() => {}}
+      onResponsesApiContextManagementModelsChange={() => {}}
+      onToggleUseResponsesApiContextManagement={() => {}}
+      onToggleUseResponsesApiWebSearch={() => {}}
+      onToggleUseResponsesApiWebSocket={() => {}}
+    />,
+  )
+
+  expect(html).toContain("Context management is disabled")
+  expect(html).toContain("Compact threshold overrides are saved")
+  expect(html).toContain("gpt-5.4")
+}
+```
+
+- [ ] **Step 3: Run the settings page test**
+
+Run:
+
+```bash
+bun test admin-ui/tests/settings-page.test.tsx
+```
+
+Expected:
+
+- PASS.
+
+If the test fails because i18next returns keys instead of English text, ensure `admin-ui/tests/settings-page.test.tsx` is still loading the project i18n setup through component imports. If it still returns keys, assert against key strings such as `settingsPage.responsesApi.title`; do not mock i18n in this plan.
+
+---
+
+## Task 7: Full targeted verification and cleanup
+
+**Files:**
+- Inspect all modified files.
+- No new source files required.
+
+- [ ] **Step 1: Run backend targeted tests**
+
+Run:
+
+```bash
+bun test tests/admin-config.test.ts tests/responses-handler.test.ts
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 2: Run frontend targeted test**
+
+Run:
+
+```bash
+bun test admin-ui/tests/settings-page.test.tsx
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 3: Run typechecks**
+
+Run:
+
+```bash
+bun run typecheck
+bun run typecheck:admin
+```
+
+Expected:
+
+- Both PASS.
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```bash
+bun run lint
+bun run lint:admin
+```
+
+Expected:
+
+- Both PASS or auto-fix-free lint success.
+- If lint reports formatting issues, run the repository’s established lint/fix command only for the affected scope, then rerun lint.
+
+- [ ] **Step 5: Inspect diff for scope control**
+
+Run:
+
+```bash
+git diff -- src/routes/admin-api/route.ts tests/admin-config.test.ts tests/responses-handler.test.ts admin-ui/src/lib/admin-api.ts admin-ui/src/pages/settings-page.tsx admin-ui/src/locales/en-US.json admin-ui/src/locales/zh-CN.json admin-ui/tests/settings-page.test.tsx docs/superpowers/plans/2026-06-06-admin-ui-settings-page-optimization.md docs/superpowers/plans/2026-06-06-admin-ui-settings-page-optimization-implementation.md
+```
+
+Expected:
+
+- Diff only touches planned files plus the two plan documents.
+- No unrelated refactor.
+- No deletion of deprecated config support.
+- No git commit unless the user explicitly asks.
+
+- [ ] **Step 6: Final report**
+
+Report:
+
+- Files changed.
+- Tests and checks run with pass/fail status.
+- Any skipped checks with reason.
+- Whether `useResponsesApiContextManagement` is now configurable from Admin-UI.
+
+Do not claim completion unless all selected verification commands pass.
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- `useResponsesApiContextManagement` Admin API support: Task 1.
+- Runtime enabled/disabled behavior: Task 2.
+- Frontend type and POST whitelist: Task 3.
+- Responses API section and card: Task 4.
+- Default/deprecated/inactive copy: Task 5.
+- Frontend card rendering tests: Task 6.
+- Verification and scope control: Task 7.
+
+### Placeholder scan
+
+This plan contains no unresolved placeholder markers. The only optional note is the explicit fallback for i18n test behavior, with a concrete alternative assertion.
+
+### Type consistency
+
+- Field name is consistently `useResponsesApiContextManagement`.
+- Section id is consistently `responsesApi`.
+- Component name is consistently `ResponsesApiSettingsCard`.
+- Existing `modelResponsesApiCompactThresholds` remains represented by `CompactThresholdsCard` state props.

--- a/docs/superpowers/plans/2026-06-06-admin-ui-settings-page-optimization.md
+++ b/docs/superpowers/plans/2026-06-06-admin-ui-settings-page-optimization.md
@@ -1,0 +1,289 @@
+# Admin-UI 设置页优化设计
+
+## 背景
+
+Admin-UI 设置页已经承载多类配置：基础鉴权、小模型、推理强度、Responses API compact threshold、模型别名、extra prompts、Providers、Dev Mode 和高级选项。近期新增的 `useResponsesApiContextManagement` 已在后端运行时配置中存在，并默认启用，但没有完整接入 Admin-UI 与 Admin API 写入链路；旧字段 `responsesApiContextManagementModels` 虽已标记为 deprecated，却仍然暴露在 Advanced 设置中。
+
+本设计选择分阶段综合优化：先修复配置完整性，再重组 Responses API 领域配置，最后补齐安全可用性细节。目标是在不重写整个设置页的前提下，降低配置遗漏、误用和信息架构膨胀的风险。
+
+## 目标
+
+1. 让 `useResponsesApiContextManagement` 能在 Admin-UI 中查看、编辑并保存。
+2. 将 Responses API 相关配置集中到独立 section，避免继续扩张 `AdvancedSettingsCard`。
+3. 保留 deprecated 配置的兼容性，同时通过 UI 文案降低误用概率。
+4. 明确默认值、生效状态和依赖关系，减少用户误判。
+5. 用 targeted tests 覆盖前端、后端和运行时关键路径。
+
+## 非目标
+
+本轮不做以下事项：
+
+- 不做全量 schema-driven 设置页。
+- 不重写整个 `SettingsPage` 状态管理。
+- 不引入新的表单库。
+- 不自动迁移或删除 deprecated 配置。
+- 不改变 runtime context management 的默认行为。
+- 不新增全局“恢复所有默认值”功能。
+
+## 方案选择
+
+采用 **分阶段综合优化**。
+
+备选方案包括：
+
+- 快速补丁：只在 Advanced 中新增 `useResponsesApiContextManagement` 开关。优点是改动最小，缺点是 Advanced 继续膨胀，Responses API 字段仍分散。
+- 深度重构：将设置页改成 schema-driven。优点是长期最稳，缺点是范围过大，会延后当前配置缺口修复。
+
+推荐方案先解决当前缺口，再逐步改善信息架构，符合 KISS 和 YAGNI。
+
+## 信息架构
+
+### Phase 1：配置完整性
+
+补齐 `useResponsesApiContextManagement` 的完整配置链路：
+
+- 后端 Admin API 允许读取、写入、清除该字段。
+- 前端 `AdminConfig` 类型包含该字段。
+- 前端提交白名单包含该字段，避免 `updateAdminConfig()` 过滤。
+- 设置页提供 Switch 控件。
+- i18n 文案覆盖中英文。
+- 测试覆盖保存、清除和无效输入。
+
+`responsesApiContextManagementModels` 保留，但标记为 legacy/deprecated。
+
+### Phase 2：Responses API 独立分组
+
+新增 **Responses API** section，将下列字段集中展示：
+
+- `useResponsesApiWebSocket`
+- `useResponsesApiWebSearch`
+- `useResponsesApiContextManagement`
+- `modelResponsesApiCompactThresholds`
+- `responsesApiContextManagementModels`（Legacy / deprecated）
+
+`AdvancedSettingsCard` 保留跨领域和低频选项，例如：
+
+- `accountAffinity`
+- `allowOriginalModelNamesForAliases`
+- `forceAgent`
+- `compactUseSmallModel`
+- `messageStartInputTokensFallback`
+- `modelRefreshIntervalHours`
+- `sessionAffinityRetentionDays`
+- `useMessagesApi`
+
+### Phase 3：安全可用性增强
+
+补齐以下交互细节：
+
+- 显示默认值与当前有效值，尤其是默认启用的布尔配置。
+- 对 deprecated 字段使用折叠区域或 warning copy。
+- 当 `useResponsesApiContextManagement === false` 时，compact thresholds 与 legacy model list 保留值但提示不生效。
+- 对清空覆盖值使用现有语义，不自动删除用户已有旧配置。
+
+## 组件设计
+
+### `ResponsesApiSettingsCard`
+
+新增组件，职责限定为 `/v1/responses` 相关配置。
+
+建议分组：
+
+1. Transport
+   - `useResponsesApiWebSocket`
+   - `useResponsesApiWebSearch`
+2. Context Management
+   - `useResponsesApiContextManagement`
+   - `modelResponsesApiCompactThresholds`
+3. Legacy / Deprecated
+   - `responsesApiContextManagementModels`
+
+该组件不负责加载/保存，只通过 props 接收状态和回调，保持与现有 card 模式一致。
+
+### `AdvancedSettingsCard`
+
+移除 Responses API 专属字段，保留跨领域高级配置。这样可以降低单个 card 的职责范围，并避免后续新增 Responses API 字段时继续堆入 Advanced。
+
+### `useSettingsPageState`
+
+短期保留现有集中状态管理模式，只新增必要状态派生和 handler。长期如果设置页继续增长，再考虑把 Responses API 状态和转换逻辑抽成专用 hook。
+
+新增派生值：
+
+```ts
+const useResponsesApiContextManagement =
+  draft.useResponsesApiContextManagement ?? true
+```
+
+新增切换 handler：
+
+```ts
+const handleUseResponsesApiContextManagementToggle = useCallback(
+  (value: boolean) => {
+    setDraft((prev) => ({ ...prev, useResponsesApiContextManagement: value }))
+  },
+  [setDraft],
+)
+```
+
+## 数据流
+
+完整链路如下：
+
+```text
+src/lib/config.ts
+  ↓
+src/routes/admin-api/route.ts
+  ↓
+admin-ui/src/lib/admin-api.ts
+  ↓
+admin-ui/src/pages/settings-page.tsx
+  ↓
+tests
+```
+
+### 后端 Admin API
+
+在 `src/routes/admin-api/route.ts` 中补齐：
+
+- `CONFIG_KEYS` 加入 `useResponsesApiContextManagement`。
+- `CONFIG_PATCH_HANDLERS` 使用现有 `applyOptionalBoolean(next, "useResponsesApiContextManagement", value)` 模式。
+
+语义：
+
+- `true` / `false`：显式保存用户覆盖值。
+- `null` / `undefined`：删除用户覆盖值，回到默认 `true`。
+- 非 boolean：返回 400，错误信息包含字段名。
+
+### 前端 Admin API
+
+在 `admin-ui/src/lib/admin-api.ts` 中补齐：
+
+- `AdminConfig.useResponsesApiContextManagement?: boolean`
+- `ADMIN_CONFIG_KEYS` 加入 `useResponsesApiContextManagement`
+
+这样 UI draft 中的字段不会在提交前被过滤。
+
+### 设置页
+
+新增 `ResponsesApiSettingsCard` 后，`SettingsPageView` 传入：
+
+- `useResponsesApiWebSocket`
+- `useResponsesApiWebSearch`
+- `useResponsesApiContextManagement`
+- `responsesApiContextManagementModelsValue`
+- compact thresholds editor 相关 props
+- 对应 toggle/change handlers
+
+`AdvancedSettingsCard` 删除这些 Responses API 专属 props。
+
+## 交互规则
+
+### `useResponsesApiContextManagement`
+
+- 使用 Switch。
+- 默认值为 `true`。
+- 文案说明开启后代理会自动附加 `context_management` 压缩指令。
+- UI 显示默认行为，避免用户误解未配置为关闭。
+
+### `modelResponsesApiCompactThresholds`
+
+- 保留现有 key-value / JSON 双模式编辑器。
+- 迁移到 Responses API section。
+- 当 context management 关闭时：
+  - 不删除已有值。
+  - 可以禁用编辑器，或保持可编辑但显示“不生效”提示。
+  - MVP 推荐保持可编辑并显示 warning，避免 disabled 状态阻止用户预先配置。
+
+### `responsesApiContextManagementModels`
+
+- 保留 textarea。
+- 放入 Legacy / Deprecated 区域。
+- 文案明确：该字段已弃用，推荐使用全局开关。
+- 当 context management 关闭时，显示该配置当前不生效。
+
+## 错误处理
+
+### 前端
+
+- 保存失败继续使用现有 `AdminApiError` 和 toast 机制。
+- `responsesApiContextManagementModels` 保留现有解析：trim、去重、忽略空行。
+- `modelResponsesApiCompactThresholds` 保留现有校验：model id 非空，threshold 为正有限数字。
+- Context management 关闭不会触发校验错误，也不会清空已有配置。
+
+### 后端
+
+- 使用统一 boolean parser。
+- 无效类型返回 400。
+- 不自动迁移 deprecated 字段。
+- 不改变默认运行时行为。
+
+## 测试策略
+
+### Admin API tests
+
+覆盖：
+
+- POST `{ useResponsesApiContextManagement: false }` 返回 false。
+- POST `{ useResponsesApiContextManagement: true }` 返回 true。
+- POST `{ useResponsesApiContextManagement: null }` 清除覆盖后返回默认 true。
+- POST 非 boolean 返回 400。
+
+### Settings page tests
+
+覆盖：
+
+- 渲染 Responses API section。
+- Context management Switch 显示默认启用。
+- 切换后页面变 dirty。
+- 保存 payload 包含 `useResponsesApiContextManagement`。
+- Deprecated legacy textarea 仍可编辑。
+
+### Runtime behavior tests
+
+覆盖：
+
+- 默认或显式 true 时，Responses API payload 自动带 `context_management`。
+- 显式 false 时，不自动附加 `context_management`。
+- 请求本身已有 `context_management` 时不覆盖。
+
+### 质量检查
+
+按改动范围执行：
+
+```bash
+bun test tests/admin-config.test.ts tests/responses-handler.test.ts
+bun run lint
+bun run typecheck
+```
+
+如果前端测试覆盖设置页，则额外运行对应 Admin-UI 测试命令。
+
+## 实施顺序
+
+1. 后端 Admin API 支持 `useResponsesApiContextManagement`。
+2. 前端 Admin API 类型与提交白名单补齐。
+3. 设置页新增 `ResponsesApiSettingsCard` 并迁移 Responses API 字段。
+4. 更新中英文 i18n 文案。
+5. 补充 targeted tests。
+6. 执行验证命令并修复问题。
+
+## 风险与缓解
+
+- 风险：前端显示字段但提交被过滤。
+  - 缓解：同步更新 `AdminConfig` 和 `ADMIN_CONFIG_KEYS`，并用测试覆盖保存 payload。
+- 风险：后端接受字段但运行时默认行为变化。
+  - 缓解：保留 `config.useResponsesApiContextManagement ?? true` 语义，并加 runtime tests。
+- 风险：迁移 UI 分组导致用户找不到旧配置。
+  - 缓解：Responses API section 明确包含 Legacy / Deprecated 区域，不删除字段。
+- 风险：设置页文件继续膨胀。
+  - 缓解：新增职责明确的 `ResponsesApiSettingsCard`，后续再考虑 hook 拆分。
+
+## 验收标准
+
+1. Admin-UI 中能看到并切换 `useResponsesApiContextManagement`。
+2. 保存后配置文件中的显式 true/false 能正确反映用户选择。
+3. 清除覆盖值后回到默认启用。
+4. Responses API 相关字段集中在独立 section。
+5. Deprecated 字段有清晰提示且仍能编辑。
+6. Targeted tests、lint 和 typecheck 按改动范围通过。

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -199,6 +199,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "useMessagesApi",
   "useResponsesApiWebSocket",
   "useResponsesApiWebSearch",
+  "useResponsesApiContextManagement",
   "devMode",
   "quotaRefresh",
 ])
@@ -899,7 +900,8 @@ function applyOptionalBoolean(
     | "useResponsesApiWebSearch"
     | "compactUseSmallModel"
     | "messageStartInputTokensFallback"
-    | "allowOriginalModelNamesForAliases",
+    | "allowOriginalModelNamesForAliases"
+    | "useResponsesApiContextManagement",
   value: unknown,
 ): string | undefined {
   const parsed = parseOptionalBoolean(value, key)
@@ -1158,6 +1160,8 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
     applyOptionalBoolean(next, "useResponsesApiWebSocket", value),
   useResponsesApiWebSearch: (next, value) =>
     applyOptionalBoolean(next, "useResponsesApiWebSearch", value),
+  useResponsesApiContextManagement: (next, value) =>
+    applyOptionalBoolean(next, "useResponsesApiContextManagement", value),
   devMode: applyDevModeConfig,
   quotaRefresh: applyQuotaRefreshConfig,
 }
@@ -1213,9 +1217,16 @@ adminApiRoutes.get("/meta", (c) => {
   return c.json(store.meta())
 })
 
+function applyAdminConfigResponseDefaults(config: AppConfig): AppConfig {
+  if (typeof config.useResponsesApiContextManagement === "boolean") {
+    return config
+  }
+  return { ...config, useResponsesApiContextManagement: true }
+}
+
 adminApiRoutes.get("/config", (c) => {
   try {
-    const config = mergeConfigWithDefaults()
+    const config = applyAdminConfigResponseDefaults(mergeConfigWithDefaults())
     return c.json({ ...config, _configPath: PATHS.CONFIG_PATH })
   } catch {
     return jsonError(c, 500, {
@@ -1253,7 +1264,7 @@ adminApiRoutes.post("/config", async (c) => {
 
   try {
     await writeConfigFile(result.config)
-    const merged = mergeConfigWithDefaults()
+    const merged = applyAdminConfigResponseDefaults(mergeConfigWithDefaults())
     accountsManager.setAccountAffinityEnabled(isAccountAffinityEnabled())
     accountsManager.setModelsRefreshIntervalMs(getModelRefreshIntervalMs())
     updateQuotaRefreshSchedulerFromConfig()

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -749,6 +749,78 @@ test("POST /api/admin/config refreshes the running quota scheduler config", asyn
   })
 })
 
+test("POST /api/admin/config updates useResponsesApiContextManagement to false then true", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res1 = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ useResponsesApiContextManagement: false }),
+      }),
+    )
+    expect(res1.status).toBe(200)
+    const body1 = (await res1.json()) as {
+      useResponsesApiContextManagement?: boolean
+    }
+    expect(body1.useResponsesApiContextManagement).toBe(false)
+
+    const res2 = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ useResponsesApiContextManagement: true }),
+      }),
+    )
+    expect(res2.status).toBe(200)
+    const body2 = (await res2.json()) as {
+      useResponsesApiContextManagement?: boolean
+    }
+    expect(body2.useResponsesApiContextManagement).toBe(true)
+  })
+})
+
+test("POST /api/admin/config clears useResponsesApiContextManagement to default", async () => {
+  await withConfig({ useResponsesApiContextManagement: false }, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ useResponsesApiContextManagement: null }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      useResponsesApiContextManagement?: boolean
+    }
+    expect(body.useResponsesApiContextManagement).toBe(true)
+  })
+})
+
+test("POST /api/admin/config rejects non-boolean useResponsesApiContextManagement", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ useResponsesApiContextManagement: "false" }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain(
+      "useResponsesApiContextManagement must be a boolean",
+    )
+  })
+})
+
 test("POST /api/admin/config rejects invalid quotaRefresh fields", async () => {
   await withConfig({}, async () => {
     const { server } = await import("../src/server")

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -12,12 +12,14 @@ const [
   { state },
   { setModelMappings, setProviderConfig },
   { responsesRoutes },
+  { responsesUtilsDependencies },
 ] = await Promise.all([
   import("~/lib/accounts-manager"),
   import("~/lib/admin-db"),
   import("~/lib/state"),
   import("~/lib/config"),
   import("~/routes/responses/route"),
+  import("~/routes/responses/utils"),
 ])
 
 type SelectionResult = Awaited<
@@ -37,6 +39,10 @@ const originalSelect =
 const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
 const originalMarkFailed =
   accountsManager.markAccountFailed.bind(accountsManager)
+const originalContextManagementEnabled =
+  responsesUtilsDependencies.isResponsesApiContextManagementEnabled
+const originalModelCompactThreshold =
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold
 
 function buildAccount(): AccountRuntime {
   return {
@@ -153,6 +159,11 @@ afterEach(() => {
   accountsManager.selectAccountForRequest = originalSelect
   accountsManager.finalizeQuota = originalFinalize
   accountsManager.markAccountFailed = originalMarkFailed
+
+  responsesUtilsDependencies.isResponsesApiContextManagementEnabled =
+    originalContextManagementEnabled
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold =
+    originalModelCompactThreshold
 
   setModelMappings({})
   setProviderConfig("acme", { enabled: false })
@@ -325,6 +336,86 @@ describe("responses handler context management", () => {
         compact_threshold: 217600,
       },
     ])
+  })
+
+  test("does not add context_management when disabled", async () => {
+    responsesUtilsDependencies.isResponsesApiContextManagementEnabled = () =>
+      false
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "gpt-5.4"))
+
+    let forwardedPayload: ResponsesPayload | undefined
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      forwardedPayload = JSON.parse(options?.body as string) as ResponsesPayload
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-5.4", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.4",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(forwardedPayload?.context_management).toBeUndefined()
+  })
+
+  test("preserves request-provided context_management", async () => {
+    responsesUtilsDependencies.isResponsesApiContextManagementEnabled = () =>
+      true
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "gpt-5.4"))
+
+    let forwardedPayload: ResponsesPayload | undefined
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      forwardedPayload = JSON.parse(options?.body as string) as ResponsesPayload
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-5.4", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.4",
+          input: "hello",
+          context_management: [
+            {
+              type: "compaction",
+              compact_threshold: 12345,
+            },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(forwardedPayload?.context_management?.[0]?.compact_threshold).toBe(
+      12345,
+    )
   })
 })
 


### PR DESCRIPTION
## Summary
- add Admin API read/write support for useResponsesApiContextManagement
- move Responses API settings into a dedicated Admin UI section with context-management, compact-threshold, and legacy allowlist controls
- cover Admin API, Responses runtime behavior, and settings page rendering with tests

## Test Plan
- [x] bun test tests/admin-config.test.ts tests/responses-handler.test.ts
- [x] bun test ./admin-ui/tests/settings-page.test.tsx
- [x] bun run typecheck:admin
- [x] bun run typecheck
- [x] bun run lint
- [x] bun run lint:admin
- [x] bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在管理员面板中新增"Responses API"设置区域
  * 新增上下文管理配置选项，用于控制 API 响应行为
  
* **改进**
  * 优化设置页布局，改进配置项的组织结构
  * 更新中文和英文本地化文案

<!-- end of auto-generated comment: release notes by coderabbit.ai -->