### PR TITLE
fix(admin): allow compact threshold config updates

### DIFF
--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -954,17 +954,21 @@ function parseModelResponsesApiCompactThresholds(
 
   const record = Object.create(null) as Record<string, number>
   for (const [rawModel, threshold] of Object.entries(value)) {
-    if (BLOCKED_KEYS.has(rawModel)) {
-      return {
-        error: `modelResponsesApiCompactThresholds.${rawModel} is not allowed`,
-      }
-    }
-
     const model = rawModel.trim()
     if (!model) {
       return {
         error:
           "modelResponsesApiCompactThresholds keys must be non-empty strings",
+      }
+    }
+    if (BLOCKED_KEYS.has(model)) {
+      return {
+        error: `modelResponsesApiCompactThresholds.${model} is not allowed`,
+      }
+    }
+    if (Object.hasOwn(record, model)) {
+      return {
+        error: `modelResponsesApiCompactThresholds.${rawModel} conflicts with normalized key "${model}"`,
       }
     }
     if (typeof threshold !== "number") {

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -189,6 +189,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "providers",
   "responsesApiContextManagementModels",
   "modelReasoningEfforts",
+  "modelResponsesApiCompactThresholds",
   "modelAliases",
   "allowOriginalModelNamesForAliases",
   "forceAgent",
@@ -943,6 +944,46 @@ function applyExtraPrompts(
   return undefined
 }
 
+function parseModelResponsesApiCompactThresholds(
+  value: unknown,
+): ParseFieldResult<Record<string, number>> {
+  if (value === null || value === undefined) return { clear: true }
+  if (!isPlainObject(value)) {
+    return { error: "modelResponsesApiCompactThresholds must be an object" }
+  }
+
+  const record = Object.create(null) as Record<string, number>
+  for (const [rawModel, threshold] of Object.entries(value)) {
+    if (BLOCKED_KEYS.has(rawModel)) {
+      return {
+        error: `modelResponsesApiCompactThresholds.${rawModel} is not allowed`,
+      }
+    }
+
+    const model = rawModel.trim()
+    if (!model) {
+      return {
+        error:
+          "modelResponsesApiCompactThresholds keys must be non-empty strings",
+      }
+    }
+    if (typeof threshold !== "number") {
+      return {
+        error: `modelResponsesApiCompactThresholds.${rawModel} must be a number`,
+      }
+    }
+    if (!Number.isFinite(threshold) || threshold <= 0) {
+      return {
+        error: `modelResponsesApiCompactThresholds.${rawModel} must be a positive finite number`,
+      }
+    }
+
+    record[model] = threshold
+  }
+
+  return { value: record }
+}
+
 function applyReasoningEfforts(
   next: AppConfig,
   value: unknown,
@@ -954,6 +995,20 @@ function applyReasoningEfforts(
     return undefined
   }
   next.modelReasoningEfforts = parsed.value
+  return undefined
+}
+
+function applyModelResponsesApiCompactThresholds(
+  next: AppConfig,
+  value: unknown,
+): string | undefined {
+  const parsed = parseModelResponsesApiCompactThresholds(value)
+  if ("error" in parsed) return parsed.error
+  if ("clear" in parsed) {
+    delete next.modelResponsesApiCompactThresholds
+    return undefined
+  }
+  next.modelResponsesApiCompactThresholds = parsed.value
   return undefined
 }
 
@@ -1142,6 +1197,7 @@ const CONFIG_PATCH_HANDLERS: Partial<Record<string, ConfigPatchHandler>> = {
   providers: applyProvidersConfig,
   responsesApiContextManagementModels: applyResponsesApiContextManagementModels,
   modelReasoningEfforts: applyReasoningEfforts,
+  modelResponsesApiCompactThresholds: applyModelResponsesApiCompactThresholds,
   modelAliases: applyModelAliases,
   allowOriginalModelNamesForAliases: (next, value) =>
     applyOptionalBoolean(next, "allowOriginalModelNamesForAliases", value),

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -310,6 +310,97 @@ test("POST /api/admin/config rejects invalid responsesApiContextManagementModels
   })
 })
 
+test("POST /api/admin/config updates modelResponsesApiCompactThresholds", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          modelResponsesApiCompactThresholds: {
+            "gpt-5.4": 123456,
+            "gpt-5.5": 217600,
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      modelResponsesApiCompactThresholds?: Record<string, number>
+    }
+    expect(body.modelResponsesApiCompactThresholds).toEqual({
+      "gpt-5.4": 123456,
+      "gpt-5.5": 217600,
+    })
+  })
+})
+
+test("POST /api/admin/config clears modelResponsesApiCompactThresholds", async () => {
+  await withConfig(
+    {
+      modelResponsesApiCompactThresholds: {
+        "gpt-5.4": 123456,
+      },
+    },
+    async () => {
+      const { server } = await import("../src/server")
+
+      const res = await server.fetch(
+        new Request("http://localhost/api/admin/config", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ modelResponsesApiCompactThresholds: null }),
+        }),
+      )
+
+      expect(res.status).toBe(200)
+
+      const body = (await res.json()) as {
+        modelResponsesApiCompactThresholds?: Record<string, number>
+      }
+      expect(body.modelResponsesApiCompactThresholds).toEqual({
+        "gpt-5.4": 217600,
+        "gpt-5.5": 217600,
+      })
+    },
+  )
+})
+
+test("POST /api/admin/config rejects invalid modelResponsesApiCompactThresholds entries", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          modelResponsesApiCompactThresholds: {
+            "gpt-5.4": -1,
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toBe(
+      "modelResponsesApiCompactThresholds.gpt-5.4 must be a positive finite number",
+    )
+  })
+})
+
 test("POST /api/admin/config updates providers", async () => {
   await withConfig({}, async () => {
     const { server } = await import("../src/server")

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -401,6 +401,61 @@ test("POST /api/admin/config rejects invalid modelResponsesApiCompactThresholds 
   })
 })
 
+test("POST /api/admin/config rejects blocked normalized modelResponsesApiCompactThresholds keys", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          modelResponsesApiCompactThresholds: {
+            " __proto__ ": 123456,
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toBe(
+      "modelResponsesApiCompactThresholds.__proto__ is not allowed",
+    )
+  })
+})
+
+test("POST /api/admin/config rejects conflicting normalized modelResponsesApiCompactThresholds entries", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          modelResponsesApiCompactThresholds: {
+            "gpt-5.4": 123456,
+            " gpt-5.4 ": 217600,
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(400)
+
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain(
+      'conflicts with normalized key "gpt-5.4"',
+    )
+  })
+})
+
 test("POST /api/admin/config updates providers", async () => {
   await withConfig({}, async () => {
     const { server } = await import("../src/server")


### PR DESCRIPTION
## Summary
- allow `/api/admin/config` to update `modelResponsesApiCompactThresholds`
- validate compact threshold payloads before writing config
- add Admin Config API regression tests for save, clear, and invalid thresholds

## Test Plan
- [x] `bun test tests/admin-config.test.ts tests/builtin-provider-config.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加对模型响应API紧凑阈值的配置支持，允许为不同模型设置阈值参数。

* **测试**
  * 新增配置接口测试用例，覆盖阈值设置、清空及验证场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->