### PR TITLE
fix: strip Codex turn-id passthrough field that hangs v0.142.x Responses requests

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -81,6 +81,7 @@ export const handleResponses = async (c: Context) => {
       `Resolved model mapping: ${requestedModel} -> ${payload.model}`,
     )
   }
+  stripInternalChatMetadataPassthrough(payload)
 
   const providerModelAlias = parseProviderModelAlias(payload.model)
   if (providerModelAlias) {
@@ -108,7 +109,6 @@ export const handleResponses = async (c: Context) => {
   if (!isResponsesApiWebSearchEnabled()) {
     removeWebSearchTool(payload)
   }
-  stripInternalChatMetadataPassthrough(payload)
   compactInputByLatestCompaction(payload)
 
   const streamRequested = Boolean(payload.stream)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -61,6 +61,7 @@ import {
   isAsyncIterable,
   removeWebSearchTool,
   sanitizeOversizedInputImages,
+  stripInternalChatMetadataPassthrough,
 } from "./utils"
 import consola from "consola"
 
@@ -107,6 +108,7 @@ export const handleResponses = async (c: Context) => {
   if (!isResponsesApiWebSearchEnabled()) {
     removeWebSearchTool(payload)
   }
+  stripInternalChatMetadataPassthrough(payload)
   compactInputByLatestCompaction(payload)
 
   const streamRequested = Boolean(payload.stream)

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -410,6 +410,30 @@ export const removeWebSearchTool = (payload: ResponsesPayload): void => {
   })
 }
 
+// Codex (>= v0.142.x) stamps every Responses input item with this field to
+// carry a turn id. GitHub Copilot's upstream `/responses` endpoint rejects
+// unknown parameters, so the request fails with a `bad_request` error
+// ("Unknown parameter: ..."). Strip it from each input item before forwarding
+// upstream.
+export const INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY =
+  "internal_chat_message_metadata_passthrough"
+
+export const stripInternalChatMetadataPassthrough = (
+  payload: ResponsesPayload,
+): void => {
+  if (!Array.isArray(payload.input) || payload.input.length === 0) return
+
+  for (const item of payload.input) {
+    if (
+      typeof item === "object"
+      && item !== null
+      && INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY in item
+    ) {
+      delete item[INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY]
+    }
+  }
+}
+
 type StreamChunk = {
   id?: string
   event?: string

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -30,7 +30,7 @@ const [
   { state },
   { setModelMappings, setProviderConfig },
   { responsesRoutes },
-  { responsesUtilsDependencies },
+  { INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY, responsesUtilsDependencies },
 ] = await Promise.all([
   import("~/lib/accounts-manager"),
   import("~/lib/admin-db"),
@@ -329,6 +329,68 @@ describe("responses handler provider alias routing", () => {
     })
 
     setProviderConfig("acme", { enabled: false })
+  })
+
+  test("strips Codex internal chat metadata before forwarding provider aliases", async () => {
+    setProviderConfig("acme", {
+      type: "openai-responses",
+      enabled: true,
+      baseUrl: "https://acme.example.com",
+      apiKey: "acme-key",
+      authType: "authorization",
+    })
+
+    let providerForwardedPayload: ResponsesPayload | undefined
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      providerForwardedPayload = JSON.parse(
+        options?.body as string,
+      ) as ResponsesPayload
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("gpt-acme", "from acme")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "acme/gpt-acme",
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "hello" }],
+              [INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY]: {
+                turn_id: "turn-provider",
+              },
+            },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(providerForwardedPayload?.model).toBe("gpt-acme")
+
+    const forwardedInput = providerForwardedPayload?.input as Array<
+      Record<string, unknown>
+    >
+    expect(INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY in forwardedInput[0]).toBe(
+      false,
+    )
+    expect(forwardedInput[0].content).toEqual([
+      { type: "input_text", text: "hello" },
+    ])
   })
 })
 

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -703,3 +703,68 @@ describe("responses handler oversized image sanitization", () => {
     ).toBe(true)
   })
 })
