### PR TITLE
[codex] record copilot aiu usage

### DIFF
--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -284,6 +284,13 @@ export function mergeCopilotAiuUsage(
   usage: UsageTokens,
   copilotUsage: CopilotAiuUsage | null | undefined,
 ): UsageTokens {
+  if (
+    copilotUsage?.total_nano_aiu === undefined
+    || copilotUsage.total_nano_aiu === null
+  ) {
+    return usage
+  }
+
   return {
     ...usage,
     ...normalizeCopilotAiuUsage(copilotUsage),

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -75,6 +75,10 @@ type ProviderTokenUsageRecorderOptions = Omit<
   "source"
 >
 
+export interface CopilotAiuUsage {
+  total_nano_aiu?: number | null
+}
+
 interface TokenUsageEventMap {
   "token_usage.recorded": PersistedTokenUsageEvent
 }
@@ -265,6 +269,24 @@ export function normalizeResponsesUsage(
     input_tokens: Math.max(0, inputTokens - cachedTokens),
     output_tokens: normalizeToken(usage?.output_tokens),
     total_tokens: normalizeOptionalToken(usage?.total_tokens),
+  }
+}
+
+export function normalizeCopilotAiuUsage(
+  usage: CopilotAiuUsage | null | undefined,
+): UsageTokens {
+  return {
+    total_nano_aiu: normalizeOptionalToken(usage?.total_nano_aiu),
+  }
+}
+
+export function mergeCopilotAiuUsage(
+  usage: UsageTokens,
+  copilotUsage: CopilotAiuUsage | null | undefined,
+): UsageTokens {
+  return {
+    ...usage,
+    ...normalizeCopilotAiuUsage(copilotUsage),
   }
 }
 

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -30,6 +30,7 @@ import { getTokenCount } from "~/lib/tokenizer"
 import {
   createCopilotTokenUsageRecorder,
   mergeCopilotAiuUsage,
+  normalizeCopilotAiuUsage,
   normalizeOpenAIUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -654,7 +655,7 @@ async function streamChatCompletionsAndLog(params: {
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
-  let tokenUsage: UsageTokens = {}
+  let tokenUsage: UsageTokens | undefined
   let errorName: string | undefined
   let errorStatus: number | undefined
   let errorMessage: string | undefined
@@ -671,9 +672,12 @@ async function streamChatCompletionsAndLog(params: {
       const usage = await extractUsageFromChunk(chunk)
       if (usage?.requestHistoryUsage) {
         lastUsage = usage.requestHistoryUsage
-      }
-      if (usage?.tokenUsage) {
         tokenUsage = usage.tokenUsage
+      } else if (usage?.tokenUsage) {
+        tokenUsage = {
+          ...(tokenUsage ?? {}),
+          ...usage.tokenUsage,
+        }
       }
 
       debugJson(logger, "Streaming chunk:", chunk)
@@ -704,7 +708,9 @@ async function streamChatCompletionsAndLog(params: {
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
 
-    recordTokenUsage(tokenUsage)
+    if (tokenUsage) {
+      recordTokenUsage(tokenUsage)
+    }
 
     insertRequestLog(store, request, {
       finishedAtMs,
@@ -759,9 +765,14 @@ async function extractUsageFromChunk(
   try {
     const parsed = JSON.parse(data) as ChatCompletionChunk
     if (!parsed.usage && !parsed.copilot_usage) return undefined
+    if (!parsed.usage) {
+      return {
+        tokenUsage: normalizeCopilotAiuUsage(parsed.copilot_usage),
+      }
+    }
+
     return {
-      requestHistoryUsage:
-        parsed.usage ? normalizeChatCompletionsUsage(parsed.usage) : undefined,
+      requestHistoryUsage: normalizeChatCompletionsUsage(parsed.usage),
       tokenUsage: mergeCopilotAiuUsage(
         normalizeOpenAIUsage(parsed.usage),
         parsed.copilot_usage,

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -28,6 +28,12 @@ import {
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
 import {
+  createCopilotTokenUsageRecorder,
+  mergeCopilotAiuUsage,
+  normalizeOpenAIUsage,
+  type UsageTokens,
+} from "~/lib/token-usage"
+import {
   generateRequestIdFromPayload,
   getUUID,
   isNullish,
@@ -207,6 +213,12 @@ export async function handleCompletion(c: Context) {
   )
   request.upstreamRequestId = upstreamRequestId
   request.upstreamSessionId = upstreamSessionId
+  const recordTokenUsage = createCopilotTokenUsageRecorder({
+    endpoint: "chat_completions",
+    fallbackSessionId: upstreamSessionId,
+    model: selectedModel.id,
+    sessionId: normalizedPromptCacheKey ?? headerSessionId ?? undefined,
+  })
 
   if (streamRequested) {
     return handleStreamingRequest({
@@ -219,6 +231,7 @@ export async function handleCompletion(c: Context) {
       clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
+      recordTokenUsage,
     })
   }
 
@@ -232,6 +245,7 @@ export async function handleCompletion(c: Context) {
     clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
+    recordTokenUsage,
   })
 }
 
@@ -399,6 +413,7 @@ async function handleStreamingRequest(params: {
   clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
   const {
     c,
@@ -410,6 +425,7 @@ async function handleStreamingRequest(params: {
     clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
+    recordTokenUsage,
   } = params
 
   let response: ChatCompletionsResult
@@ -444,6 +460,7 @@ async function handleStreamingRequest(params: {
       premiumRemainingBefore,
       premiumUnlimitedBefore,
       response,
+      recordTokenUsage,
     })
   }
 
@@ -459,6 +476,7 @@ async function handleStreamingRequest(params: {
       clientModel,
       premiumRemainingBefore,
       premiumUnlimitedBefore,
+      recordTokenUsage,
     }),
   )
 }
@@ -533,6 +551,7 @@ async function handleNonStreamingUpstreamResponse(params: {
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   response: ChatCompletionResponse
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
   const {
     c,
@@ -543,12 +562,17 @@ async function handleNonStreamingUpstreamResponse(params: {
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     response,
+    recordTokenUsage,
   } = params
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
 
   let httpStatus = 200
   const usage: NormalizedUsage = normalizeChatCompletionsUsage(response.usage)
+  const tokenUsage = mergeCopilotAiuUsage(
+    normalizeOpenAIUsage(response.usage),
+    response.copilot_usage,
+  )
   let errorName: string | undefined
   let errorStatus: number | undefined
   let errorMessage: string | undefined
@@ -558,6 +582,7 @@ async function handleNonStreamingUpstreamResponse(params: {
 
   try {
     debugJson(logger, "Non-streaming response:", response)
+    recordTokenUsage(tokenUsage)
     return c.json(response)
   } catch (error) {
     const details = await extractErrorObservability(error)
@@ -611,6 +636,7 @@ async function streamChatCompletionsAndLog(params: {
   clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<void> {
   const {
     stream,
@@ -621,12 +647,14 @@ async function streamChatCompletionsAndLog(params: {
     clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
+    recordTokenUsage,
   } = params
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
   let errorName: string | undefined
   let errorStatus: number | undefined
   let errorMessage: string | undefined
@@ -641,8 +669,11 @@ async function streamChatCompletionsAndLog(params: {
       }
 
       const usage = await extractUsageFromChunk(chunk)
-      if (usage) {
-        lastUsage = usage
+      if (usage?.requestHistoryUsage) {
+        lastUsage = usage.requestHistoryUsage
+      }
+      if (usage?.tokenUsage) {
+        tokenUsage = usage.tokenUsage
       }
 
       debugJson(logger, "Streaming chunk:", chunk)
@@ -673,6 +704,8 @@ async function streamChatCompletionsAndLog(params: {
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
 
+    recordTokenUsage(tokenUsage)
+
     insertRequestLog(store, request, {
       finishedAtMs,
       durationMs: finishedAtMs - request.startedAtMs,
@@ -702,9 +735,14 @@ async function streamChatCompletionsAndLog(params: {
   }
 }
 
+interface ParsedChatCompletionsChunkUsage {
+  requestHistoryUsage?: NormalizedUsage
+  tokenUsage?: UsageTokens
+}
+
 async function extractUsageFromChunk(
   chunk: SSEMessage,
-): Promise<NormalizedUsage | undefined> {
+): Promise<ParsedChatCompletionsChunkUsage | undefined> {
   let data: string | undefined
 
   try {
@@ -720,8 +758,15 @@ async function extractUsageFromChunk(
 
   try {
     const parsed = JSON.parse(data) as ChatCompletionChunk
-    if (!parsed.usage) return undefined
-    return normalizeChatCompletionsUsage(parsed.usage)
+    if (!parsed.usage && !parsed.copilot_usage) return undefined
+    return {
+      requestHistoryUsage:
+        parsed.usage ? normalizeChatCompletionsUsage(parsed.usage) : undefined,
+      tokenUsage: mergeCopilotAiuUsage(
+        normalizeOpenAIUsage(parsed.usage),
+        parsed.copilot_usage,
+      ),
+    }
   } catch (error) {
     logger.warn("Failed to parse chat completions usage chunk:", {
       error,
@@ -741,6 +786,7 @@ async function handleNonStreamingRequest(params: {
   clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
   const {
     c,
@@ -752,6 +798,7 @@ async function handleNonStreamingRequest(params: {
     clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
+    recordTokenUsage,
   } = params
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
@@ -776,6 +823,12 @@ async function handleNonStreamingRequest(params: {
     selection.confirmAffinity?.()
     finishedAtMs = Date.now()
     usage = normalizeChatCompletionsUsage(response.usage)
+    recordTokenUsage(
+      mergeCopilotAiuUsage(
+        normalizeOpenAIUsage(response.usage),
+        response.copilot_usage,
+      ),
+    )
 
     debugJson(logger, "Non-streaming response:", response)
     return c.json(response)

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -65,6 +65,7 @@ import {
   mergeCopilotAiuUsage,
   mergeAnthropicUsage,
   normalizeAnthropicUsage,
+  normalizeCopilotAiuUsage,
   normalizeOpenAIUsage,
   normalizeOptionalToken,
   normalizeResponsesUsage,
@@ -1286,7 +1287,7 @@ async function streamChatCompletionsAndLog(params: {
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
-  let tokenUsage: UsageTokens = {}
+  let tokenUsage: UsageTokens | undefined
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1313,10 +1314,7 @@ async function streamChatCompletionsAndLog(params: {
 
       logger.debug("Copilot raw stream event:", JSON.stringify(rawEvent))
 
-      const { data: rawData } = rawEvent as {
-        data?: string | Promise<string>
-      }
-      const data = typeof rawData === "string" ? rawData : await rawData
+      const data = await resolveStreamChunkData(rawEvent)
 
       if (data === "[DONE]") {
         break
@@ -1329,12 +1327,15 @@ async function streamChatCompletionsAndLog(params: {
       const chunk = JSON.parse(data) as ChatCompletionChunk
       if (chunk.usage) {
         lastUsage = normalizeChatCompletionsUsage(chunk.usage)
-      }
-      if (chunk.usage || chunk.copilot_usage) {
         tokenUsage = mergeCopilotAiuUsage(
           normalizeOpenAIUsage(chunk.usage),
           chunk.copilot_usage,
         )
+      } else if (chunk.copilot_usage) {
+        tokenUsage = {
+          ...(tokenUsage ?? {}),
+          ...normalizeCopilotAiuUsage(chunk.copilot_usage),
+        }
       }
 
       const events = translateChunkToAnthropicEvents(chunk, streamState)
@@ -1371,7 +1372,9 @@ async function streamChatCompletionsAndLog(params: {
       premiumRemainingDiff,
     } = await finalizeQuotaAndGetPremiumSnapshot(instr)
 
-    recordTokenUsage(tokenUsage)
+    if (tokenUsage) {
+      recordTokenUsage(tokenUsage)
+    }
 
     insertRequestLog(instr, {
       finishedAtMs,
@@ -1477,7 +1480,7 @@ async function streamWebSearchResponsesAndLog(params: {
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
-  let tokenUsage: UsageTokens = {}
+  let tokenUsage: UsageTokens | undefined
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1536,7 +1539,9 @@ async function streamWebSearchResponsesAndLog(params: {
       premiumRemainingDiff,
     } = await finalizeQuotaAndGetPremiumSnapshot(instr)
 
-    recordTokenUsage(tokenUsage)
+    if (tokenUsage) {
+      recordTokenUsage(tokenUsage)
+    }
 
     insertRequestLog(instr, {
       finishedAtMs,
@@ -1762,6 +1767,13 @@ async function writeAnthropicStreamError(
   }
 }
 
+async function resolveStreamChunkData(chunk: {
+  data?: string | Promise<string>
+}): Promise<string | undefined> {
+  const rawData = chunk.data
+  return typeof rawData === "string" ? rawData : await rawData
+}
+
 function collectResponsesStreamOwnerKeys(
   event: ResponseStreamEvent,
   responseOwnerKeys: Set<string>,
@@ -1843,9 +1855,14 @@ function getResponsesStreamTokenUsage(
     return undefined
   }
 
+  const response = event.response
+  if (!response) {
+    return undefined
+  }
+
   return mergeCopilotAiuUsage(
-    normalizeResponsesUsage(event.response.usage),
-    event.copilot_usage ?? event.response.copilot_usage,
+    normalizeResponsesUsage(response.usage),
+    event.copilot_usage ?? response.copilot_usage,
   )
 }
 
@@ -1875,7 +1892,7 @@ async function streamResponsesAndLog(params: {
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
-  let tokenUsage: UsageTokens = {}
+  let tokenUsage: UsageTokens | undefined
   let tokenUsageRecorded = false
 
   let errorName: string | undefined
@@ -1898,8 +1915,9 @@ async function streamResponsesAndLog(params: {
         continue
       }
 
-      const rawData = (chunk as { data?: string | Promise<string> }).data
-      const data = typeof rawData === "string" ? rawData : await rawData
+      const data = await resolveStreamChunkData(
+        chunk as { data?: string | Promise<string> },
+      )
       if (!data) {
         continue
       }
@@ -1972,7 +1990,7 @@ async function streamResponsesAndLog(params: {
       premiumRemainingDiff,
     } = await finalizeQuotaAndGetPremiumSnapshot(instr)
 
-    if (!tokenUsageRecorded) {
+    if (!tokenUsageRecorded && tokenUsage) {
       recordTokenUsage(tokenUsage)
     }
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -62,9 +62,12 @@ import {
 } from "~/routes/messages/responses-item-ownership"
 import {
   createCopilotTokenUsageRecorder,
+  mergeCopilotAiuUsage,
   mergeAnthropicUsage,
   normalizeAnthropicUsage,
+  normalizeOpenAIUsage,
   normalizeOptionalToken,
+  normalizeResponsesUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
 import {
@@ -744,6 +747,12 @@ const handleWithChatCompletions = async (params: {
   })
 
   instr.initiator = effectiveInitiator
+  const recordTokenUsage = createCopilotTokenUsageRecorder({
+    endpoint: "chat_completions",
+    fallbackSessionId: sessionId,
+    model: selectedModel.id,
+    sessionId: instr.promptCacheKey,
+  })
 
   let response: ChatCompletionsResult
 
@@ -771,6 +780,7 @@ const handleWithChatCompletions = async (params: {
       c,
       response,
       instr,
+      recordTokenUsage,
     })
   }
 
@@ -799,6 +809,7 @@ const handleWithChatCompletions = async (params: {
       instr,
       estimatedInputTokens,
       historicalUsage: historicalUsage ?? undefined,
+      recordTokenUsage,
     }),
   )
 }
@@ -837,6 +848,12 @@ const handleWithWebSearchResponsesApi = async (params: {
   const ctx = toAccountContext(instr.account)
 
   instr.initiator = effectiveInitiator
+  const recordTokenUsage = createCopilotTokenUsageRecorder({
+    endpoint: "responses",
+    fallbackSessionId: sessionId,
+    model: selectedModel.id,
+    sessionId: instr.promptCacheKey,
+  })
 
   debugJson(
     logger,
@@ -880,6 +897,7 @@ const handleWithWebSearchResponsesApi = async (params: {
           response,
           originalPayload: anthropicPayload,
           instr,
+          recordTokenUsage,
         }),
       )
     }
@@ -889,6 +907,7 @@ const handleWithWebSearchResponsesApi = async (params: {
       response,
       originalPayload: anthropicPayload,
       instr,
+      recordTokenUsage,
     })
   }
 
@@ -897,6 +916,7 @@ const handleWithWebSearchResponsesApi = async (params: {
     result: response,
     originalPayload: anthropicPayload,
     instr,
+    recordTokenUsage,
   })
 }
 
@@ -947,6 +967,12 @@ const handleWithResponsesApi = async (params: {
   const ctx = toAccountContext(instr.account)
 
   instr.initiator = effectiveInitiator
+  const recordTokenUsage = createCopilotTokenUsageRecorder({
+    endpoint: "responses",
+    fallbackSessionId: sessionId,
+    model: selectedModel.id,
+    sessionId: instr.promptCacheKey,
+  })
 
   let response: Awaited<ReturnType<typeof createResponses>>
 
@@ -1001,6 +1027,7 @@ const handleWithResponsesApi = async (params: {
         instr,
         estimatedInputTokens,
         historicalUsage: historicalUsage ?? undefined,
+        recordTokenUsage,
       }),
     )
   }
@@ -1009,6 +1036,7 @@ const handleWithResponsesApi = async (params: {
     c,
     result: response as ResponsesResult,
     instr,
+    recordTokenUsage,
   })
 }
 
@@ -1171,11 +1199,16 @@ async function handleChatCompletionsNonStreaming(params: {
   c: Context
   response: ChatCompletionResponse
   instr: InstrumentationContext
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
-  const { c, response, instr } = params
+  const { c, response, instr, recordTokenUsage } = params
 
   let httpStatus = 200
   const usage: NormalizedUsage = normalizeChatCompletionsUsage(response.usage)
+  const tokenUsage = mergeCopilotAiuUsage(
+    normalizeOpenAIUsage(response.usage),
+    response.copilot_usage,
+  )
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1193,6 +1226,7 @@ async function handleChatCompletionsNonStreaming(params: {
     const anthropicResponse = translateToAnthropic(response)
     debugJson(logger, "Translated Anthropic response:", anthropicResponse)
 
+    recordTokenUsage(tokenUsage)
     return c.json(anthropicResponse)
   } catch (error) {
     const details = await extractErrorObservability(error)
@@ -1239,12 +1273,20 @@ async function streamChatCompletionsAndLog(params: {
   instr: InstrumentationContext
   estimatedInputTokens?: number
   historicalUsage?: NormalizedUsage
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<void> {
-  const { stream, response, instr, estimatedInputTokens, historicalUsage } =
-    params
+  const {
+    stream,
+    response,
+    instr,
+    estimatedInputTokens,
+    historicalUsage,
+    recordTokenUsage,
+  } = params
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1288,6 +1330,12 @@ async function streamChatCompletionsAndLog(params: {
       if (chunk.usage) {
         lastUsage = normalizeChatCompletionsUsage(chunk.usage)
       }
+      if (chunk.usage || chunk.copilot_usage) {
+        tokenUsage = mergeCopilotAiuUsage(
+          normalizeOpenAIUsage(chunk.usage),
+          chunk.copilot_usage,
+        )
+      }
 
       const events = translateChunkToAnthropicEvents(chunk, streamState)
       for (const event of events) {
@@ -1322,6 +1370,8 @@ async function streamChatCompletionsAndLog(params: {
       premiumUnlimitedAfter,
       premiumRemainingDiff,
     } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    recordTokenUsage(tokenUsage)
 
     insertRequestLog(instr, {
       finishedAtMs,
@@ -1391,8 +1441,9 @@ async function handleWebSearchResponsesStreamToJson(params: {
   response: AsyncIterable<unknown>
   originalPayload: AnthropicMessagesPayload
   instr: InstrumentationContext
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
-  const { c, response, originalPayload, instr } = params
+  const { c, response, originalPayload, instr, recordTokenUsage } = params
 
   try {
     const result = await collectWebSearchResponsesStreamResult({
@@ -1404,6 +1455,7 @@ async function handleWebSearchResponsesStreamToJson(params: {
       result,
       originalPayload,
       instr,
+      recordTokenUsage,
     })
   } catch (error) {
     return await handleResponsesCreateError({
@@ -1419,11 +1471,13 @@ async function streamWebSearchResponsesAndLog(params: {
   response: AsyncIterable<unknown>
   originalPayload: AnthropicMessagesPayload
   instr: InstrumentationContext
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<void> {
-  const { stream, response, originalPayload, instr } = params
+  const { stream, response, originalPayload, instr, recordTokenUsage } = params
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1437,6 +1491,10 @@ async function streamWebSearchResponsesAndLog(params: {
     })
     ttfbMs = Date.now() - instr.startedAtMs
     lastUsage = extractResponsesUsageFromResult(result)
+    tokenUsage = mergeCopilotAiuUsage(
+      normalizeResponsesUsage(result.usage),
+      result.copilot_usage,
+    )
 
     const responsePayload = {
       ...originalPayload,
@@ -1478,6 +1536,8 @@ async function streamWebSearchResponsesAndLog(params: {
       premiumRemainingDiff,
     } = await finalizeQuotaAndGetPremiumSnapshot(instr)
 
+    recordTokenUsage(tokenUsage)
+
     insertRequestLog(instr, {
       finishedAtMs,
       durationMs: finishedAtMs - instr.startedAtMs,
@@ -1501,11 +1561,13 @@ async function handleWebSearchResponsesNonStreaming(params: {
   result: ResponsesResult
   originalPayload: AnthropicMessagesPayload
   instr: InstrumentationContext
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
-  const { c, result, originalPayload, instr } = params
+  const { c, result, originalPayload, instr, recordTokenUsage } = params
 
   let httpStatus = 200
   let usage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1516,6 +1578,10 @@ async function handleWebSearchResponsesNonStreaming(params: {
 
   try {
     usage = extractResponsesUsageFromResult(result)
+    tokenUsage = mergeCopilotAiuUsage(
+      normalizeResponsesUsage(result.usage),
+      result.copilot_usage,
+    )
     const responsePayload = {
       ...originalPayload,
       model: instr.clientModel,
@@ -1532,6 +1598,7 @@ async function handleWebSearchResponsesNonStreaming(params: {
       result,
     )
 
+    recordTokenUsage(tokenUsage)
     return c.json(response)
   } catch (error) {
     const details = await extractErrorObservability(error)
@@ -1575,11 +1642,13 @@ async function handleResponsesNonStreaming(params: {
   c: Context
   result: ResponsesResult
   instr: InstrumentationContext
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
-  const { c, result, instr } = params
+  const { c, result, instr, recordTokenUsage } = params
 
   let httpStatus = 200
   let usage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1590,6 +1659,10 @@ async function handleResponsesNonStreaming(params: {
 
   try {
     usage = extractResponsesUsageFromResult(result)
+    tokenUsage = mergeCopilotAiuUsage(
+      normalizeResponsesUsage(result.usage),
+      result.copilot_usage,
+    )
     const responseOwnerKeys = extractResponsesResultOwnerKeys(result)
     instr.responsesItemOwnerRecordedKeys = responseOwnerKeys
 
@@ -1609,6 +1682,7 @@ async function handleResponsesNonStreaming(params: {
       )
     }
 
+    recordTokenUsage(tokenUsage)
     return response
   } catch (error) {
     const details = await extractErrorObservability(error)
@@ -1758,6 +1832,23 @@ function getResponsesStreamEventError(event: ResponseStreamEvent):
   return undefined
 }
 
+function getResponsesStreamTokenUsage(
+  event: ResponseStreamEvent,
+): UsageTokens | undefined {
+  if (
+    event.type !== "response.completed"
+    && event.type !== "response.incomplete"
+    && event.type !== "response.failed"
+  ) {
+    return undefined
+  }
+
+  return mergeCopilotAiuUsage(
+    normalizeResponsesUsage(event.response.usage),
+    event.copilot_usage ?? event.response.copilot_usage,
+  )
+}
+
 async function writeTranslatedAnthropicStreamEvents(
   stream: StreamSseStream,
   events: Array<AnthropicStreamEventData>,
@@ -1778,11 +1869,14 @@ async function streamResponsesAndLog(params: {
   instr: InstrumentationContext
   estimatedInputTokens?: number
   historicalUsage?: NormalizedUsage
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<void> {
-  const { stream, response, instr } = params
+  const { stream, response, instr, recordTokenUsage } = params
 
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
+  let tokenUsageRecorded = false
 
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -1804,7 +1898,8 @@ async function streamResponsesAndLog(params: {
         continue
       }
 
-      const data = (chunk as { data?: string }).data
+      const rawData = (chunk as { data?: string | Promise<string> }).data
+      const data = typeof rawData === "string" ? rawData : await rawData
       if (!data) {
         continue
       }
@@ -1824,6 +1919,12 @@ async function streamResponsesAndLog(params: {
       const u = extractResponsesUsageFromStreamEvent(parsed)
       if (u.usageJson) {
         lastUsage = u
+      }
+      const usageForTokenStore = getResponsesStreamTokenUsage(parsed)
+      if (usageForTokenStore) {
+        tokenUsage = usageForTokenStore
+        recordTokenUsage(tokenUsage)
+        tokenUsageRecorded = true
       }
 
       const events = translateResponsesStreamEvent(parsed, streamState)
@@ -1870,6 +1971,10 @@ async function streamResponsesAndLog(params: {
       premiumUnlimitedAfter,
       premiumRemainingDiff,
     } = await finalizeQuotaAndGetPremiumSnapshot(instr)
+
+    if (!tokenUsageRecorded) {
+      recordTokenUsage(tokenUsage)
+    }
 
     insertRequestLog(instr, {
       finishedAtMs,

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -15,6 +15,7 @@ import {
 } from "~/lib/provider-model"
 import {
   createCopilotTokenUsageRecorder,
+  mergeCopilotAiuUsage,
   normalizeResponsesUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -371,7 +372,13 @@ const collectWebSearchResponsesStreamEvent = (
   }
 
   if (isResponsesTerminalEvent(event)) {
-    state.terminalResponse = event.response
+    const eventCopilotUsage = (
+      event as { copilot_usage?: ResponsesResult["copilot_usage"] }
+    ).copilot_usage
+    state.terminalResponse = {
+      ...event.response,
+      copilot_usage: event.response.copilot_usage ?? eventCopilotUsage,
+    }
     return
   }
 
@@ -684,7 +691,12 @@ export const handleWebSearchViaResponses = async (
     options.sessionId,
     webSearchModel,
   )
-  recordUsage(normalizeResponsesUsage(result.usage))
+  recordUsage(
+    mergeCopilotAiuUsage(
+      normalizeResponsesUsage(result.usage),
+      result.copilot_usage,
+    ),
+  )
 
   if (!wantsStream) {
     return c.json(response)

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -301,11 +301,14 @@ export const collectWebSearchResponsesStreamResult = async ({
       continue
     }
 
-    if (!chunk.data || chunk.data === "[DONE]") {
+    const data = await Promise.resolve(
+      (chunk as unknown as { data?: string | Promise<string> }).data,
+    )
+    if (!data || data === "[DONE]") {
       continue
     }
 
-    const parsed = parseEvent(chunk.data)
+    const parsed = parseEvent(data)
     if (!parsed) {
       continue
     }

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -533,9 +533,13 @@ function extractTokenUsageFromChunkData(
     ) {
       return undefined
     }
+    const response = event.response
+    if (!response) {
+      return undefined
+    }
     return mergeCopilotAiuUsage(
-      normalizeResponsesUsage(event.response.usage),
-      event.copilot_usage ?? event.response.copilot_usage,
+      normalizeResponsesUsage(response.usage),
+      event.copilot_usage ?? response.copilot_usage,
     )
   } catch {
     return undefined
@@ -824,7 +828,7 @@ async function streamResponsesAndLog(params: {
   const idTracker = createStreamIdTracker()
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
-  let tokenUsage: UsageTokens = {}
+  let tokenUsage: UsageTokens | undefined
   let tokenUsageRecorded = false
   let errorName: string | undefined
   let errorStatus: number | undefined
@@ -890,7 +894,7 @@ async function streamResponsesAndLog(params: {
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
 
-    if (!tokenUsageRecorded) {
+    if (!tokenUsageRecorded && tokenUsage) {
       recordTokenUsage(tokenUsage)
     }
 

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -34,6 +34,12 @@ import {
 } from "~/lib/request-history"
 import { state } from "~/lib/state"
 import {
+  createCopilotTokenUsageRecorder,
+  mergeCopilotAiuUsage,
+  normalizeResponsesUsage,
+  type UsageTokens,
+} from "~/lib/token-usage"
+import {
   generateRequestIdFromPayload,
   getUUID,
   parseUserIdMetadata,
@@ -231,6 +237,12 @@ export const handleResponses = async (c: Context) => {
   )
   request.upstreamRequestId = upstreamRequestId
   request.upstreamSessionId = upstreamSessionId
+  const recordTokenUsage = createCopilotTokenUsageRecorder({
+    endpoint: "responses",
+    fallbackSessionId: upstreamSessionId,
+    model: selectedModel.id,
+    sessionId: normalizedPromptCacheKey ?? headerSessionId ?? undefined,
+  })
 
   // Set by the Responses websocket bridge (src/routes/responses/websocket.ts) so
   // the upstream pool can close the originating bridge socket when its GitHub
@@ -253,6 +265,7 @@ export const handleResponses = async (c: Context) => {
       premiumUnlimitedBefore,
       transport,
       bridgeId,
+      recordTokenUsage,
     })
   }
 
@@ -271,6 +284,7 @@ export const handleResponses = async (c: Context) => {
     premiumUnlimitedBefore,
     transport,
     bridgeId,
+    recordTokenUsage,
   })
 }
 
@@ -505,6 +519,29 @@ function extractUsageFromChunkData(
   }
 }
 
+function extractTokenUsageFromChunkData(
+  data: string | undefined,
+): UsageTokens | undefined {
+  if (!data) return undefined
+
+  try {
+    const event = JSON.parse(data) as ResponseStreamEvent
+    if (
+      event.type !== "response.completed"
+      && event.type !== "response.incomplete"
+      && event.type !== "response.failed"
+    ) {
+      return undefined
+    }
+    return mergeCopilotAiuUsage(
+      normalizeResponsesUsage(event.response.usage),
+      event.copilot_usage ?? event.response.copilot_usage,
+    )
+  } catch {
+    return undefined
+  }
+}
+
 async function handleStreamingResponses(params: {
   c: Context
   store: Store
@@ -520,6 +557,7 @@ async function handleStreamingResponses(params: {
   premiumUnlimitedBefore: boolean | undefined
   transport: ResponsesTransport
   bridgeId: string | undefined
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
   const {
     c,
@@ -536,6 +574,7 @@ async function handleStreamingResponses(params: {
     premiumUnlimitedBefore,
     transport,
     bridgeId,
+    recordTokenUsage,
   } = params
 
   let response: Awaited<ReturnType<typeof createResponses>>
@@ -581,6 +620,7 @@ async function handleStreamingResponses(params: {
         clientModel,
         premiumRemainingBefore,
         premiumUnlimitedBefore,
+        recordTokenUsage,
       }),
     )
   }
@@ -594,6 +634,7 @@ async function handleStreamingResponses(params: {
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     result: response,
+    recordTokenUsage,
   })
 }
 
@@ -675,6 +716,7 @@ async function handleNonStreamingUpstreamResult(params: {
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
   result: ResponsesResult
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
   const {
     c,
@@ -685,12 +727,17 @@ async function handleNonStreamingUpstreamResult(params: {
     premiumRemainingBefore,
     premiumUnlimitedBefore,
     result,
+    recordTokenUsage,
   } = params
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
 
   let httpStatus = 200
   const usage: NormalizedUsage = extractResponsesUsageFromResult(result)
+  const tokenUsage = mergeCopilotAiuUsage(
+    normalizeResponsesUsage(result.usage),
+    result.copilot_usage,
+  )
   let errorName: string | undefined
   let errorStatus: number | undefined
   let errorMessage: string | undefined
@@ -703,6 +750,7 @@ async function handleNonStreamingUpstreamResult(params: {
       value: result,
       tailLength: 400,
     })
+    recordTokenUsage(tokenUsage)
     return c.json(result)
   } catch (error) {
     const details = await extractErrorObservability(error)
@@ -757,6 +805,7 @@ async function streamResponsesAndLog(params: {
   clientModel: string
   premiumRemainingBefore: number | undefined
   premiumUnlimitedBefore: boolean | undefined
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<void> {
   const {
     stream,
@@ -767,6 +816,7 @@ async function streamResponsesAndLog(params: {
     clientModel,
     premiumRemainingBefore,
     premiumUnlimitedBefore,
+    recordTokenUsage,
   } = params
 
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
@@ -774,6 +824,8 @@ async function streamResponsesAndLog(params: {
   const idTracker = createStreamIdTracker()
   let ttfbMs: number | undefined
   let lastUsage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
+  let tokenUsageRecorded = false
   let errorName: string | undefined
   let errorStatus: number | undefined
   let errorMessage: string | undefined
@@ -785,12 +837,19 @@ async function streamResponsesAndLog(params: {
         ttfbMs = Date.now() - request.startedAtMs
       }
 
-      const { id, event, data } = getStreamChunkFields(chunk)
+      const { id, event, data: rawData } = getStreamChunkFields(chunk)
+      const data = typeof rawData === "string" ? rawData : await rawData
       const processedData = fixStreamIds(data ?? "", event, idTracker)
 
       const usage = extractUsageFromChunkData(processedData)
       if (usage) {
         lastUsage = usage
+      }
+      const usageForTokenStore = extractTokenUsageFromChunkData(processedData)
+      if (usageForTokenStore) {
+        tokenUsage = usageForTokenStore
+        recordTokenUsage(tokenUsage)
+        tokenUsageRecorded = true
       }
 
       debugJson(logger, "Responses stream chunk:", chunk)
@@ -830,6 +889,10 @@ async function streamResponsesAndLog(params: {
 
     const premiumRemainingAfter = account.premiumRemaining
     const premiumUnlimitedAfter = account.unlimited
+
+    if (!tokenUsageRecorded) {
+      recordTokenUsage(tokenUsage)
+    }
 
     insertRequestLog(store, request, {
       finishedAtMs,
@@ -875,6 +938,7 @@ async function handleNonStreamingResponses(params: {
   premiumUnlimitedBefore: boolean | undefined
   transport: ResponsesTransport
   bridgeId: string | undefined
+  recordTokenUsage: (usage: UsageTokens) => void
 }): Promise<Response> {
   const {
     c,
@@ -891,9 +955,11 @@ async function handleNonStreamingResponses(params: {
     premiumUnlimitedBefore,
     transport,
     bridgeId,
+    recordTokenUsage,
   } = params
   const { account, reservation, selectedModel, endpoint, costUnits } = selection
   let usage: NormalizedUsage = {}
+  let tokenUsage: UsageTokens = {}
   let errorState: ObservedErrorState = { httpStatus: 200 }
   let finishedAtMs: number | undefined
   try {
@@ -918,10 +984,15 @@ async function handleNonStreamingResponses(params: {
     finishedAtMs = Date.now()
     const result = response
     usage = extractResponsesUsageFromResult(result)
+    tokenUsage = mergeCopilotAiuUsage(
+      normalizeResponsesUsage(result.usage),
+      result.copilot_usage,
+    )
     debugJsonTail(logger, "Forwarding native Responses result:", {
       value: result,
       tailLength: 400,
     })
+    recordTokenUsage(tokenUsage)
     return c.json(result)
   } catch (error) {
     finishedAtMs = Date.now()

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -437,7 +437,7 @@ export const stripInternalChatMetadataPassthrough = (
 type StreamChunk = {
   id?: string
   event?: string
-  data?: string
+  data?: string | Promise<string>
 }
 
 export function getStreamChunkFields(chunk: unknown): StreamChunk {

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -90,10 +90,13 @@ export interface NamespaceTool {
 
 export type ResponseIncludable =
   | "file_search_call.results"
+  | "web_search_call.results"
+  | "web_search_call.action.sources"
   | "message.input_image.image_url"
   | "computer_call_output.output.image_url"
   | "reasoning.encrypted_content"
   | "code_interpreter_call.outputs"
+  | "message.output_text.logprobs"
 
 export interface Reasoning {
   effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | null
@@ -212,6 +215,7 @@ export interface ResponsesResult {
   output: Array<ResponseOutputItem>
   output_text: string
   status: string
+  copilot_usage?: CopilotUsage | null
   usage?: ResponseUsage | null
   error: ResponseError | null
   incomplete_details: IncompleteDetails | null
@@ -224,6 +228,10 @@ export interface ResponsesResult {
   top_p: number | null
 }
 
+export interface CopilotUsage {
+  total_nano_aiu?: number | null
+}
+
 export type Metadata = { [key: string]: string }
 
 export interface IncompleteDetails {
@@ -231,6 +239,7 @@ export interface IncompleteDetails {
 }
 
 export interface ResponseError {
+  code?: string | null
   message: string
 }
 
@@ -240,6 +249,7 @@ export type ResponseOutputItem =
   | ResponseOutputFunctionCall
   | ResponseOutputToolSearchCall
   | ResponseOutputToolSearchOutput
+  | ResponseOutputWebSearchCall
   | ResponseOutputCompaction
 
 export interface ResponseOutputMessage {
@@ -291,6 +301,20 @@ export interface ResponseOutputToolSearchOutput {
   status?: "in_progress" | "completed" | "incomplete"
 }
 
+export interface ResponseOutputWebSearchCall {
+  id?: string
+  type: "web_search_call"
+  action?: {
+    query?: string
+    queries?: Array<string>
+    sources?: Array<{ type?: "url"; url: string }>
+    type?: string
+    url?: string
+    pattern?: string
+  }
+  status?: "in_progress" | "searching" | "completed" | "failed"
+}
+
 export interface ResponseOutputCompaction {
   id: string
   type: "compaction"
@@ -329,12 +353,21 @@ export type ResponseStreamEvent =
   | ResponseCompletedEvent
   | ResponseIncompleteEvent
   | ResponseCreatedEvent
+  | ResponseInProgressEvent
   | ResponseErrorEvent
   | ResponseFunctionCallArgumentsDeltaEvent
   | ResponseFunctionCallArgumentsDoneEvent
   | ResponseFailedEvent
   | ResponseOutputItemAddedEvent
   | ResponseOutputItemDoneEvent
+  | ResponseContentPartAddedEvent
+  | ResponseOutputTextAnnotationAddedEvent
+  | ResponseContentPartDoneEvent
+  | ResponseWebSearchCallInProgressEvent
+  | ResponseWebSearchCallSearchingEvent
+  | ResponseWebSearchCallCompletedEvent
+  | ResponseReasoningSummaryPartAddedEvent
+  | ResponseReasoningSummaryPartDoneEvent
   | ResponseReasoningSummaryTextDeltaEvent
   | ResponseReasoningSummaryTextDoneEvent
   | ResponseTextDeltaEvent
@@ -342,12 +375,14 @@ export type ResponseStreamEvent =
 
 export interface ResponseCompletedEvent {
   copilot_quota_snapshots?: Record<string, CopilotQuotaSnapshot>
+  copilot_usage?: CopilotUsage | null
   response: ResponsesResult
   sequence_number: number
   type: "response.completed"
 }
 
 export interface ResponseIncompleteEvent {
+  copilot_usage?: CopilotUsage | null
   response: ResponsesResult
   sequence_number: number
   type: "response.incomplete"
@@ -357,6 +392,12 @@ export interface ResponseCreatedEvent {
   response: ResponsesResult
   sequence_number: number
   type: "response.created"
+}
+
+export interface ResponseInProgressEvent {
+  response: ResponsesResult
+  sequence_number: number
+  type: "response.in_progress"
 }
 
 export interface ResponseErrorEvent {
@@ -392,6 +433,7 @@ export interface ResponseFunctionCallArgumentsDoneEvent {
 }
 
 export interface ResponseFailedEvent {
+  copilot_usage?: CopilotUsage | null
   response: ResponsesResult
   sequence_number: number
   type: "response.failed"
@@ -409,6 +451,73 @@ export interface ResponseOutputItemDoneEvent {
   output_index: number
   sequence_number: number
   type: "response.output_item.done"
+}
+
+export interface ResponseContentPartAddedEvent {
+  content_index: number
+  item_id: string
+  output_index: number
+  part: ResponseOutputContentBlock
+  sequence_number: number
+  type: "response.content_part.added"
+}
+
+export interface ResponseOutputTextAnnotationAddedEvent {
+  annotation: unknown
+  annotation_index?: number
+  content_index: number
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.output_text.annotation.added"
+}
+
+export interface ResponseContentPartDoneEvent {
+  content_index: number
+  item_id: string
+  output_index: number
+  part: ResponseOutputContentBlock
+  sequence_number: number
+  type: "response.content_part.done"
+}
+
+export interface ResponseWebSearchCallInProgressEvent {
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.web_search_call.in_progress"
+}
+
+export interface ResponseWebSearchCallSearchingEvent {
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.web_search_call.searching"
+}
+
+export interface ResponseWebSearchCallCompletedEvent {
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.web_search_call.completed"
+}
+
+export interface ResponseReasoningSummaryPartAddedEvent {
+  item_id: string
+  output_index: number
+  part: ResponseReasoningBlock
+  sequence_number: number
+  summary_index: number
+  type: "response.reasoning_summary_part.added"
+}
+
+export interface ResponseReasoningSummaryPartDoneEvent {
+  item_id: string
+  output_index: number
+  part: ResponseReasoningBlock
+  sequence_number: number
+  summary_index: number
+  type: "response.reasoning_summary_part.done"
 }
 
 export interface ResponseReasoningSummaryTextDeltaEvent {

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
 
+import type { AccountRuntime } from "~/lib/types/account"
+import type { Model } from "~/services/copilot/get-models"
+
 const actualRateLimitModule = await import("../src/lib/rate-limit")
 
 await mock.module("~/lib/rate-limit", () => ({
@@ -9,9 +12,24 @@ await mock.module("~/lib/rate-limit", () => ({
 }))
 
 import { state } from "../src/lib/state"
+import { accountsManager } from "../src/lib/accounts-manager"
+import {
+  closeUsageStore,
+  getTokenUsageEventsPage,
+} from "../src/lib/token-usage"
 import { completionRoutes } from "../src/routes/chat-completions/route"
 
+type SelectionResult = Awaited<
+  ReturnType<(typeof accountsManager)["selectAccountForRequest"]>
+>
+type SelectionOk = Extract<SelectionResult, { ok: true }>
+
 const originalFetch = globalThis.fetch
+const originalSelect =
+  accountsManager.selectAccountForRequest.bind(accountsManager)
+const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
+const originalMarkFailed =
+  accountsManager.markAccountFailed.bind(accountsManager)
 const originalState = {
   accountType: state.accountType,
   copilotToken: state.copilotToken,
@@ -21,6 +39,59 @@ const originalState = {
   rateLimitWait: state.rateLimitWait,
   verbose: state.verbose,
   vsCodeVersion: state.vsCodeVersion,
+}
+const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
+
+function buildAccount(): AccountRuntime {
+  return {
+    id: "octocat",
+    accountType: "individual",
+    addedAt: Date.now(),
+    githubToken: "ghu_test",
+    copilotToken: "copilot_test",
+    vsCodeVersion: "1.0.0",
+    premiumRemaining: 10,
+    unlimited: false,
+  }
+}
+
+function buildModel(id: string): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+
+function buildSelection(modelId: string): SelectionOk {
+  return {
+    ok: true,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId),
+    endpoint: "/chat/completions",
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    affinityHit: false,
+    selectionReason: "affinity_miss",
+  }
 }
 
 const fetchMock = mock(() =>
@@ -49,7 +120,10 @@ const createApp = () => {
   return app
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  process.env[DB_PATH_ENV] = ":memory:"
+  await closeUsageStore()
+
   state.accountType = "individual"
   state.copilotToken = "test-token"
   state.manualApprove = false
@@ -59,12 +133,17 @@ beforeEach(() => {
   state.rateLimitSeconds = undefined
   state.lastRequestTimestamp = undefined
 
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("gpt-test"))
+  accountsManager.finalizeQuota = () => Promise.resolve()
+  accountsManager.markAccountFailed = () => {}
+
   fetchMock.mockClear()
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
     fetchMock as unknown as typeof fetch
 })
 
-afterEach(() => {
+afterEach(async () => {
   state.accountType = originalState.accountType
   state.copilotToken = originalState.copilotToken
   state.manualApprove = originalState.manualApprove
@@ -73,6 +152,11 @@ afterEach(() => {
   state.rateLimitWait = originalState.rateLimitWait
   state.rateLimitSeconds = originalState.rateLimitSeconds
   state.lastRequestTimestamp = originalState.lastRequestTimestamp
+  accountsManager.selectAccountForRequest = originalSelect
+  accountsManager.finalizeQuota = originalFinalize
+  accountsManager.markAccountFailed = originalMarkFailed
+  await closeUsageStore()
+  Reflect.deleteProperty(process.env, DB_PATH_ENV)
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
 })
 
@@ -98,5 +182,154 @@ describe("chat completions handler", () => {
       },
     })
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("records Copilot AIU from non-streaming Chat Completions responses", async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "gpt-test",
+            choices: [],
+            copilot_usage: {
+              total_nano_aiu: 1_000_000_000,
+            },
+            usage: {
+              prompt_tokens: 5,
+              completion_tokens: 2,
+              total_tokens: 7,
+              prompt_tokens_details: {
+                cached_tokens: 1,
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        ),
+      ),
+    )
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+    await response.text()
+
+    const usageEvents = await getTokenUsageEventsPage({
+      page: 1,
+      pageSize: 10,
+      period: "day",
+    })
+
+    expect(response.status).toBe(200)
+    expect(usageEvents.items).toHaveLength(1)
+    expect(usageEvents.items[0]).toMatchObject({
+      cache_read_input_tokens: 1,
+      cost: {
+        amount: 0.01,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 10_000_000,
+      },
+      endpoint: "chat_completions",
+      input_tokens: 4,
+      model: "gpt-test",
+      output_tokens: 2,
+      source: "copilot",
+      total_nano_aiu: 1_000_000_000,
+      total_tokens: 7,
+    })
+  })
+
+  test("records Copilot AIU from streaming Chat Completions chunks", async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          [
+            "data: "
+              + JSON.stringify({
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                created: 0,
+                model: "gpt-test",
+                choices: [],
+                copilot_usage: {
+                  total_nano_aiu: 3_000_000_000,
+                },
+                usage: {
+                  prompt_tokens: 10,
+                  completion_tokens: 4,
+                  total_tokens: 14,
+                  prompt_tokens_details: {
+                    cached_tokens: 3,
+                  },
+                },
+              }),
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/event-stream",
+            },
+          },
+        ),
+      ),
+    )
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+    await response.text()
+
+    const usageEvents = await getTokenUsageEventsPage({
+      page: 1,
+      pageSize: 10,
+      period: "day",
+    })
+
+    expect(response.status).toBe(200)
+    expect(usageEvents.items).toHaveLength(1)
+    expect(usageEvents.items[0]).toMatchObject({
+      cache_read_input_tokens: 3,
+      cost: {
+        amount: 0.03,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 30_000_000,
+      },
+      endpoint: "chat_completions",
+      input_tokens: 7,
+      model: "gpt-test",
+      output_tokens: 4,
+      source: "copilot",
+      total_nano_aiu: 3_000_000_000,
+      total_tokens: 14,
+    })
   })
 })

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -41,6 +41,7 @@ const originalState = {
   vsCodeVersion: state.vsCodeVersion,
 }
 const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
+let dbPathBeforeTest: string | undefined
 
 function buildAccount(): AccountRuntime {
   return {
@@ -121,6 +122,7 @@ const createApp = () => {
 }
 
 beforeEach(async () => {
+  dbPathBeforeTest = process.env[DB_PATH_ENV]
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
 
@@ -156,7 +158,12 @@ afterEach(async () => {
   accountsManager.finalizeQuota = originalFinalize
   accountsManager.markAccountFailed = originalMarkFailed
   await closeUsageStore()
-  Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  if (dbPathBeforeTest === undefined) {
+    Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  } else {
+    process.env[DB_PATH_ENV] = dbPathBeforeTest
+  }
+  dbPathBeforeTest = undefined
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
 })
 
@@ -267,9 +274,6 @@ describe("chat completions handler", () => {
                 created: 0,
                 model: "gpt-test",
                 choices: [],
-                copilot_usage: {
-                  total_nano_aiu: 3_000_000_000,
-                },
                 usage: {
                   prompt_tokens: 10,
                   completion_tokens: 4,
@@ -277,6 +281,18 @@ describe("chat completions handler", () => {
                   prompt_tokens_details: {
                     cached_tokens: 3,
                   },
+                },
+              }),
+            "",
+            "data: "
+              + JSON.stringify({
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                created: 0,
+                model: "gpt-test",
+                choices: [],
+                copilot_usage: {
+                  total_nano_aiu: 3_000_000_000,
                 },
               }),
             "",

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 
 import type { AccountContext } from "~/lib/types/account"
 import type {
+  ResponseIncludable,
+  ResponseStreamEvent,
   ResponsesPayload,
   ResponsesResult,
 } from "~/services/copilot/create-responses"
@@ -62,6 +64,79 @@ const createResponsesResult = (model: string): ResponsesResult => ({
   usage: null,
 })
 
+const supportedResponseIncludables: Array<ResponseIncludable> = [
+  "web_search_call.results",
+  "web_search_call.action.sources",
+  "message.output_text.logprobs",
+]
+
+const responseStreamEventsWithCopilotUsage: Array<ResponseStreamEvent> = [
+  {
+    copilot_usage: {
+      total_nano_aiu: 1_000_000_000,
+    },
+    response: {
+      ...createResponsesResult("gpt-test"),
+      output: [
+        {
+          action: {
+            query: "node lts",
+            sources: [{ type: "url", url: "https://nodejs.org" }],
+          },
+          id: "search-1",
+          status: "completed",
+          type: "web_search_call",
+        },
+      ],
+    },
+    sequence_number: 1,
+    type: "response.completed",
+  },
+  {
+    response: createResponsesResult("gpt-test"),
+    sequence_number: 2,
+    type: "response.in_progress",
+  },
+  {
+    content_index: 0,
+    item_id: "msg-1",
+    output_index: 0,
+    part: {
+      annotations: [],
+      text: "",
+      type: "output_text",
+    },
+    sequence_number: 3,
+    type: "response.content_part.added",
+  },
+  {
+    annotation: {
+      title: "Node.js",
+      type: "url_citation",
+      url: "https://nodejs.org",
+    },
+    content_index: 0,
+    item_id: "msg-1",
+    output_index: 0,
+    sequence_number: 4,
+    type: "response.output_text.annotation.added",
+  },
+  {
+    item_id: "search-1",
+    output_index: 0,
+    sequence_number: 5,
+    type: "response.web_search_call.searching",
+  },
+  {
+    item_id: "reasoning-1",
+    output_index: 0,
+    part: { text: "Searching", type: "summary_text" },
+    sequence_number: 6,
+    summary_index: 0,
+    type: "response.reasoning_summary_part.done",
+  },
+]
+
 const fetchMock = mock((_url: string | URL | Request, _init?: RequestInit) =>
   Promise.resolve(
     new Response(JSON.stringify(createResponsesResult("gpt-test")), {
@@ -119,6 +194,13 @@ afterEach(() => {
 })
 
 describe("createResponses HTTP headers", () => {
+  test("types include Copilot AIU and current Responses stream events", () => {
+    expect(supportedResponseIncludables).toHaveLength(3)
+    expect(
+      responseStreamEventsWithCopilotUsage.map((event) => event.type),
+    ).toContain("response.web_search_call.searching")
+  })
+
   test("keeps x-initiator as user for ordinary responses requests", async () => {
     await createResponses(
       basePayload([{ role: "user", content: "hello" }]),

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -189,6 +189,16 @@ function createPayload(
   }
 }
 
+async function readSingleTokenUsageEvent() {
+  const usageEvents = await getTokenUsageEventsPage({
+    page: 1,
+    pageSize: 10,
+    period: "day",
+  })
+  expect(usageEvents.items).toHaveLength(1)
+  return usageEvents.items[0]
+}
+
 beforeEach(async () => {
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
@@ -782,6 +792,135 @@ describe("messages handler routing", () => {
     expect(selection.confirmOwnership).toHaveBeenCalledTimes(1)
   })
 
+  test("records Copilot AIU when Messages routes to non-streaming Responses", async () => {
+    const selection = buildSelection("/responses", "responses-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...buildResponsesResult("responses-model", "responses"),
+            copilot_usage: {
+              total_nano_aiu: 1_500_000_000,
+            },
+            usage: {
+              input_tokens: 9,
+              input_tokens_details: {
+                cached_tokens: 2,
+              },
+              output_tokens: 3,
+              total_tokens: 12,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload()),
+      }),
+    )
+    await response.text()
+
+    expect(response.status).toBe(200)
+    expect(await readSingleTokenUsageEvent()).toMatchObject({
+      cache_read_input_tokens: 2,
+      cost: {
+        amount: 0.015,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 15_000_000,
+      },
+      endpoint: "responses",
+      input_tokens: 7,
+      model: "responses-model",
+      output_tokens: 3,
+      source: "copilot",
+      total_nano_aiu: 1_500_000_000,
+      total_tokens: 12,
+    })
+  })
+
+  test("records Copilot AIU when Messages routes to streaming Responses", async () => {
+    const selection = buildSelection("/responses", "responses-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          [
+            "event: response.completed",
+            `data: ${JSON.stringify({
+              copilot_usage: {
+                total_nano_aiu: 2_250_000_000,
+              },
+              response: {
+                ...buildResponsesResult("responses-model", "responses"),
+                usage: {
+                  input_tokens: 11,
+                  input_tokens_details: {
+                    cached_tokens: 4,
+                  },
+                  output_tokens: 5,
+                  total_tokens: 16,
+                },
+              },
+              sequence_number: 1,
+              type: "response.completed",
+            })}`,
+            "",
+            "",
+          ].join("\n"),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload({ stream: true })),
+      }),
+    )
+    await response.text()
+
+    expect(response.status).toBe(200)
+    expect(await readSingleTokenUsageEvent()).toMatchObject({
+      cache_read_input_tokens: 4,
+      cost: {
+        amount: 0.0225,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 22_500_000,
+      },
+      endpoint: "responses",
+      input_tokens: 7,
+      model: "responses-model",
+      output_tokens: 5,
+      source: "copilot",
+      total_nano_aiu: 2_250_000_000,
+      total_tokens: 16,
+    })
+  })
+
   test("falls back to Chat Completions when selection chooses /chat/completions", async () => {
     let requestedUrl = ""
     let upstreamBody: Record<string, unknown> | undefined
@@ -825,6 +964,159 @@ describe("messages handler routing", () => {
     expect(body.content[0].text).toBe("chat")
     expect(selection.confirmAffinity).toHaveBeenCalledTimes(1)
     expect(selection.confirmOwnership).toHaveBeenCalledTimes(1)
+  })
+
+  test("records Copilot AIU when Messages routes to non-streaming Chat Completions", async () => {
+    const selection = buildSelection("/chat/completions", "chat-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...buildChatCompletionResponse("chat-model", "chat"),
+            copilot_usage: {
+              total_nano_aiu: 3_500_000_000,
+            },
+            usage: {
+              prompt_tokens: 12,
+              completion_tokens: 4,
+              total_tokens: 16,
+              prompt_tokens_details: {
+                cached_tokens: 5,
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload()),
+      }),
+    )
+    await response.text()
+
+    expect(response.status).toBe(200)
+    expect(await readSingleTokenUsageEvent()).toMatchObject({
+      cache_read_input_tokens: 5,
+      cost: {
+        amount: 0.035,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 35_000_000,
+      },
+      endpoint: "chat_completions",
+      input_tokens: 7,
+      model: "chat-model",
+      output_tokens: 4,
+      source: "copilot",
+      total_nano_aiu: 3_500_000_000,
+      total_tokens: 16,
+    })
+  })
+
+  test("records Copilot AIU when Messages routes to streaming Chat Completions", async () => {
+    const selection = buildSelection("/chat/completions", "chat-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          [
+            "data: "
+              + JSON.stringify({
+                id: "chatcmpl_1",
+                object: "chat.completion.chunk",
+                created: 0,
+                model: "chat-model",
+                choices: [
+                  {
+                    index: 0,
+                    delta: { role: "assistant", content: "chat" },
+                    finish_reason: null,
+                    logprobs: null,
+                  },
+                ],
+                copilot_usage: {
+                  total_nano_aiu: 4_000_000_000,
+                },
+                usage: {
+                  prompt_tokens: 15,
+                  completion_tokens: 6,
+                  total_tokens: 21,
+                  prompt_tokens_details: {
+                    cached_tokens: 8,
+                  },
+                },
+              }),
+            "",
+            "data: "
+              + JSON.stringify({
+                id: "chatcmpl_1",
+                object: "chat.completion.chunk",
+                created: 0,
+                model: "chat-model",
+                choices: [
+                  {
+                    index: 0,
+                    delta: {},
+                    finish_reason: "stop",
+                    logprobs: null,
+                  },
+                ],
+              }),
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+      ),
+    )
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload({ stream: true })),
+      }),
+    )
+    await response.text()
+
+    expect(response.status).toBe(200)
+    expect(await readSingleTokenUsageEvent()).toMatchObject({
+      cache_read_input_tokens: 8,
+      cost: {
+        amount: 0.04,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 40_000_000,
+      },
+      endpoint: "chat_completions",
+      input_tokens: 7,
+      model: "chat-model",
+      output_tokens: 6,
+      source: "copilot",
+      total_nano_aiu: 4_000_000_000,
+      total_tokens: 21,
+    })
   })
 })
 

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -35,6 +35,7 @@ const originalSelect =
 const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
 const originalMarkFailed =
   accountsManager.markAccountFailed.bind(accountsManager)
+let dbPathBeforeTest: string | undefined
 
 function parseFetchBody(body: unknown): Record<string, unknown> {
   if (typeof body !== "string") {
@@ -200,6 +201,7 @@ async function readSingleTokenUsageEvent() {
 }
 
 beforeEach(async () => {
+  dbPathBeforeTest = process.env[DB_PATH_ENV]
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
 
@@ -220,7 +222,12 @@ afterEach(async () => {
   accountsManager.finalizeQuota = originalFinalize
   accountsManager.markAccountFailed = originalMarkFailed
   await closeUsageStore()
-  Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  if (dbPathBeforeTest === undefined) {
+    Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  } else {
+    process.env[DB_PATH_ENV] = dbPathBeforeTest
+  }
+  dbPathBeforeTest = undefined
 })
 
 describe("messages handler sanitization", () => {
@@ -921,6 +928,76 @@ describe("messages handler routing", () => {
     })
   })
 
+  test("records Copilot AIU when Messages web search routes through Responses", async () => {
+    const selection = buildSelection("/responses", "search-model")
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    let upstreamBody: Record<string, unknown> | undefined
+    const fetchMock = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = parseFetchBody(opts?.body)
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...buildResponsesResult("search-model", "search result"),
+            copilot_usage: {
+              total_nano_aiu: 1_750_000_000,
+            },
+            usage: {
+              input_tokens: 13,
+              input_tokens_details: {
+                cached_tokens: 6,
+              },
+              output_tokens: 4,
+              total_tokens: 17,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            tools: [
+              { type: "web_search_20250305", name: "web_search" },
+            ] as never,
+          }),
+        ),
+      }),
+    )
+    await response.text()
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.model).toBe("search-model")
+    expect(await readSingleTokenUsageEvent()).toMatchObject({
+      cache_read_input_tokens: 6,
+      cost: {
+        amount: 0.0175,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 17_500_000,
+      },
+      endpoint: "responses",
+      input_tokens: 7,
+      model: "search-model",
+      output_tokens: 4,
+      source: "copilot",
+      total_nano_aiu: 1_750_000_000,
+      total_tokens: 17,
+    })
+  })
+
   test("falls back to Chat Completions when selection chooses /chat/completions", async () => {
     let requestedUrl = ""
     let upstreamBody: Record<string, unknown> | undefined
@@ -1048,9 +1125,6 @@ describe("messages handler routing", () => {
                     logprobs: null,
                   },
                 ],
-                copilot_usage: {
-                  total_nano_aiu: 4_000_000_000,
-                },
                 usage: {
                   prompt_tokens: 15,
                   completion_tokens: 6,
@@ -1058,6 +1132,18 @@ describe("messages handler routing", () => {
                   prompt_tokens_details: {
                     cached_tokens: 8,
                   },
+                },
+              }),
+            "",
+            "data: "
+              + JSON.stringify({
+                id: "chatcmpl_1",
+                object: "chat.completion.chunk",
+                created: 0,
+                model: "chat-model",
+                choices: [],
+                copilot_usage: {
+                  total_nano_aiu: 4_000_000_000,
                 },
               }),
             "",

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload } from "~/services/copilot/create-responses"
 import type { Model } from "~/services/copilot/get-models"
 
 const actualTokenUsageModule = await import("~/lib/token-usage")
+const { closeUsageStore, getTokenUsageEventsPage } = actualTokenUsageModule
 type ProviderUsageRecorderOptions = Parameters<
   (typeof actualTokenUsageModule)["createProviderTokenUsageRecorder"]
 >[0]
@@ -65,6 +66,7 @@ const originalContextManagementEnabled =
   responsesUtilsDependencies.isResponsesApiContextManagementEnabled
 const originalModelCompactThreshold =
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold
+const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
 let configBeforeTest: string | null | undefined
 
 const readConfigText = async (): Promise<string | null> =>
@@ -178,6 +180,8 @@ function buildResponsesResult(model: string, text: string) {
 }
 
 beforeEach(async () => {
+  process.env[DB_PATH_ENV] = ":memory:"
+  await closeUsageStore()
   configBeforeTest = await readConfigText()
 
   providerUsageRecords.length = 0
@@ -199,6 +203,8 @@ afterEach(async () => {
   accountsManager.selectAccountForRequest = originalSelect
   accountsManager.finalizeQuota = originalFinalize
   accountsManager.markAccountFailed = originalMarkFailed
+  await closeUsageStore()
+  Reflect.deleteProperty(process.env, DB_PATH_ENV)
 
   responsesUtilsDependencies.isResponsesApiContextManagementEnabled =
     originalContextManagementEnabled
@@ -287,6 +293,158 @@ describe("responses handler model mapping", () => {
 
     expect(response.status).toBe(200)
     expect(selectionCandidates?.[0]?.modelId).toBe("gpt-original")
+  })
+})
+
+describe("responses handler Copilot AIU token usage", () => {
+  test("records Copilot AIU from non-streaming native Responses results", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "gpt-test"))
+
+    const fetchMock = mock((_url: string, _opts?: FetchOptions) => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...buildResponsesResult("gpt-test", "ok"),
+            copilot_usage: {
+              total_nano_aiu: 1_234_000_000,
+            },
+            usage: {
+              input_tokens: 5,
+              input_tokens_details: {
+                cached_tokens: 1,
+              },
+              output_tokens: 2,
+              total_tokens: 7,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-test",
+          input: "hello",
+        }),
+      }),
+    )
+    await response.text()
+
+    const usageEvents = await getTokenUsageEventsPage({
+      page: 1,
+      pageSize: 10,
+      period: "day",
+    })
+
+    expect(response.status).toBe(200)
+    expect(usageEvents.items).toHaveLength(1)
+    expect(usageEvents.items[0]).toMatchObject({
+      cache_read_input_tokens: 1,
+      cost: {
+        amount: 0.01234,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 12_340_000,
+      },
+      endpoint: "responses",
+      input_tokens: 4,
+      model: "gpt-test",
+      output_tokens: 2,
+      source: "copilot",
+      total_nano_aiu: 1_234_000_000,
+      total_tokens: 7,
+    })
+  })
+
+  test("records Copilot AIU from streaming native Responses terminal events", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "gpt-test"))
+
+    const fetchMock = mock((_url: string, _opts?: FetchOptions) => {
+      return Promise.resolve(
+        new Response(
+          [
+            "event: response.completed",
+            `data: ${JSON.stringify({
+              copilot_usage: {
+                total_nano_aiu: 2_500_000_000,
+              },
+              response: {
+                ...buildResponsesResult("gpt-test", "ok"),
+                usage: {
+                  input_tokens: 10,
+                  input_tokens_details: {
+                    cached_tokens: 4,
+                  },
+                  output_tokens: 3,
+                  total_tokens: 13,
+                },
+              },
+              sequence_number: 1,
+              type: "response.completed",
+            })}`,
+            "",
+            "",
+          ].join("\n"),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-test",
+          input: "hello",
+          stream: true,
+        }),
+      }),
+    )
+    await response.text()
+
+    const usageEvents = await getTokenUsageEventsPage({
+      page: 1,
+      pageSize: 10,
+      period: "day",
+    })
+
+    expect(response.status).toBe(200)
+    expect(usageEvents.items).toHaveLength(1)
+    expect(usageEvents.items[0]).toMatchObject({
+      cache_read_input_tokens: 4,
+      cost: {
+        amount: 0.025,
+        currency: "USD",
+        source: "copilot_aiu",
+        total_cost_nanos: 25_000_000,
+      },
+      endpoint: "responses",
+      input_tokens: 6,
+      model: "gpt-test",
+      output_tokens: 3,
+      source: "copilot",
+      total_nano_aiu: 2_500_000_000,
+      total_tokens: 13,
+    })
   })
 })
 

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -68,6 +68,7 @@ const originalModelCompactThreshold =
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold
 const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
 let configBeforeTest: string | null | undefined
+let dbPathBeforeTest: string | undefined
 
 const readConfigText = async (): Promise<string | null> =>
   await fs.readFile(PATHS.CONFIG_PATH, "utf8").catch(() => null)
@@ -180,6 +181,7 @@ function buildResponsesResult(model: string, text: string) {
 }
 
 beforeEach(async () => {
+  dbPathBeforeTest = process.env[DB_PATH_ENV]
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
   configBeforeTest = await readConfigText()
@@ -204,7 +206,12 @@ afterEach(async () => {
   accountsManager.finalizeQuota = originalFinalize
   accountsManager.markAccountFailed = originalMarkFailed
   await closeUsageStore()
-  Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  if (dbPathBeforeTest === undefined) {
+    Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  } else {
+    process.env[DB_PATH_ENV] = dbPathBeforeTest
+  }
+  dbPathBeforeTest = undefined
 
   responsesUtilsDependencies.isResponsesApiContextManagementEnabled =
     originalContextManagementEnabled

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -13,6 +13,7 @@ import { state } from "~/lib/state"
 import {
   closeUsageStore,
   createCopilotTokenUsageRecorder,
+  mergeCopilotAiuUsage,
   normalizeOpenAIUsage,
   recordTokenUsageEvent,
   type TokenUsageDailySummary,
@@ -24,8 +25,10 @@ import { adminApiRoutes } from "~/routes/admin-api/route"
 import { tokenUsageRoute } from "~/routes/token-usage/route"
 
 const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
+let dbPathBeforeTest: string | undefined
 
 beforeEach(async () => {
+  dbPathBeforeTest = process.env[DB_PATH_ENV]
   process.env[DB_PATH_ENV] = ":memory:"
   state.userName = "copilot-login"
   await closeUsageStore()
@@ -35,7 +38,12 @@ afterEach(async () => {
   await closeUsageStore()
   setSystemTime()
   state.userName = undefined
-  Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  if (dbPathBeforeTest === undefined) {
+    Reflect.deleteProperty(process.env, DB_PATH_ENV)
+  } else {
+    process.env[DB_PATH_ENV] = dbPathBeforeTest
+  }
+  dbPathBeforeTest = undefined
 })
 
 function createTokenUsageApp(): Hono {
@@ -89,6 +97,32 @@ describe("token usage storage", () => {
       input_tokens: 68,
       output_tokens: 10,
       total_tokens: 110,
+    })
+  })
+
+  test("keeps existing AIU when merged Copilot usage is absent", () => {
+    expect(
+      mergeCopilotAiuUsage(
+        {
+          input_tokens: 100,
+          total_nano_aiu: 500,
+        },
+        null,
+      ),
+    ).toEqual({
+      input_tokens: 100,
+      total_nano_aiu: 500,
+    })
+
+    expect(
+      mergeCopilotAiuUsage(
+        {
+          input_tokens: 100,
+        },
+        undefined,
+      ),
+    ).toEqual({
+      input_tokens: 100,
     })
   })
 

--- a/tests/web-search-fulfill.test.ts
+++ b/tests/web-search-fulfill.test.ts
@@ -12,6 +12,7 @@ import type {
 
 import {
   buildSyntheticStreamEvents,
+  collectWebSearchResponsesStreamResult,
   handleWebSearchViaResponses,
   hasWebSearchServerTool,
   isWebSearchOnlyRequest,
@@ -275,6 +276,9 @@ async function* makeResponsesStream(result: ResponsesResult) {
   yield {
     event: "response.completed",
     data: JSON.stringify({
+      copilot_usage: {
+        total_nano_aiu: 987_000_000,
+      },
       response: {
         ...result,
         output: [],
@@ -426,6 +430,15 @@ describe("resolveWebSearchRoute", () => {
 })
 
 describe("handleWebSearchViaResponses", () => {
+  it("preserves Copilot AIU from terminal Responses stream events", async () => {
+    const result = await collectWebSearchResponsesStreamResult({
+      logger: consola,
+      upstreamResponse: makeResponsesStream(makeResponsesResult()),
+    })
+
+    expect(result.copilot_usage?.total_nano_aiu).toBe(987_000_000)
+  })
+
   it("switches model, runs Responses web_search, and reconstructs blocks", async () => {
     let sentPayload: ResponsesPayload | undefined
     webSearchFlowDependencies.createResponses = (payload: ResponsesPayload) => {

--- a/tests/web-search-fulfill.test.ts
+++ b/tests/web-search-fulfill.test.ts
@@ -290,6 +290,15 @@ async function* makeResponsesStream(result: ResponsesResult) {
   }
 }
 
+async function* makeResponsesStreamWithPromiseData(result: ResponsesResult) {
+  for await (const chunk of makeResponsesStream(result)) {
+    yield {
+      ...chunk,
+      data: Promise.resolve(chunk.data),
+    }
+  }
+}
+
 const originalDeps = { ...webSearchFlowDependencies }
 
 afterEach(() => {
@@ -436,6 +445,20 @@ describe("handleWebSearchViaResponses", () => {
       upstreamResponse: makeResponsesStream(makeResponsesResult()),
     })
 
+    expect(result.copilot_usage?.total_nano_aiu).toBe(987_000_000)
+  })
+
+  it("collects terminal Responses events when stream data is promise-backed", async () => {
+    const result = await collectWebSearchResponsesStreamResult({
+      logger: consola,
+      upstreamResponse: makeResponsesStreamWithPromiseData(
+        makeResponsesResult(),
+      ) as never,
+    })
+
+    expect(JSON.stringify(result.output)).toContain(
+      "Node.js 24 is the latest LTS.",
+    )
     expect(result.copilot_usage?.total_nano_aiu).toBe(987_000_000)
   })
 


### PR DESCRIPTION
## Summary
- Add Copilot AIU usage normalization and merge it into token usage records.
- Record Copilot AIU for native Responses, Chat Completions, Messages routed through Responses/Chat Completions, and Messages web-search via Responses.
- Extend Responses typings for Copilot AIU, web search output items, and newer stream events.
- Add regression coverage for streaming and non-streaming AIU capture paths.

## Validation
- bun run lint
- bun run typecheck
- bun run lint:admin
- bun run typecheck:admin
- bun run build
- bun test

## Notes
- Build succeeds with the existing bun:sqlite external warning and Vite chunk-size warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 现在会记录并汇总 Copilot AIU 相关的 token 用量，覆盖聊天补全、Responses 和 Web 搜索等请求路径。
  * 流式与非流式响应都会在结束时生成更完整的用量统计。

* **Bug 修复**
  * 修正了部分流式场景下用量未被记录或丢失的问题。
  * 改善了终端事件中的 AIU 用量回填，确保统计结果更一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->