+
+describe("responses handler Codex internal chat metadata stripping", () => {
+  test("strips internal_chat_message_metadata_passthrough from every input item before forwarding upstream", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "gpt-5.5"))
+
+    let forwardedPayload: ResponsesPayload | undefined
+    const fetchMock = mock((_url: string, options?: FetchOptions) => {
+      forwardedPayload = JSON.parse(options?.body as string) as ResponsesPayload
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-5.5", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    // Mirrors a Codex >= v0.142.x turn payload: each input item carries the
+    // turn-id passthrough field that GitHub Copilot's upstream rejects.
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.5",
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "test message" }],
+              internal_chat_message_metadata_passthrough: {
+                turn_id: "turn-1",
+              },
+            },
+            {
+              type: "function_call",
+              call_id: "call-1",
+              name: "shell",
+              arguments: "{}",
+              internal_chat_message_metadata_passthrough: {
+                turn_id: "turn-1",
+              },
+            },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+
+    const forwardedInput = forwardedPayload?.input as Array<
+      Record<string, unknown>
+    >
+    expect(Array.isArray(forwardedInput)).toBe(true)
+    for (const item of forwardedInput) {
+      expect("internal_chat_message_metadata_passthrough" in item).toBe(false)
+    }
+    // Real content survives the strip.
+    expect(forwardedInput[0].role).toBe("user")
+    expect(forwardedInput[1].name).toBe("shell")
+  })
+})

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
 
 import "./shared-admin-db-test-home"
 
@@ -28,7 +30,8 @@ const [
   { accountsManager },
   { getAdminDb },
   { state },
-  { setModelMappings, setProviderConfig },
+  { mergeConfigWithDefaults, setModelMappings, setProviderConfig },
+  { PATHS },
   { responsesRoutes },
   { INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY, responsesUtilsDependencies },
 ] = await Promise.all([
@@ -36,6 +39,7 @@ const [
   import("~/lib/admin-db"),
   import("~/lib/state"),
   import("~/lib/config"),
+  import("~/lib/paths"),
   import("~/routes/responses/route"),
   import("~/routes/responses/utils"),
 ])
@@ -61,6 +65,20 @@ const originalContextManagementEnabled =
   responsesUtilsDependencies.isResponsesApiContextManagementEnabled
 const originalModelCompactThreshold =
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold
+let configBeforeTest: string | null | undefined
+
+const readConfigText = async (): Promise<string | null> =>
+  await fs.readFile(PATHS.CONFIG_PATH, "utf8").catch(() => null)
+
+const restoreConfigText = async (configText: string | null): Promise<void> => {
+  if (configText === null) {
+    await fs.rm(PATHS.CONFIG_PATH, { force: true })
+  } else {
+    await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+    await fs.writeFile(PATHS.CONFIG_PATH, configText, "utf8")
+  }
+  mergeConfigWithDefaults()
+}
 
 function buildAccount(): AccountRuntime {
   return {
@@ -159,7 +177,9 @@ function buildResponsesResult(model: string, text: string) {
   }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  configBeforeTest = await readConfigText()
+
   providerUsageRecords.length = 0
 
   state.manualApprove = false
@@ -174,7 +194,7 @@ beforeEach(() => {
   setModelMappings({})
 })
 
-afterEach(() => {
+afterEach(async () => {
   fetchHolder.fetch = originalFetch
   accountsManager.selectAccountForRequest = originalSelect
   accountsManager.finalizeQuota = originalFinalize
@@ -185,8 +205,10 @@ afterEach(() => {
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold =
     originalModelCompactThreshold
 
-  setModelMappings({})
-  setProviderConfig("acme", { enabled: false })
+  if (configBeforeTest !== undefined) {
+    await restoreConfigText(configBeforeTest)
+    configBeforeTest = undefined
+  }
 })
 
 describe("responses handler model mapping", () => {
@@ -327,8 +349,6 @@ describe("responses handler provider alias routing", () => {
       output_tokens: 1,
       total_tokens: 2,
     })
-
-    setProviderConfig("acme", { enabled: false })
   })
 
   test("strips Codex internal chat metadata before forwarding provider aliases", async () => {

--- a/tests/responses-strip-internal-chat-metadata.test.ts
+++ b/tests/responses-strip-internal-chat-metadata.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test"
+
+import type { ResponsesPayload } from "~/services/copilot/create-responses"
+
+import {
+  INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY,
+  stripInternalChatMetadataPassthrough,
+} from "~/routes/responses/utils"
+
+const KEY = INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY
+
+const makePayload = (input: ResponsesPayload["input"]): ResponsesPayload => ({
+  model: "gpt-5",
+  input,
+})
+
+describe("stripInternalChatMetadataPassthrough", () => {
+  it("strips the field from a single input item", () => {
+    const payload = makePayload([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+        [KEY]: { turn_id: "abc" },
+      },
+    ] as ResponsesPayload["input"])
+
+    stripInternalChatMetadataPassthrough(payload)
+
+    const item = (payload.input as Array<Record<string, unknown>>)[0]
+    expect(KEY in item).toBe(false)
+    // Other fields are preserved.
+    expect(item.type).toBe("message")
+    expect(item.role).toBe("user")
+    expect(item.content).toEqual([{ type: "input_text", text: "hi" }])
+  })
+
+  it("strips the field from multiple, mixed item types", () => {
+    const payload = makePayload([
+      {
+        type: "message",
+        role: "user",
+        content: "one",
+        [KEY]: { turn_id: "t1" },
+      },
+      {
+        type: "function_call",
+        call_id: "c1",
+        name: "foo",
+        arguments: "{}",
+        [KEY]: { turn_id: "t1" },
+      },
+      {
+        type: "function_call_output",
+        call_id: "c1",
+        output: "ok",
+        [KEY]: { turn_id: "t1" },
+      },
+    ] as ResponsesPayload["input"])
+
+    stripInternalChatMetadataPassthrough(payload)
+
+    for (const item of payload.input as Array<Record<string, unknown>>) {
+      expect(KEY in item).toBe(false)
+    }
+    // Sanity: structural fields survive on each item.
+    const items = payload.input as Array<Record<string, unknown>>
+    expect(items[1].name).toBe("foo")
+    expect(items[2].output).toBe("ok")
+  })
+
+  it("leaves other fields and items without the key untouched", () => {
+    const payload = makePayload([
+      { type: "message", role: "user", content: "no-field" },
+      { type: "message", role: "assistant", content: "also-none" },
+    ] as ResponsesPayload["input"])
+
+    stripInternalChatMetadataPassthrough(payload)
+
+    expect(payload.input).toEqual([
+      { type: "message", role: "user", content: "no-field" },
+      { type: "message", role: "assistant", content: "also-none" },
+    ] as ResponsesPayload["input"])
+  })
+
+  it("does not recurse into nested content", () => {
+    const payload = makePayload([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "hi",
+            // A same-named key nested in content must NOT be stripped: only
+            // top-level item metadata is rejected by upstream.
+            [KEY]: { turn_id: "nested" },
+          },
+        ],
+        [KEY]: { turn_id: "top" },
+      },
+    ] as ResponsesPayload["input"])
+
+    stripInternalChatMetadataPassthrough(payload)
+
+    const item = (payload.input as Array<Record<string, unknown>>)[0]
+    expect(KEY in item).toBe(false)
+    const content = item.content as Array<Record<string, unknown>>
+    expect(KEY in content[0]).toBe(true)
+  })
+
+  it("is a no-op when input is missing", () => {
+    const payload = { model: "gpt-5" } as unknown as ResponsesPayload
+    expect(() => stripInternalChatMetadataPassthrough(payload)).not.toThrow()
+    expect(payload.input).toBeUndefined()
+  })
+
+  it("is a no-op when input is a string", () => {
+    const payload = makePayload("just a string")
+    stripInternalChatMetadataPassthrough(payload)
+    expect(payload.input).toBe("just a string")
+  })
+
+  it("is a no-op when input is an empty array", () => {
+    const payload = makePayload([] as ResponsesPayload["input"])
+    stripInternalChatMetadataPassthrough(payload)
+    expect(payload.input).toEqual([] as ResponsesPayload["input"])
+  })
+
+  it("ignores non-object entries inside input", () => {
+    const payload = makePayload([
+      null,
+      "weird",
+      { type: "message", role: "user", content: "x", [KEY]: { turn_id: "t" } },
+    ] as unknown as ResponsesPayload["input"])
+
+    expect(() => stripInternalChatMetadataPassthrough(payload)).not.toThrow()
+
+    const items = payload.input as Array<unknown>
+    expect(items[0]).toBeNull()
+    expect(items[1]).toBe("weird")
+    expect(KEY in (items[2] as Record<string, unknown>)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

This PR fixes a **hard hang on every Codex CLI turn** introduced by Codex `>= v0.142.x`. Codex now stamps every Responses **input item** with an `internal_chat_message_metadata_passthrough` field. GitHub Copilot's upstream rejects the unknown parameter, thus Codex never recovers from the resulting error frame, thus the request hangs indefinitely. This PR strips that field from each input item before the request is forwarded upstream, at the same sanitizer choke point already used for other Codex-compatibility scrubbing.

Fixes #98.

## Why

Starting with Codex `v0.142.x`, a chat session pointed at `copilot-api` hangs forever on the very first message:

```text
> test message


• Working (23s • esc to interrupt)
```

The same setup works on older `v0.13x` builds. The regression is independent of OS / shell — reproduced on Windows (PowerShell 7), WSL (Arch/zsh), and a separate Linux machine pointed at the same proxy over LAN.

## Root cause

Codex `v0.142.x` began stamping a turn id onto **every** Responses input item:

```jsonc
{
  "type": "message",
  "role": "user",
  "content": [{ "type": "input_text", "text": "test message" }],
  "internal_chat_message_metadata_passthrough": { "turn_id": "..." }
}
```

GitHub Copilot's upstream `/responses` endpoint validates parameters strictly and rejects the unknown field, replying with an error frame:

```json
{ "type": "error", "error": { "code": "bad_request", "message": "Unknown parameter: 'input[0].internal_chat_message_metadata_passthrough'." } }
```

Two things then combine into the hang:

1. **Upstream rejects the request** because the field is not a recognized parameter.
2. **Codex does not treat the upstream `error` frame as terminal**. It logs `unhandled responses event: error` and keeps waiting on a stream that will never produce a `response.completed`, so the turn deadlocks.


### How it was traced

- Codex trace logs (`~/.codex/logs_2.sqlite`) showed the real turn request followed immediately by the `bad_request` error frame above and an `unhandled responses event: error` line, then silence.
- Dumping the outgoing payload confirmed **every** input item carried `internal_chat_message_metadata_passthrough: { turn_id }`.
- Cross-referencing Codex history, the field is emitted unconditionally starting in the stable `rust-v0.142.x` line (`skip_serializing_if = Option::is_none`, but always populated for a turn) — matching the reported timeline.
- **Reproduced directly against the live proxy:** an otherwise-identical request **with** the field returns the exact `bad_request` every time; **without** it returns `200` every time, for both streaming and non-streaming. A top-level `client_metadata` object is accepted — the per-input field is the sole blocker.

## The fix

Add a small sanitizer that removes `internal_chat_message_metadata_passthrough` from each Responses input item, mirroring the existing `removeWebSearchTool` / `removeUnsupportedTools` scrubbers:

- **`src/routes/responses/utils.ts`**: new exported `stripInternalChatMetadataPassthrough(payload)` plus an exported `INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY` constant. It guards on `Array.isArray(payload.input)`, iterates input items, and deletes the key from each object entry. Acts as a no-op when `input` is missing, a string, or empty, and it ignores non-object entries. It does **not** recurse into nested `content`, so legitimate message content is left untouched.
- **`src/routes/responses/handler.ts`**: call the sanitizer once on the incoming `payload`, right after `removeWebSearchTool` and before `compactInputByLatestCompaction`. `handleResponses` is the single source of truth for **both** transports — the HTTP `POST /responses` path and the Codex WebSocket bridge, which re-POSTs `response.create` frames back through this same handler — so one strip covers Codex's preferred WebSocket transport and the HTTP fallback alike. (`upstreamPayload` is later built as a shallow copy that shares the same `input` array reference, so it's covered by this same call.)

WebSocket warmup frames (`generate: false`) short-circuit in the bridge before reaching the handler and carry no input items, so they need no change.

## What changed

- **`src/routes/responses/utils.ts`** — add `INTERNAL_CHAT_METADATA_PASSTHROUGH_KEY` + `stripInternalChatMetadataPassthrough`.
- **`src/routes/responses/handler.ts`** — wire the sanitizer into the pre-flight scrub path.
- **`tests/responses-strip-internal-chat-metadata.test.ts`** *(new)* — unit coverage for the sanitizer.
- **`tests/responses-handler.test.ts`** — handler-level regression test.

## Testing

```sh
bun run typecheck   # clean
bun run lint        # clean (changed files)
bun test tests/responses-handler.test.ts tests/responses-strip-internal-chat-metadata.test.ts   # 20 pass, 0 fail
```

Coverage for this change:

- `tests/responses-strip-internal-chat-metadata.test.ts` (8): strips the field from a single item, from multiple mixed item types (message / function_call), preserves other fields and items without the key, does **not** recurse into nested content, and is a no-op for missing / string / empty input and non-object entries.
- `tests/responses-handler.test.ts` (1 new): posts a Codex-shaped turn (each input item carrying `internal_chat_message_metadata_passthrough: { turn_id }`) through the real handler, asserts a `200`, and asserts the field is gone from **every** forwarded input item while the real content survives.

Also verified end-to-end against the live proxy: the previously-hanging request now returns normally once the field is stripped.

> The full `bun test` run shows some failures that are **pre-existing and unrelated** — they reproduce on the base branch without this change and are order-dependent (each affected file passes in isolation), e.g. the long-standing date-dependent `getConsumptionFromSnapshots computes daily consumption from remaining deltas`.

## A note on this approach and future patches

Stripping one field invites the obvious question: do we just keep adding band-aid fixes every time Codex adds a field? 

A more "friendly" alternative might be to let the request fail and retry after parsing the offending field out of the upstream error, but that means firing a request we expect to be rejected on every turn. We obviously don't want to send bad traffic purposefully, so deliberately emitting `bad_request` traffic upstream cuts against that idea (unless we implement some sort of dynamic behavior, which adds significant complexity).

If broader hardening is wanted (e.g. an allow-list for OpenAI-internal passthrough fields, or a single "source of truth" for what should and should not be allowed to get passed to the copilot servers), I think that's worth its own discussion rather than bundling it here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加对 Responses 请求中“内部聊天元数据透传”的自动清理，在转发前移除未知字段，提升上游兼容性与成功率。
* **Bug 修复**
  * 现在会在 provider 路由与最终转发前剔除该透传字段，确保消息内容与函数调用等业务字段保持不变。
* **测试**
  * 扩展单元与转发断言：覆盖 message / function_call、多种异常与空值场景，并验证嵌套内容不被误删。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->