### PR TITLE
[codex] Normalize reasoning effort by model support

### DIFF
--- a/admin-ui/src/lib/admin-api.ts
+++ b/admin-ui/src/lib/admin-api.ts
@@ -222,7 +222,14 @@ export type AdminRequestDetailResponse = {
   has_outbound?: boolean
 }
 
-export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+export type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
 
 export type ModelAliasSpec = {
   target: string
@@ -454,6 +461,7 @@ export type AdminModelDetailsItem = {
       structured_outputs?: boolean
       streaming?: boolean
       vision?: boolean
+      reasoning_effort?: Array<string>
     }
   }
   aliases: Array<string>

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -625,6 +625,11 @@
       "jsonPlaceholder": "{ \"gpt-5-mini\": \"low\" }",
       "emptyState": "No reasoning overrides. Add a model below.",
       "itemHint": "Overrides reasoning effort for this model.",
+      "aliasSupportHint": "Uses {{target}} reasoning options.",
+      "noMetadataTitle": "No reasoning effort metadata",
+      "noMetadataDescription": "This model does not currently advertise reasoning effort support.",
+      "unsupportedEffortTitle": "Effort will be normalized",
+      "unsupportedEffortDescription": "{{effort}} is kept as intent and normalized at runtime.",
       "addButton": "Add model override"
     },
     "compactThresholds": {

--- a/admin-ui/src/locales/en-US.json
+++ b/admin-ui/src/locales/en-US.json
@@ -575,6 +575,7 @@
     },
     "toast": {
       "loadModelsFailed": "Failed to load models",
+      "loadReasoningSupportFailed": "Failed to load reasoning effort metadata",
       "loadDevModeFailed": "Failed to load Developer Mode settings",
       "loadConfigFailed": "Failed to load config",
       "configSaved": "Config saved",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -575,6 +575,7 @@
     },
     "toast": {
       "loadModelsFailed": "加载模型失败",
+      "loadReasoningSupportFailed": "加载推理强度元数据失败",
       "loadDevModeFailed": "加载开发者模式设置失败",
       "loadConfigFailed": "加载配置失败",
       "configSaved": "配置已保存",

--- a/admin-ui/src/locales/zh-CN.json
+++ b/admin-ui/src/locales/zh-CN.json
@@ -625,6 +625,11 @@
       "jsonPlaceholder": "{ \\\"gpt-5-mini\\\": \\\"low\\\" }",
       "emptyState": "没有推理覆盖。请在下方添加模型。",
       "itemHint": "覆盖该模型的推理强度。",
+      "aliasSupportHint": "使用 {{target}} 的推理强度选项。",
+      "noMetadataTitle": "缺少推理强度元数据",
+      "noMetadataDescription": "该模型当前没有声明支持的推理强度。",
+      "unsupportedEffortTitle": "推理强度会被规范化",
+      "unsupportedEffortDescription": "{{effort}} 会作为意图保留，并在运行时规范化。",
       "addButton": "添加模型覆盖"
     },
     "compactThresholds": {

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -14,6 +14,7 @@ import {
   AdminApiError,
   type AdminConfig,
   type AdminConfigResponse,
+  type AdminModelDetailsItem,
   type DevModeState,
   type ModelAliasSpec,
   type ProviderAuthType,
@@ -25,6 +26,7 @@ import {
   type TokenUsagePricingTier,
   type ToolContentSupportType,
   getAdminConfig,
+  getAdminModelDetails,
   getAdminModels,
   getDevMode,
   setDevMode,
@@ -78,6 +80,7 @@ const REASONING_EFFORTS: Array<ReasoningEffort> = [
   "medium",
   "high",
   "xhigh",
+  "max",
 ]
 
 const PROVIDER_TYPES: Array<ProviderType> = [
@@ -171,6 +174,11 @@ type ReasoningItem = {
   id: string
   model: string
   effort: ReasoningEffort
+}
+
+export type ReasoningSupportInfo = {
+  efforts: Array<ReasoningEffort>
+  target?: string
 }
 
 type CompactThresholdItem = {
@@ -465,6 +473,45 @@ function reasoningRecordFromItems(
     record[key] = item.effort
   }
   return record
+}
+
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return REASONING_EFFORTS.includes(value as ReasoningEffort)
+}
+
+function normalizeReasoningSupport(
+  values: ReadonlyArray<string> | undefined,
+): Array<ReasoningEffort> {
+  if (!values) return []
+
+  const supported = new Set(
+    values.filter((value): value is ReasoningEffort => isReasoningEffort(value)),
+  )
+
+  return REASONING_EFFORTS.filter((effort) => supported.has(effort))
+}
+
+export function deriveReasoningSupportByModel(
+  details: Array<AdminModelDetailsItem>,
+): Record<string, ReasoningSupportInfo> {
+  const support: Record<string, ReasoningSupportInfo> = {}
+
+  for (const model of details) {
+    const efforts = normalizeReasoningSupport(
+      model.capabilities.supports.reasoning_effort,
+    )
+    if (efforts.length === 0) continue
+
+    support[model.id] = { efforts }
+    for (const alias of model.aliases) {
+      support[alias] = {
+        efforts,
+        target: model.id,
+      }
+    }
+  }
+
+  return support
 }
 
 function isPositiveInteger(value: number): boolean {
@@ -1201,7 +1248,7 @@ function parseExtraPromptsJson(
   }
 }
 
-function parseReasoningJson(
+export function parseReasoningJson(
   value: string,
 ): ParseResult<Record<string, ReasoningEffort>> {
   if (!value.trim()) return { record: {} }
@@ -2045,6 +2092,7 @@ type ReasoningEffortsCardProps = {
   jsonIssue: string | null
   items: Array<ReasoningItem>
   models: Array<string>
+  reasoningSupportByModel?: Record<string, ReasoningSupportInfo>
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -2052,12 +2100,13 @@ type ReasoningEffortsCardProps = {
   onUpdateItem: (id: string, patch: Partial<ReasoningItem>) => void
 }
 
-function ReasoningEffortsCard({
+export function ReasoningEffortsCard({
   mode,
   json,
   jsonIssue,
   items,
   models,
+  reasoningSupportByModel = {},
   onToggleMode,
   onJsonChange,
   onAddItem,
@@ -2111,9 +2160,27 @@ function ReasoningEffortsCard({
                 const showCustomModel =
                   modelValue !== defaultModelValue && !models.includes(modelValue)
                 const disableModelSelect = !hasModels && !showCustomModel
+                const supportInfo =
+                  modelValue !== defaultModelValue
+                    ? reasoningSupportByModel[modelValue]
+                    : undefined
+                const supportedEfforts =
+                  supportInfo?.efforts.length ? supportInfo.efforts : REASONING_EFFORTS
+                const showUnsupportedConfiguredEffort =
+                  !supportedEfforts.includes(item.effort)
+                const effortOptions =
+                  showUnsupportedConfiguredEffort
+                    ? [item.effort, ...supportedEfforts]
+                    : supportedEfforts
 
                 return (
-                  <div key={item.id} className="grid gap-2 rounded-lg border p-3">
+                  <div
+                    key={item.id}
+                    className="grid gap-2 rounded-lg border p-3"
+                    data-reasoning-model={modelValue}
+                    data-reasoning-target={supportInfo?.target}
+                    data-reasoning-effort-options={effortOptions.join(",")}
+                  >
                     <div className="flex flex-wrap items-center gap-2">
                       <Select
                         value={modelValue}
@@ -2159,7 +2226,7 @@ function ReasoningEffortsCard({
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {REASONING_EFFORTS.map((effort) => (
+                          {effortOptions.map((effort) => (
                             <SelectItem key={effort} value={effort}>
                               {effort}
                             </SelectItem>
@@ -2175,6 +2242,25 @@ function ReasoningEffortsCard({
                         {t("settingsPage.common.remove")}
                       </Button>
                     </div>
+                    {supportInfo?.target ? (
+                      <div className="text-muted-foreground text-xs">
+                        {`Uses ${supportInfo.target} reasoning options.`}
+                      </div>
+                    ) : null}
+                    {modelValue !== defaultModelValue && !supportInfo ? (
+                      <InlineAlert
+                        variant="warning"
+                        title="No reasoning effort metadata"
+                        description="This model does not currently advertise reasoning effort support."
+                      />
+                    ) : null}
+                    {showUnsupportedConfiguredEffort ? (
+                      <InlineAlert
+                        variant="warning"
+                        title="Effort will be normalized"
+                        description={`${item.effort} is kept as intent and normalized at runtime.`}
+                      />
+                    ) : null}
                     <div className="text-muted-foreground text-xs">
                       {t("settingsPage.reasoning.itemHint")}
                     </div>
@@ -4172,6 +4258,7 @@ type SettingsPageViewProps = {
   reasoningJson: string
   reasoningJsonIssue: string | null
   reasoningItems: Array<ReasoningItem>
+  reasoningSupportByModel: Record<string, ReasoningSupportInfo>
   onReasoningToggleMode: (next: boolean) => void
   onReasoningJsonChange: (value: string) => void
   onReasoningAddItem: () => void
@@ -4261,6 +4348,9 @@ function useSettingsPageState(): SettingsPageViewProps {
   const [configPath, setConfigPath] = useState<string | null>(null)
 
   const [models, setModels] = useState<Array<string>>([])
+  const [reasoningSupportByModel, setReasoningSupportByModel] = useState<
+    Record<string, ReasoningSupportInfo>
+  >({})
   const [devMode, setDevModeState] = useState<DevModeState>({
     enabled: false,
     capture4xx: false,
@@ -4444,11 +4534,13 @@ function useSettingsPageState(): SettingsPageViewProps {
     setError(null)
 
     try {
-      const [configRes, modelsRes, devModeRes] = await Promise.allSettled([
-        getAdminConfig(),
-        getAdminModels(),
-        getDevMode(),
-      ])
+      const [configRes, modelsRes, modelDetailsRes, devModeRes] =
+        await Promise.allSettled([
+          getAdminConfig(),
+          getAdminModels(),
+          getAdminModelDetails(),
+          getDevMode(),
+        ])
 
       if (configRes.status === "fulfilled") {
         applyConfigResponse(configRes.value)
@@ -4463,6 +4555,20 @@ function useSettingsPageState(): SettingsPageViewProps {
         toast.error(i18n.t("settingsPage.toast.loadModelsFailed"), {
           description:
             modelsRes.reason instanceof Error ? modelsRes.reason.message : String(modelsRes.reason),
+        })
+      }
+
+      if (modelDetailsRes.status === "fulfilled") {
+        setReasoningSupportByModel(
+          deriveReasoningSupportByModel(modelDetailsRes.value.items),
+        )
+      } else {
+        setReasoningSupportByModel({})
+        toast.error(i18n.t("settingsPage.toast.loadModelsFailed"), {
+          description:
+            modelDetailsRes.reason instanceof Error
+              ? modelDetailsRes.reason.message
+              : String(modelDetailsRes.reason),
         })
       }
 
@@ -4806,6 +4912,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     reasoningJson,
     reasoningJsonIssue,
     reasoningItems,
+    reasoningSupportByModel,
     onReasoningToggleMode,
     onReasoningJsonChange,
     onReasoningAddItem,
@@ -4919,6 +5026,7 @@ function SettingsPageView({
   reasoningJson,
   reasoningJsonIssue,
   reasoningItems,
+  reasoningSupportByModel,
   onReasoningToggleMode,
   onReasoningJsonChange,
   onReasoningAddItem,
@@ -5144,6 +5252,7 @@ function SettingsPageView({
               jsonIssue={reasoningJsonIssue}
               items={reasoningItems}
               models={models}
+              reasoningSupportByModel={reasoningSupportByModel}
               onToggleMode={onReasoningToggleMode}
               onJsonChange={onReasoningJsonChange}
               onAddItem={onReasoningAddItem}

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -2093,6 +2093,7 @@ type ReasoningEffortsCardProps = {
   items: Array<ReasoningItem>
   models: Array<string>
   reasoningSupportByModel?: Record<string, ReasoningSupportInfo>
+  reasoningSupportLoaded?: boolean
   onToggleMode: (next: boolean) => void
   onJsonChange: (value: string) => void
   onAddItem: () => void
@@ -2107,6 +2108,7 @@ export function ReasoningEffortsCard({
   items,
   models,
   reasoningSupportByModel = {},
+  reasoningSupportLoaded = true,
   onToggleMode,
   onJsonChange,
   onAddItem,
@@ -2157,17 +2159,24 @@ export function ReasoningEffortsCard({
             ) : (
               items.map((item) => {
                 const modelValue = item.model || defaultModelValue
+                const isDefaultModel = modelValue === defaultModelValue
                 const showCustomModel =
-                  modelValue !== defaultModelValue && !models.includes(modelValue)
+                  !isDefaultModel && !models.includes(modelValue)
                 const disableModelSelect = !hasModels && !showCustomModel
                 const supportInfo =
-                  modelValue !== defaultModelValue
-                    ? reasoningSupportByModel[modelValue]
-                    : undefined
+                  !isDefaultModel ? reasoningSupportByModel[modelValue] : undefined
+                const supportEfforts = supportInfo?.efforts ?? []
+                const hasSupportEfforts = supportEfforts.length > 0
+                const supportMissingForModel =
+                  reasoningSupportLoaded && !isDefaultModel && !hasSupportEfforts
                 const supportedEfforts =
-                  supportInfo?.efforts.length ? supportInfo.efforts : REASONING_EFFORTS
+                  hasSupportEfforts
+                    ? supportEfforts
+                    : supportMissingForModel
+                      ? [item.effort]
+                      : REASONING_EFFORTS
                 const showUnsupportedConfiguredEffort =
-                  !supportedEfforts.includes(item.effort)
+                  hasSupportEfforts && !supportEfforts.includes(item.effort)
                 const effortOptions =
                   showUnsupportedConfiguredEffort
                     ? [item.effort, ...supportedEfforts]
@@ -2180,6 +2189,9 @@ export function ReasoningEffortsCard({
                     data-reasoning-model={modelValue}
                     data-reasoning-target={supportInfo?.target}
                     data-reasoning-effort-options={effortOptions.join(",")}
+                    data-reasoning-effort-disabled={
+                      supportMissingForModel ? "true" : undefined
+                    }
                   >
                     <div className="flex flex-wrap items-center gap-2">
                       <Select
@@ -2221,6 +2233,7 @@ export function ReasoningEffortsCard({
                         onValueChange={(value) =>
                           onUpdateItem(item.id, { effort: value as ReasoningEffort })
                         }
+                        disabled={supportMissingForModel}
                       >
                         <SelectTrigger className="w-40">
                           <SelectValue />
@@ -2244,21 +2257,28 @@ export function ReasoningEffortsCard({
                     </div>
                     {supportInfo?.target ? (
                       <div className="text-muted-foreground text-xs">
-                        {`Uses ${supportInfo.target} reasoning options.`}
+                        {t("settingsPage.reasoning.aliasSupportHint", {
+                          target: supportInfo.target,
+                        })}
                       </div>
                     ) : null}
-                    {modelValue !== defaultModelValue && !supportInfo ? (
+                    {supportMissingForModel ? (
                       <InlineAlert
                         variant="warning"
-                        title="No reasoning effort metadata"
-                        description="This model does not currently advertise reasoning effort support."
+                        title={t("settingsPage.reasoning.noMetadataTitle")}
+                        description={t(
+                          "settingsPage.reasoning.noMetadataDescription",
+                        )}
                       />
                     ) : null}
                     {showUnsupportedConfiguredEffort ? (
                       <InlineAlert
                         variant="warning"
-                        title="Effort will be normalized"
-                        description={`${item.effort} is kept as intent and normalized at runtime.`}
+                        title={t("settingsPage.reasoning.unsupportedEffortTitle")}
+                        description={t(
+                          "settingsPage.reasoning.unsupportedEffortDescription",
+                          { effort: item.effort },
+                        )}
                       />
                     ) : null}
                     <div className="text-muted-foreground text-xs">
@@ -4259,6 +4279,7 @@ type SettingsPageViewProps = {
   reasoningJsonIssue: string | null
   reasoningItems: Array<ReasoningItem>
   reasoningSupportByModel: Record<string, ReasoningSupportInfo>
+  reasoningSupportLoaded: boolean
   onReasoningToggleMode: (next: boolean) => void
   onReasoningJsonChange: (value: string) => void
   onReasoningAddItem: () => void
@@ -4351,6 +4372,7 @@ function useSettingsPageState(): SettingsPageViewProps {
   const [reasoningSupportByModel, setReasoningSupportByModel] = useState<
     Record<string, ReasoningSupportInfo>
   >({})
+  const [reasoningSupportLoaded, setReasoningSupportLoaded] = useState(false)
   const [devMode, setDevModeState] = useState<DevModeState>({
     enabled: false,
     capture4xx: false,
@@ -4562,8 +4584,10 @@ function useSettingsPageState(): SettingsPageViewProps {
         setReasoningSupportByModel(
           deriveReasoningSupportByModel(modelDetailsRes.value.items),
         )
+        setReasoningSupportLoaded(true)
       } else {
         setReasoningSupportByModel({})
+        setReasoningSupportLoaded(false)
         toast.error(i18n.t("settingsPage.toast.loadModelsFailed"), {
           description:
             modelDetailsRes.reason instanceof Error
@@ -4913,6 +4937,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     reasoningJsonIssue,
     reasoningItems,
     reasoningSupportByModel,
+    reasoningSupportLoaded,
     onReasoningToggleMode,
     onReasoningJsonChange,
     onReasoningAddItem,
@@ -5027,6 +5052,7 @@ function SettingsPageView({
   reasoningJsonIssue,
   reasoningItems,
   reasoningSupportByModel,
+  reasoningSupportLoaded,
   onReasoningToggleMode,
   onReasoningJsonChange,
   onReasoningAddItem,
@@ -5253,6 +5279,7 @@ function SettingsPageView({
               items={reasoningItems}
               models={models}
               reasoningSupportByModel={reasoningSupportByModel}
+              reasoningSupportLoaded={reasoningSupportLoaded}
               onToggleMode={onReasoningToggleMode}
               onJsonChange={onReasoningJsonChange}
               onAddItem={onReasoningAddItem}

--- a/admin-ui/src/pages/settings-page.tsx
+++ b/admin-ui/src/pages/settings-page.tsx
@@ -498,7 +498,7 @@ export function deriveReasoningSupportByModel(
 
   for (const model of details) {
     const efforts = normalizeReasoningSupport(
-      model.capabilities.supports.reasoning_effort,
+      model.capabilities?.supports?.reasoning_effort,
     )
     if (efforts.length === 0) continue
 
@@ -4551,18 +4551,36 @@ function useSettingsPageState(): SettingsPageViewProps {
     ],
   )
 
+  const loadReasoningSupport = useCallback(async () => {
+    setReasoningSupportLoaded(false)
+    setReasoningSupportByModel({})
+
+    try {
+      const modelDetails = await getAdminModelDetails()
+      setReasoningSupportByModel(
+        deriveReasoningSupportByModel(modelDetails.items ?? []),
+      )
+      setReasoningSupportLoaded(true)
+    } catch (err) {
+      setReasoningSupportByModel({})
+      setReasoningSupportLoaded(false)
+      toast.error(i18n.t("settingsPage.toast.loadReasoningSupportFailed"), {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [])
+
   const load = useCallback(async () => {
     setLoading(true)
     setError(null)
+    setReasoningSupportLoaded(false)
 
     try {
-      const [configRes, modelsRes, modelDetailsRes, devModeRes] =
-        await Promise.allSettled([
-          getAdminConfig(),
-          getAdminModels(),
-          getAdminModelDetails(),
-          getDevMode(),
-        ])
+      const [configRes, modelsRes, devModeRes] = await Promise.allSettled([
+        getAdminConfig(),
+        getAdminModels(),
+        getDevMode(),
+      ])
 
       if (configRes.status === "fulfilled") {
         applyConfigResponse(configRes.value)
@@ -4580,22 +4598,6 @@ function useSettingsPageState(): SettingsPageViewProps {
         })
       }
 
-      if (modelDetailsRes.status === "fulfilled") {
-        setReasoningSupportByModel(
-          deriveReasoningSupportByModel(modelDetailsRes.value.items),
-        )
-        setReasoningSupportLoaded(true)
-      } else {
-        setReasoningSupportByModel({})
-        setReasoningSupportLoaded(false)
-        toast.error(i18n.t("settingsPage.toast.loadModelsFailed"), {
-          description:
-            modelDetailsRes.reason instanceof Error
-              ? modelDetailsRes.reason.message
-              : String(modelDetailsRes.reason),
-        })
-      }
-
       if (devModeRes.status === "fulfilled") {
         setDevModeState(devModeRes.value)
       } else {
@@ -4607,6 +4609,8 @@ function useSettingsPageState(): SettingsPageViewProps {
               : String(devModeRes.reason),
         })
       }
+
+      void loadReasoningSupport()
     } catch (err) {
       const msg = err instanceof AdminApiError ? err.message : String(err)
       setError(msg)
@@ -4614,7 +4618,7 @@ function useSettingsPageState(): SettingsPageViewProps {
     } finally {
       setLoading(false)
     }
-  }, [applyConfigResponse])
+  }, [applyConfigResponse, loadReasoningSupport])
 
   useEffect(() => {
     void load()

--- a/admin-ui/tests/settings-page.test.tsx
+++ b/admin-ui/tests/settings-page.test.tsx
@@ -306,6 +306,53 @@ test("reasoning editor shows alias support inherited from target", () => {
   expect(html).toContain("xhigh")
 })
 
+test("reasoning editor disables effort choices when loaded metadata lacks model support", () => {
+  const html = renderToStaticMarkup(
+    <ReasoningEffortsCard
+      mode="form"
+      json="{}"
+      jsonIssue={null}
+      items={[{ id: "reasoning-1", model: "gemini-lite", effort: "medium" }]}
+      models={["gemini-lite"]}
+      reasoningSupportByModel={{}}
+      reasoningSupportLoaded
+      onToggleMode={() => {}}
+      onJsonChange={() => {}}
+      onAddItem={() => {}}
+      onRemoveItem={() => {}}
+      onUpdateItem={() => {}}
+    />,
+  )
+
+  expect(html).toContain('data-reasoning-effort-disabled="true"')
+  expect(html).toContain('data-reasoning-effort-options="medium"')
+  expect(html).toContain("No reasoning effort metadata")
+  expect(html).not.toContain("xhigh")
+})
+
+test("reasoning editor falls back without row warnings when metadata fails to load", () => {
+  const html = renderToStaticMarkup(
+    <ReasoningEffortsCard
+      mode="form"
+      json="{}"
+      jsonIssue={null}
+      items={[{ id: "reasoning-1", model: "gemini-lite", effort: "medium" }]}
+      models={["gemini-lite"]}
+      reasoningSupportByModel={{}}
+      reasoningSupportLoaded={false}
+      onToggleMode={() => {}}
+      onJsonChange={() => {}}
+      onAddItem={() => {}}
+      onRemoveItem={() => {}}
+      onUpdateItem={() => {}}
+    />,
+  )
+
+  expect(html).not.toContain("No reasoning effort metadata")
+  expect(html).not.toContain('data-reasoning-effort-disabled="true"')
+  expect(html).toContain("xhigh")
+})
+
 test("reasoning JSON validation accepts max", () => {
   expect(parseReasoningJson('{ "gpt-5.5": "max" }')).toEqual({
     record: {

--- a/admin-ui/tests/settings-page.test.tsx
+++ b/admin-ui/tests/settings-page.test.tsx
@@ -3,13 +3,16 @@ import { renderToStaticMarkup } from "react-dom/server"
 
 import {
   ModelMappingsCard,
+  ReasoningEffortsCard,
   ResponsesApiSettingsCard,
   compactThresholdRecordFromItems,
   createQuickProviderItem,
+  deriveReasoningSupportByModel,
   deriveProviderModelSuggestions,
   getUniqueProviderName,
   parseCompactThresholdsJson,
   parseModelMappingsJson,
+  parseReasoningJson,
 } from "../src/pages/settings-page"
 
 test("Responses API settings exposes transport toggles and context management", () => {
@@ -246,6 +249,92 @@ test("compact threshold form record skips decimals", () => {
   ])
 
   expect(record).toEqual({ "gpt-5.5": 2 })
+})
+
+test("reasoning editor renders model-specific effort choices", () => {
+  const html = renderToStaticMarkup(
+    <ReasoningEffortsCard
+      mode="form"
+      json="{}"
+      jsonIssue={null}
+      items={[{ id: "reasoning-1", model: "gpt-5-mini", effort: "low" }]}
+      models={["gpt-5-mini"]}
+      reasoningSupportByModel={{
+        "gpt-5-mini": {
+          efforts: ["low", "medium"],
+        },
+      }}
+      onToggleMode={() => {}}
+      onJsonChange={() => {}}
+      onAddItem={() => {}}
+      onRemoveItem={() => {}}
+      onUpdateItem={() => {}}
+    />,
+  )
+
+  expect(html).toContain("gpt-5-mini")
+  expect(html).toContain("low")
+  expect(html).toContain("medium")
+  expect(html).not.toContain("xhigh")
+})
+
+test("reasoning editor shows alias support inherited from target", () => {
+  const html = renderToStaticMarkup(
+    <ReasoningEffortsCard
+      mode="form"
+      json="{}"
+      jsonIssue={null}
+      items={[{ id: "reasoning-1", model: "fast", effort: "xhigh" }]}
+      models={["fast"]}
+      reasoningSupportByModel={{
+        fast: {
+          efforts: ["high", "xhigh"],
+          target: "gpt-5.4",
+        },
+      }}
+      onToggleMode={() => {}}
+      onJsonChange={() => {}}
+      onAddItem={() => {}}
+      onRemoveItem={() => {}}
+      onUpdateItem={() => {}}
+    />,
+  )
+
+  expect(html).toContain("fast")
+  expect(html).toContain("gpt-5.4")
+  expect(html).toContain("high")
+  expect(html).toContain("xhigh")
+})
+
+test("reasoning JSON validation accepts max", () => {
+  expect(parseReasoningJson('{ "gpt-5.5": "max" }')).toEqual({
+    record: {
+      "gpt-5.5": "max",
+    },
+  })
+})
+
+test("reasoning support derivation includes aliases and ignores unknown efforts", () => {
+  expect(
+    deriveReasoningSupportByModel([
+      {
+        id: "gpt-5-mini",
+        name: "GPT-5 mini",
+        preview: false,
+        supported_endpoints: ["/chat/completions"],
+        capabilities: {
+          limits: {},
+          supports: {
+            reasoning_effort: ["low", "medium", "ultra", "xhigh"],
+          },
+        },
+        aliases: ["fast"],
+      },
+    ]),
+  ).toEqual({
+    "gpt-5-mini": { efforts: ["low", "medium", "xhigh"] },
+    fast: { efforts: ["low", "medium", "xhigh"], target: "gpt-5-mini" },
+  })
 })
 
 test("model mappings card renders mappings editor", () => {

--- a/docs/superpowers/plans/2026-07-01-reasoning-effort-normalization.md
+++ b/docs/superpowers/plans/2026-07-01-reasoning-effort-normalization.md
@@ -278,16 +278,24 @@ export function resolveReasoningEffortForTarget(params: {
   explicitEffort: unknown
   requestModel: string
   targetModel: Pick<Model, "capabilities"> | undefined
-  defaultEffortResolver?: (model: string) => ReasoningEffort
+  targetModelId?: string
+  defaultEffortResolver?: (model: string) => ReasoningEffort | undefined
 }): ReasoningEffort | undefined {
+  if (params.explicitEffort === null) return undefined
+
   const explicit = parseReasoningEffort(params.explicitEffort)
   const defaultEffortResolver =
-    params.defaultEffortResolver ?? getReasoningEffortForModel
-  const intent = explicit ?? defaultEffortResolver(params.requestModel)
+    params.defaultEffortResolver ?? getConfiguredReasoningEffortForModel
+  const requestDefault = defaultEffortResolver(params.requestModel)
+  const targetDefault =
+    params.targetModelId && params.targetModelId !== params.requestModel ?
+      defaultEffortResolver(params.targetModelId)
+    : undefined
+  const intent = explicit ?? requestDefault ?? targetDefault
 
   return normalizeReasoningEffortForSupport(
     intent,
-    params.targetModel?.capabilities.supports.reasoning_effort,
+    params.targetModel?.capabilities?.supports?.reasoning_effort,
   )
 }
 ```
@@ -1506,21 +1514,29 @@ Accept the prop with a default:
 Inside the `items.map((item) => {` callback before the `return (` statement, derive options:
 
 ```ts
+                const isDefaultModel = modelValue === defaultModelValue
                 const supportInfo =
-                  modelValue !== defaultModelValue ?
-                    reasoningSupportByModel[modelValue]
-                  : undefined
+                  !isDefaultModel ? reasoningSupportByModel[modelValue] : undefined
+                const supportEfforts = supportInfo?.efforts ?? []
+                const hasSupportEfforts = supportEfforts.length > 0
+                const supportMissingForModel =
+                  reasoningSupportLoaded && !isDefaultModel && !hasSupportEfforts
                 const supportedEfforts =
-                  supportInfo?.efforts.length ? supportInfo.efforts : REASONING_EFFORTS
+                  hasSupportEfforts
+                    ? supportEfforts
+                    : supportMissingForModel
+                      ? [item.effort]
+                      : REASONING_EFFORTS
                 const showUnsupportedConfiguredEffort =
-                  item.effort && !supportedEfforts.includes(item.effort)
+                  hasSupportEfforts && !supportEfforts.includes(item.effort)
                 const effortOptions =
                   showUnsupportedConfiguredEffort ?
                     [item.effort, ...supportedEfforts]
                   : supportedEfforts
 ```
 
-Replace the effort `SelectContent` mapping with:
+Pass `disabled={supportMissingForModel}` to the effort `Select`, then replace the
+effort `SelectContent` mapping with:
 
 ```tsx
                         <SelectContent>
@@ -1540,7 +1556,7 @@ Below the row controls, before the existing item hint, render alias/support hint
                           {`Uses ${supportInfo.target} reasoning options.`}
                         </div>
                       ) : null}
-                      {modelValue !== defaultModelValue && !supportInfo ? (
+                      {supportMissingForModel ? (
                         <InlineAlert
                           variant="warning"
                           title="No reasoning effort metadata"

--- a/docs/superpowers/plans/2026-07-01-reasoning-effort-normalization.md
+++ b/docs/superpowers/plans/2026-07-01-reasoning-effort-normalization.md
@@ -1,0 +1,1650 @@
+# Reasoning Effort Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Normalize reasoning effort defaults and explicit request values against each final Copilot upstream model's advertised support list.
+
+**Architecture:** Add one shared reasoning-effort helper module, then route all Chat Completions, Responses, and Messages request preparation through it after the final upstream model is selected. Extend Admin API and Admin UI so model-specific reasoning effort support from cached `/models` metadata is visible and usable in settings.
+
+**Tech Stack:** Bun test runner, TypeScript, Hono route handlers, React Admin UI with existing shadcn-style controls.
+
+---
+
+## File Structure
+
+- Create `src/lib/reasoning-effort.ts`: owns canonical effort order, parsing, support filtering, nearest-value normalization, and request default resolution.
+- Create `tests/reasoning-effort.test.ts`: focused unit coverage for helper semantics.
+- Modify `src/lib/config.ts`: allow `max` in `modelReasoningEfforts`.
+- Modify `src/routes/admin-api/route.ts`: allow `max` in config validation and expose `capabilities.supports.reasoning_effort` from model details.
+- Modify `admin-ui/src/lib/admin-api.ts`: update wire/UI types for `max` and model detail support arrays.
+- Modify `admin-ui/src/pages/settings-page.tsx`: load model details, derive reasoning support for aliases, and render model-specific effort options.
+- Modify `admin-ui/tests/settings-page.test.tsx`: cover model-specific and alias reasoning effort rendering plus JSON `max`.
+- Modify `tests/admin-config.test.ts`: accept `max` in config save.
+- Modify `tests/admin-models-details.test.ts`: assert model detail support metadata includes `reasoning_effort`.
+- Modify `src/services/copilot/create-chat-completions.ts`: remove service-layer `gpt-5-mini` default injection once route-level normalization exists.
+- Modify `src/services/copilot/create-responses.ts`: include `max` in the `Reasoning.effort` type.
+- Modify `src/routes/chat-completions/handler.ts`: normalize `reasoning_effort` after account/model selection.
+- Modify `src/routes/responses/handler.ts`: normalize `reasoning.effort` after account/model selection.
+- Modify `src/routes/messages/preprocess.ts`: use the shared helper for native Messages API payload preparation.
+- Modify `src/routes/messages/non-stream-translation.ts`: keep downstream effort extraction, with final normalization happening after selection.
+- Modify `src/routes/messages/responses-translation.ts`: accept normalized effort from the handler instead of reading config directly.
+- Modify `src/routes/messages/handler.ts`: pass normalized effort into Messages, Responses, and Chat Completions upstream paths.
+- Modify `tests/chat-completions-handler.test.ts`, `tests/responses-handler.test.ts`, and `tests/messages-handler.test.ts`: verify route behavior.
+- Modify `tests/create-chat-completions.test.ts`: remove or update tests that assert the old `gpt-5-mini` service special case.
+
+---
+
+### Task 1: Shared Reasoning Effort Helper
+
+**Files:**
+- Create: `src/lib/reasoning-effort.ts`
+- Create: `tests/reasoning-effort.test.ts`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Create `tests/reasoning-effort.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+
+import type { Model } from "~/services/copilot/get-models"
+
+import {
+  getReasoningEffortSupport,
+  normalizeReasoningEffortForSupport,
+  parseReasoningEffort,
+  resolveReasoningEffortForTarget,
+} from "~/lib/reasoning-effort"
+
+const buildModel = (
+  reasoningEffort?: Array<string>,
+): Pick<Model, "capabilities"> => ({
+  capabilities: {
+    family: "test",
+    limits: {},
+    object: "capabilities",
+    supports: {
+      reasoning_effort: reasoningEffort,
+    },
+    tokenizer: "test",
+    type: "chat",
+  },
+})
+
+describe("reasoning effort normalization", () => {
+  test("parses only canonical effort values", () => {
+    expect(parseReasoningEffort("none")).toBe("none")
+    expect(parseReasoningEffort("minimal")).toBe("minimal")
+    expect(parseReasoningEffort("low")).toBe("low")
+    expect(parseReasoningEffort("medium")).toBe("medium")
+    expect(parseReasoningEffort("high")).toBe("high")
+    expect(parseReasoningEffort("xhigh")).toBe("xhigh")
+    expect(parseReasoningEffort("max")).toBe("max")
+    expect(parseReasoningEffort("ultra")).toBeUndefined()
+    expect(parseReasoningEffort(null)).toBeUndefined()
+  })
+
+  test("normalizes to the closest supported lower value on ties", () => {
+    expect(
+      normalizeReasoningEffortForSupport("max", [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+      ]),
+    ).toBe("xhigh")
+    expect(
+      normalizeReasoningEffortForSupport("minimal", [
+        "low",
+        "medium",
+        "high",
+      ]),
+    ).toBe("low")
+    expect(
+      normalizeReasoningEffortForSupport("xhigh", [
+        "low",
+        "medium",
+        "high",
+      ]),
+    ).toBe("high")
+    expect(normalizeReasoningEffortForSupport("medium", ["low", "high"])).toBe(
+      "low",
+    )
+  })
+
+  test("omits effort when support is missing, empty, or unknown", () => {
+    expect(normalizeReasoningEffortForSupport("high", undefined)).toBeUndefined()
+    expect(normalizeReasoningEffortForSupport("high", [])).toBeUndefined()
+    expect(
+      normalizeReasoningEffortForSupport("high", ["turbo", "ultra"]),
+    ).toBeUndefined()
+  })
+
+  test("extracts sorted unique canonical support from model metadata", () => {
+    expect(
+      getReasoningEffortSupport(
+        buildModel(["xhigh", "low", "low", "ultra", "medium"]),
+      ),
+    ).toEqual(["low", "medium", "xhigh"])
+  })
+
+  test("uses explicit effort before configured default", () => {
+    const model = buildModel(["low", "medium", "high", "xhigh"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: "max",
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "low",
+      }),
+    ).toBe("xhigh")
+  })
+
+  test("uses configured default when explicit effort is omitted or invalid", () => {
+    const model = buildModel(["low", "medium"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "high",
+      }),
+    ).toBe("medium")
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: "ultra",
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "high",
+      }),
+    ).toBe("medium")
+  })
+})
+```
+
+- [ ] **Step 2: Run the helper test and verify it fails**
+
+Run:
+
+```bash
+bun test tests/reasoning-effort.test.ts
+```
+
+Expected: FAIL with a module resolution error for `~/lib/reasoning-effort`.
+
+- [ ] **Step 3: Add the helper implementation**
+
+Create `src/lib/reasoning-effort.ts`:
+
+```ts
+import type { Model } from "~/services/copilot/get-models"
+
+import { getReasoningEffortForModel } from "~/lib/config"
+
+export const REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number]
+
+const REASONING_EFFORT_RANKS = new Map<ReasoningEffort, number>(
+  REASONING_EFFORTS.map((effort, index) => [effort, index]),
+)
+
+export function parseReasoningEffort(
+  value: unknown,
+): ReasoningEffort | undefined {
+  if (typeof value !== "string") return undefined
+  return REASONING_EFFORT_RANKS.has(value as ReasoningEffort) ?
+      (value as ReasoningEffort)
+    : undefined
+}
+
+export function getReasoningEffortSupport(
+  model: Pick<Model, "capabilities"> | undefined,
+): Array<ReasoningEffort> | undefined {
+  const rawSupport = model?.capabilities.supports.reasoning_effort
+  if (!Array.isArray(rawSupport)) return undefined
+
+  const seen = new Set<ReasoningEffort>()
+  for (const item of rawSupport) {
+    const effort = parseReasoningEffort(item)
+    if (effort) seen.add(effort)
+  }
+
+  const support = [...seen].sort(
+    (left, right) =>
+      (REASONING_EFFORT_RANKS.get(left) ?? 0)
+      - (REASONING_EFFORT_RANKS.get(right) ?? 0),
+  )
+
+  return support.length > 0 ? support : undefined
+}
+
+export function normalizeReasoningEffortForSupport(
+  intent: unknown,
+  rawSupport: ReadonlyArray<string> | undefined,
+): ReasoningEffort | undefined {
+  const requested = parseReasoningEffort(intent)
+  if (!requested) return undefined
+
+  const support = getReasoningEffortSupport({
+    capabilities: {
+      family: "",
+      limits: {},
+      object: "",
+      supports: {
+        reasoning_effort: rawSupport ? [...rawSupport] : undefined,
+      },
+      tokenizer: "",
+      type: "",
+    },
+  })
+  if (!support) return undefined
+
+  if (support.includes(requested)) return requested
+
+  const requestedRank = REASONING_EFFORT_RANKS.get(requested) ?? 0
+  let best = support[0]
+  let bestDistance = Number.POSITIVE_INFINITY
+  let bestRank = REASONING_EFFORT_RANKS.get(best) ?? 0
+
+  for (const candidate of support) {
+    const candidateRank = REASONING_EFFORT_RANKS.get(candidate) ?? 0
+    const distance = Math.abs(candidateRank - requestedRank)
+    if (
+      distance < bestDistance
+      || (distance === bestDistance && candidateRank < bestRank)
+    ) {
+      best = candidate
+      bestDistance = distance
+      bestRank = candidateRank
+    }
+  }
+
+  return best
+}
+
+export function resolveReasoningEffortForTarget(params: {
+  explicitEffort: unknown
+  requestModel: string
+  targetModel: Pick<Model, "capabilities"> | undefined
+  defaultEffortResolver?: (model: string) => ReasoningEffort
+}): ReasoningEffort | undefined {
+  const explicit = parseReasoningEffort(params.explicitEffort)
+  const defaultEffortResolver =
+    params.defaultEffortResolver ?? getReasoningEffortForModel
+  const intent = explicit ?? defaultEffortResolver(params.requestModel)
+
+  return normalizeReasoningEffortForSupport(
+    intent,
+    params.targetModel?.capabilities.supports.reasoning_effort,
+  )
+}
+```
+
+- [ ] **Step 4: Run the helper test and verify it passes**
+
+Run:
+
+```bash
+bun test tests/reasoning-effort.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the helper**
+
+```bash
+git add src/lib/reasoning-effort.ts tests/reasoning-effort.test.ts
+git commit -m "feat: add reasoning effort normalization helper"
+```
+
+---
+
+### Task 2: Admin Config And Model Detail Metadata
+
+**Files:**
+- Modify: `src/lib/config.ts`
+- Modify: `src/routes/admin-api/route.ts`
+- Modify: `admin-ui/src/lib/admin-api.ts`
+- Modify: `tests/admin-config.test.ts`
+- Modify: `tests/admin-models-details.test.ts`
+
+- [ ] **Step 1: Write failing Admin API tests**
+
+In `tests/admin-config.test.ts`, replace the existing test named `POST /api/admin/config keeps reasoning max out of config layer` with:
+
+```ts
+test("POST /api/admin/config accepts max reasoning effort as intent", async () => {
+  await withConfig({}, async () => {
+    const { server } = await import("../src/server")
+
+    const res = await server.fetch(
+      new Request("http://localhost/api/admin/config", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          modelReasoningEfforts: {
+            "gpt-5.5": "max",
+          },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      modelReasoningEfforts?: Record<string, string>
+    }
+    expect(body.modelReasoningEfforts?.["gpt-5.5"]).toBe("max")
+  })
+})
+```
+
+In `tests/admin-models-details.test.ts`, update the `gpt-5-mini` override object in the first test so it includes reasoning support:
+
+```ts
+capabilities: {
+  family: "test",
+  limits: {
+    max_context_window_tokens: 128_000,
+    max_prompt_tokens: 96_000,
+    max_output_tokens: 32_000,
+  },
+  object: "capabilities",
+  supports: {
+    tool_calls: true,
+    vision: false,
+    structured_outputs: true,
+    streaming: true,
+    parallel_tool_calls: true,
+    reasoning_effort: ["low", "medium", "high", "xhigh"],
+  },
+  tokenizer: "test",
+  type: "chat",
+},
+```
+
+Then update the local response type and assertion in that same test:
+
+```ts
+capabilities: {
+  limits: {
+    max_context_window_tokens?: number
+    max_prompt_tokens?: number
+    max_output_tokens?: number
+  }
+  supports: {
+    tool_calls?: boolean
+    reasoning_effort?: Array<string>
+  }
+}
+```
+
+```ts
+expect(mini?.capabilities.supports.reasoning_effort).toEqual([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+])
+```
+
+- [ ] **Step 2: Run the Admin API tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/admin-config.test.ts tests/admin-models-details.test.ts
+```
+
+Expected: FAIL. The config test should reject `max`, and the model details test should not see `reasoning_effort`.
+
+- [ ] **Step 3: Allow `max` in config types and validation**
+
+In `src/lib/config.ts`, change the `modelReasoningEfforts` type to:
+
+```ts
+  modelReasoningEfforts?: Record<
+    string,
+    "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
+  >
+```
+
+In the same file, update `getReasoningEffortForModel()` so its return type also includes `max`:
+
+```ts
+export function getReasoningEffortForModel(
+  model: string,
+): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" {
+```
+
+In `src/routes/admin-api/route.ts`, change the local `ReasoningEffort` type and set:
+
+```ts
+type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+```
+
+```ts
+const REASONING_EFFORTS = new Set<ReasoningEffort>([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+])
+```
+
+In `admin-ui/src/lib/admin-api.ts`, change the exported `ReasoningEffort` type to:
+
+```ts
+export type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+```
+
+- [ ] **Step 4: Expose `reasoning_effort` in Admin model details**
+
+In `src/routes/admin-api/route.ts`, update `AdminModelDetailsItem["capabilities"]["supports"]`:
+
+```ts
+    supports: {
+      tool_calls?: boolean
+      parallel_tool_calls?: boolean
+      structured_outputs?: boolean
+      streaming?: boolean
+      vision?: boolean
+      reasoning_effort?: Array<string>
+    }
+```
+
+In `parseCapabilities()`, add this property:
+
+```ts
+      reasoning_effort: parseStringArray(supportsRaw?.reasoning_effort),
+```
+
+In `admin-ui/src/lib/admin-api.ts`, update `AdminModelDetailsItem["capabilities"]["supports"]`:
+
+```ts
+    supports: {
+      tool_calls?: boolean
+      parallel_tool_calls?: boolean
+      structured_outputs?: boolean
+      streaming?: boolean
+      vision?: boolean
+      reasoning_effort?: Array<string>
+    }
+```
+
+- [ ] **Step 5: Run the Admin API tests and verify they pass**
+
+Run:
+
+```bash
+bun test tests/admin-config.test.ts tests/admin-models-details.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Admin metadata support**
+
+```bash
+git add src/lib/config.ts src/routes/admin-api/route.ts admin-ui/src/lib/admin-api.ts tests/admin-config.test.ts tests/admin-models-details.test.ts
+git commit -m "feat: expose model reasoning effort support"
+```
+
+---
+
+### Task 3: Direct Responses And Chat Completions Routes
+
+**Files:**
+- Modify: `src/services/copilot/create-chat-completions.ts`
+- Modify: `src/services/copilot/create-responses.ts`
+- Modify: `src/routes/chat-completions/handler.ts`
+- Modify: `src/routes/responses/handler.ts`
+- Modify: `tests/chat-completions-handler.test.ts`
+- Modify: `tests/responses-handler.test.ts`
+- Modify: `tests/create-chat-completions.test.ts`
+
+- [ ] **Step 1: Write failing Chat Completions route tests**
+
+In `tests/chat-completions-handler.test.ts`, change `buildModel()` to accept support:
+
+```ts
+function buildModel(
+  id: string,
+  reasoningEffort: Array<string> = ["low", "medium", "high", "xhigh"],
+): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+        reasoning_effort: reasoningEffort,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+```
+
+Change `buildSelection()` to pass support through:
+
+```ts
+function buildSelection(
+  modelId: string,
+  reasoningEffort?: Array<string>,
+): SelectionOk {
+  return {
+    ok: true,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId, reasoningEffort),
+    endpoint: "/chat/completions",
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    affinityHit: false,
+    selectionReason: "affinity_miss",
+  }
+}
+```
+
+Add these tests inside the `describe("chat completions handler", () => {` block before its closing `})`:
+
+```ts
+test("normalizes explicit reasoning_effort to selected model support", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("gpt-test", ["low", "medium", "high"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchMock.mockImplementationOnce((_url, opts) => {
+    upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          created: 0,
+          model: "gpt-test",
+          choices: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    )
+  })
+
+  const app = createApp()
+  const response = await app.request("/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-test",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "max",
+    }),
+  })
+
+  expect(response.status).toBe(200)
+  expect(upstreamBody?.reasoning_effort).toBe("high")
+})
+
+test("injects configured fallback effort for any supported chat model", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("gpt-test", ["low", "medium"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchMock.mockImplementationOnce((_url, opts) => {
+    upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          created: 0,
+          model: "gpt-test",
+          choices: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    )
+  })
+
+  const app = createApp()
+  const response = await app.request("/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-test",
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  })
+
+  expect(response.status).toBe(200)
+  expect(upstreamBody?.reasoning_effort).toBe("medium")
+})
+```
+
+- [ ] **Step 2: Write failing Responses route tests**
+
+In `tests/responses-handler.test.ts`, change `buildModel()` so it accepts support:
+
+```ts
+function buildModel(
+  id: string,
+  maxPromptImageSize?: number,
+  reasoningEffort: Array<string> = ["low", "medium", "high", "xhigh"],
+): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+        ...(maxPromptImageSize !== undefined ?
+          { vision: { max_prompt_image_size: maxPromptImageSize } }
+        : {}),
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+        vision: maxPromptImageSize !== undefined ? true : undefined,
+        reasoning_effort: reasoningEffort,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+```
+
+Change `buildSelection()` to pass support through:
+
+```ts
+function buildSelection(
+  endpoint: string,
+  modelId: string,
+  reasoningEffort?: Array<string>,
+): SelectionOk {
+  return {
+    ok: true,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId, undefined, reasoningEffort),
+    endpoint,
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    affinityHit: false,
+    affinityCacheKey: "test-cache-key",
+    selectionReason: "affinity_miss",
+  }
+}
+```
+
+Add these tests:
+
+```ts
+test("normalizes explicit Responses reasoning effort to selected model support", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/responses", "gpt-test", ["low", "high"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+    upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+    return Promise.resolve(
+      new Response(JSON.stringify(buildResponsesResult("gpt-test", "ok")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  const response = await responsesRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-test",
+        input: "hello",
+        reasoning: { effort: "medium" },
+      }),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("low")
+})
+
+test("injects configured fallback effort for supported Responses models", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/responses", "gpt-test", ["low", "medium"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+    upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+    return Promise.resolve(
+      new Response(JSON.stringify(buildResponsesResult("gpt-test", "ok")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  const response = await responsesRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-test",
+        input: "hello",
+      }),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe(
+    "medium",
+  )
+})
+```
+
+- [ ] **Step 3: Run route tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/chat-completions-handler.test.ts tests/responses-handler.test.ts
+```
+
+Expected: FAIL because direct route handlers do not yet normalize or inject these fields.
+
+- [ ] **Step 4: Apply normalization in Chat Completions handler and remove service special case**
+
+In `src/services/copilot/create-chat-completions.ts`, remove:
+
+```ts
+import { getReasoningEffortForModel, isForceAgentEnabled } from "~/lib/config"
+```
+
+Replace it with:
+
+```ts
+import { isForceAgentEnabled } from "~/lib/config"
+```
+
+Delete `isGpt5MiniFamily()` and `applyDefaultReasoningEffort()`.
+
+Replace:
+
+```ts
+  const upstreamPayload = applyDefaultReasoningEffort(payload)
+```
+
+with:
+
+```ts
+  const upstreamPayload = payload
+```
+
+In `src/routes/chat-completions/handler.ts`, import the helper:
+
+```ts
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
+```
+
+Before `await logTokenCountForRequest({ payload: upstreamPayload, selectedModel })`, replace the `const upstreamPayload` declaration with:
+
+```ts
+  const upstreamPayload = { ...payload, model: selectedModel.id }
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.reasoning_effort,
+    requestModel: clientModel,
+    targetModel: selectedModel,
+  })
+  if (reasoningEffort) {
+    upstreamPayload.reasoning_effort = reasoningEffort
+  } else {
+    delete upstreamPayload.reasoning_effort
+  }
+```
+
+- [ ] **Step 5: Apply normalization in Responses handler and type**
+
+In `src/services/copilot/create-responses.ts`, update `Reasoning.effort`:
+
+```ts
+  effort?:
+    | "none"
+    | "minimal"
+    | "low"
+    | "medium"
+    | "high"
+    | "xhigh"
+    | "max"
+    | null
+```
+
+In `src/routes/responses/handler.ts`, import:
+
+```ts
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
+```
+
+Replace:
+
+```ts
+  const upstreamPayload = { ...payload, model: selectedModel.id }
+```
+
+with:
+
+```ts
+  const upstreamPayload = { ...payload, model: selectedModel.id }
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.reasoning?.effort,
+    requestModel: clientModel,
+    targetModel: selectedModel,
+  })
+  if (reasoningEffort) {
+    upstreamPayload.reasoning = {
+      ...(upstreamPayload.reasoning ?? {}),
+      effort: reasoningEffort,
+    }
+  } else if (upstreamPayload.reasoning) {
+    delete upstreamPayload.reasoning.effort
+  }
+```
+
+- [ ] **Step 6: Update old service-level Chat Completions tests**
+
+In `tests/create-chat-completions.test.ts`, remove the complete test blocks named `injects reasoning_effort from config for gpt-5-mini when omitted` and `injects reasoning_effort for gpt-5-mini variant models when omitted` because route-level normalization replaces the service special case.
+
+Keep and rename the explicit pass-through tests so service behavior stays simple:
+
+```ts
+test("passes through explicit reasoning_effort unchanged", async () => {
+  const callCountBefore = fetchMock.mock.calls.length
+
+  const payload: ChatCompletionsPayload = {
+    messages: [{ role: "user", content: "hi" }],
+    model: "gpt-5-mini",
+    reasoning_effort: "high",
+  }
+
+  await callCreateChatCompletions(payload)
+
+  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
+  const upstreamPayload = getLastUpstreamPayload()
+  expect(upstreamPayload["reasoning_effort"]).toBe("high")
+})
+```
+
+- [ ] **Step 7: Run direct route and service tests**
+
+Run:
+
+```bash
+bun test tests/chat-completions-handler.test.ts tests/responses-handler.test.ts tests/create-chat-completions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit direct route normalization**
+
+```bash
+git add src/services/copilot/create-chat-completions.ts src/services/copilot/create-responses.ts src/routes/chat-completions/handler.ts src/routes/responses/handler.ts tests/chat-completions-handler.test.ts tests/responses-handler.test.ts tests/create-chat-completions.test.ts
+git commit -m "feat: normalize direct reasoning efforts"
+```
+
+---
+
+### Task 4: Messages Route And Translation Normalization
+
+**Files:**
+- Modify: `src/routes/messages/preprocess.ts`
+- Modify: `src/routes/messages/responses-translation.ts`
+- Modify: `src/routes/messages/handler.ts`
+- Modify: `tests/messages-handler.test.ts`
+
+- [ ] **Step 1: Write failing Messages route tests**
+
+In `tests/messages-handler.test.ts`, change `buildModel()` to accept support:
+
+```ts
+function buildModel(
+  id: string,
+  reasoningEffort: Array<string> = ["low", "medium", "high", "xhigh"],
+): Model {
+  return {
+    id,
+    name: id,
+    vendor: "upstream",
+    object: "model",
+    preview: false,
+    version: "test",
+    model_picker_enabled: true,
+    capabilities: {
+      family: "test",
+      limits: {
+        max_output_tokens: 8192,
+        max_prompt_tokens: 200_000,
+      },
+      object: "capabilities",
+      supports: {
+        adaptive_thinking: true,
+        streaming: true,
+        reasoning_effort: reasoningEffort,
+      },
+      tokenizer: "o200k_base",
+      type: "chat",
+    },
+  }
+}
+```
+
+Change `buildSelection()`:
+
+```ts
+function buildSelection(
+  endpoint: string,
+  modelId: string,
+  reasoningEffort?: Array<string>,
+): SelectionOk {
+  return {
+    ok: true,
+    account: buildAccount(),
+    selectedModel: buildModel(modelId, reasoningEffort),
+    endpoint,
+    costUnits: 0,
+    confirmAffinity: mock(() => {}),
+    confirmOwnership: mock(() => {}),
+    affinityHit: false,
+    selectionReason: "affinity_miss",
+  }
+}
+```
+
+Add tests:
+
+```ts
+test("Messages to Responses preserves explicit effort as normalized intent", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/responses", "responses-model", ["low", "high"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+    upstreamBody = parseFetchBody(opts?.body)
+    return Promise.resolve(
+      new Response(
+        JSON.stringify(buildResponsesResult("responses-model", "responses")),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    )
+  }) as unknown as typeof fetch
+
+  const response = await messageRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        createPayload({
+          output_config: {
+            effort: "medium",
+          },
+        }),
+      ),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("low")
+})
+
+test("Messages to native Messages injects default effort when omitted", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/v1/messages", "messages-model", ["low", "medium"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+    upstreamBody = parseFetchBody(opts?.body)
+    return Promise.resolve(
+      new Response(
+        JSON.stringify(buildAnthropicResponse("messages-model", "messages")),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    )
+  }) as unknown as typeof fetch
+
+  const response = await messageRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(createPayload()),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect((upstreamBody?.output_config as { effort?: string }).effort).toBe(
+    "medium",
+  )
+})
+
+test("Messages to Chat Completions writes normalized reasoning_effort", async () => {
+  accountsManager.selectAccountForRequest = () =>
+    Promise.resolve(buildSelection("/chat/completions", "chat-model", ["low", "high"]))
+
+  let upstreamBody: Record<string, unknown> | undefined
+  fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+    upstreamBody = parseFetchBody(opts?.body)
+    return Promise.resolve(
+      new Response(
+        JSON.stringify(buildChatCompletionResponse("chat-model", "chat")),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    )
+  }) as unknown as typeof fetch
+
+  const response = await messageRoutes.fetch(
+    new Request("http://local/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        createPayload({
+          output_config: {
+            effort: "medium",
+          },
+        }),
+      ),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect(upstreamBody?.reasoning_effort).toBe("low")
+})
+```
+
+- [ ] **Step 2: Run Messages tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/messages-handler.test.ts
+```
+
+Expected: FAIL because `/responses` still uses config unconditionally and native Messages/Chat paths do not yet share final-model normalization.
+
+- [ ] **Step 3: Update native Messages preprocessing**
+
+In `src/routes/messages/preprocess.ts`, replace the `getReasoningEffortForModel` import with:
+
+```ts
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
+```
+
+Inside the adaptive thinking block, replace:
+
+```ts
+    let effort =
+      payload.output_config?.effort ?? getReasoningEffortForModel(payload.model)
+    if (effort === "none" || effort === "minimal") {
+      effort = "low"
+    }
+    const reasoningEffort = selectedModel.capabilities.supports.reasoning_effort
+    if (reasoningEffort && !reasoningEffort.includes(effort)) {
+      effort = reasoningEffort.at(-1) as "low" | "medium" | "high"
+    }
+    payload.output_config = {
+      effort: effort,
+    }
+```
+
+with:
+
+```ts
+    let effort = resolveReasoningEffortForTarget({
+      explicitEffort: payload.output_config?.effort,
+      requestModel: payload.model,
+      targetModel: selectedModel,
+    })
+    if (effort === "none" || effort === "minimal") {
+      effort = "low"
+    }
+    if (effort) {
+      payload.output_config = {
+        ...payload.output_config,
+        effort,
+      }
+    } else if (payload.output_config) {
+      delete payload.output_config.effort
+      if (Object.keys(payload.output_config).length === 0) {
+        delete payload.output_config
+      }
+    }
+```
+
+- [ ] **Step 4: Update Messages to Responses translation options**
+
+In `src/routes/messages/responses-translation.ts`, remove the `getReasoningEffortForModel` import and import the type:
+
+```ts
+import type { ReasoningEffort } from "~/lib/reasoning-effort"
+```
+
+Extend the options type for `translateAnthropicMessagesToResponsesPayload()`:
+
+```ts
+  reasoningEffort?: ReasoningEffort
+```
+
+In the returned `responsesPayload`, replace:
+
+```ts
+    reasoning: {
+      effort: getReasoningEffortForModel(model),
+      summary: "auto",
+    },
+```
+
+with:
+
+```ts
+    reasoning: options.reasoningEffort ?
+      {
+        effort: options.reasoningEffort,
+        summary: "auto",
+      }
+    : {
+        summary: "auto",
+      },
+```
+
+- [ ] **Step 5: Normalize in Messages handler after selection**
+
+In `src/routes/messages/handler.ts`, import:
+
+```ts
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
+```
+
+In `handleWithChatCompletions()`, before logging the payload, insert:
+
+```ts
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: openAIPayload.reasoning_effort,
+    requestModel: instr.clientModel,
+    targetModel: selectedModel,
+  })
+  if (reasoningEffort) {
+    openAIPayload.reasoning_effort = reasoningEffort
+  } else {
+    delete openAIPayload.reasoning_effort
+  }
+```
+
+In `handleWithResponsesApi()`, compute normalized effort before translation:
+
+```ts
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: anthropicPayload.output_config?.effort,
+    requestModel: instr.clientModel,
+    targetModel: selectedModel,
+  })
+```
+
+Then pass it into translation:
+
+```ts
+  const responsesPayload = translateAnthropicMessagesToResponsesPayload(
+    anthropicPayload,
+    {
+      modelOverride: selectedModel.id,
+      subagentAgentId: subagentMarker?.agent_id,
+      reasoningEffort,
+    },
+  )
+```
+
+- [ ] **Step 6: Run Messages tests and verify they pass**
+
+Run:
+
+```bash
+bun test tests/messages-handler.test.ts tests/messages-preprocess.test.ts tests/responses-translation.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Messages normalization**
+
+```bash
+git add src/routes/messages/preprocess.ts src/routes/messages/responses-translation.ts src/routes/messages/handler.ts tests/messages-handler.test.ts
+git commit -m "feat: normalize messages reasoning efforts"
+```
+
+---
+
+### Task 5: Admin UI Model-Specific Reasoning Options
+
+**Files:**
+- Modify: `admin-ui/src/lib/admin-api.ts`
+- Modify: `admin-ui/src/pages/settings-page.tsx`
+- Modify: `admin-ui/tests/settings-page.test.tsx`
+
+- [ ] **Step 1: Write failing Admin UI tests**
+
+In `admin-ui/tests/settings-page.test.tsx`, update the import:
+
+```ts
+import {
+  ModelMappingsCard,
+  ReasoningEffortsCard,
+  ResponsesApiSettingsCard,
+  compactThresholdRecordFromItems,
+  createQuickProviderItem,
+  deriveProviderModelSuggestions,
+  getUniqueProviderName,
+  parseCompactThresholdsJson,
+  parseModelMappingsJson,
+  parseReasoningJson,
+} from "../src/pages/settings-page"
+```
+
+Add tests:
+
+```tsx
+test("reasoning editor renders model-specific effort choices", () => {
+  const html = renderToStaticMarkup(
+    <ReasoningEffortsCard
+      mode="form"
+      json="{}"
+      jsonIssue={null}
+      items={[{ id: "reasoning-1", model: "gpt-5-mini", effort: "low" }]}
+      models={["gpt-5-mini"]}
+      reasoningSupportByModel={{
+        "gpt-5-mini": {
+          efforts: ["low", "medium"],
+        },
+      }}
+      onToggleMode={() => {}}
+      onJsonChange={() => {}}
+      onAddItem={() => {}}
+      onRemoveItem={() => {}}
+      onUpdateItem={() => {}}
+    />,
+  )
+
+  expect(html).toContain("gpt-5-mini")
+  expect(html).toContain("low")
+  expect(html).toContain("medium")
+  expect(html).not.toContain("xhigh")
+})
+
+test("reasoning editor shows alias support inherited from target", () => {
+  const html = renderToStaticMarkup(
+    <ReasoningEffortsCard
+      mode="form"
+      json="{}"
+      jsonIssue={null}
+      items={[{ id: "reasoning-1", model: "fast", effort: "xhigh" }]}
+      models={["fast"]}
+      reasoningSupportByModel={{
+        fast: {
+          efforts: ["high", "xhigh"],
+          target: "gpt-5.4",
+        },
+      }}
+      onToggleMode={() => {}}
+      onJsonChange={() => {}}
+      onAddItem={() => {}}
+      onRemoveItem={() => {}}
+      onUpdateItem={() => {}}
+    />,
+  )
+
+  expect(html).toContain("fast")
+  expect(html).toContain("gpt-5.4")
+  expect(html).toContain("high")
+  expect(html).toContain("xhigh")
+})
+
+test("reasoning JSON validation accepts max", () => {
+  expect(parseReasoningJson('{ "gpt-5.5": "max" }')).toEqual({
+    value: {
+      "gpt-5.5": "max",
+    },
+  })
+})
+```
+
+- [ ] **Step 2: Run Admin UI tests and verify they fail**
+
+Run:
+
+```bash
+cd admin-ui && bun test tests/settings-page.test.tsx
+```
+
+Expected: FAIL because `ReasoningEffortsCard` and `parseReasoningJson` are not exported, `max` is not valid in the UI type, and the card does not accept `reasoningSupportByModel`.
+
+- [ ] **Step 3: Add UI support types and `max`**
+
+In `admin-ui/src/pages/settings-page.tsx`, update `REASONING_EFFORTS`:
+
+```ts
+const REASONING_EFFORTS: Array<ReasoningEffort> = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]
+```
+
+Add this type near `ReasoningItem`:
+
+```ts
+type ReasoningSupportInfo = {
+  efforts: Array<ReasoningEffort>
+  target?: string
+}
+```
+
+Export `parseReasoningJson`:
+
+```ts
+export function parseReasoningJson(
+  value: string,
+): ParseResult<Record<string, ReasoningEffort>> {
+```
+
+Export `ReasoningEffortsCard`:
+
+```ts
+export function ReasoningEffortsCard({
+```
+
+- [ ] **Step 4: Derive model and alias support from model details**
+
+In `admin-ui/src/pages/settings-page.tsx`, import `getAdminModelDetails` and `AdminModelDetailsItem` from the Admin API module:
+
+```ts
+  getAdminModelDetails,
+  type AdminModelDetailsItem,
+```
+
+Add this helper near other pure helpers:
+
+```ts
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return REASONING_EFFORTS.includes(value as ReasoningEffort)
+}
+
+export function deriveReasoningSupportByModel(
+  details: Array<AdminModelDetailsItem>,
+): Record<string, ReasoningSupportInfo> {
+  const support: Record<string, ReasoningSupportInfo> = {}
+
+  for (const model of details) {
+    const efforts =
+      model.capabilities.supports.reasoning_effort?.filter(isReasoningEffort)
+      ?? []
+    if (efforts.length === 0) continue
+
+    support[model.id] = { efforts }
+    for (const alias of model.aliases) {
+      support[alias] = {
+        efforts,
+        target: model.id,
+      }
+    }
+  }
+
+  return support
+}
+```
+
+In `SettingsPage`, add state:
+
+```ts
+  const [reasoningSupportByModel, setReasoningSupportByModel] = useState<
+    Record<string, ReasoningSupportInfo>
+  >({})
+```
+
+In `load`, include model details:
+
+```ts
+      const [configRes, modelsRes, modelDetailsRes, devModeRes] =
+        await Promise.allSettled([
+          getAdminConfig(),
+          getAdminModels(),
+          getAdminModelDetails(),
+          getDevMode(),
+        ])
+```
+
+After handling `modelsRes`, handle `modelDetailsRes`:
+
+```ts
+      if (modelDetailsRes.status === "fulfilled") {
+        setReasoningSupportByModel(
+          deriveReasoningSupportByModel(modelDetailsRes.value.items),
+        )
+      } else {
+        setReasoningSupportByModel({})
+        toast.error(i18n.t("settingsPage.toast.loadModelsFailed"), {
+          description:
+            modelDetailsRes.reason instanceof Error ?
+              modelDetailsRes.reason.message
+            : String(modelDetailsRes.reason),
+        })
+      }
+```
+
+- [ ] **Step 5: Render model-specific options in the reasoning card**
+
+Extend `ReasoningEffortsCardProps`:
+
+```ts
+  reasoningSupportByModel?: Record<string, ReasoningSupportInfo>
+```
+
+Accept the prop with a default:
+
+```ts
+  reasoningSupportByModel = {},
+```
+
+Inside the `items.map((item) => {` callback before the `return (` statement, derive options:
+
+```ts
+                const supportInfo =
+                  modelValue !== defaultModelValue ?
+                    reasoningSupportByModel[modelValue]
+                  : undefined
+                const supportedEfforts =
+                  supportInfo?.efforts.length ? supportInfo.efforts : REASONING_EFFORTS
+                const showUnsupportedConfiguredEffort =
+                  item.effort && !supportedEfforts.includes(item.effort)
+                const effortOptions =
+                  showUnsupportedConfiguredEffort ?
+                    [item.effort, ...supportedEfforts]
+                  : supportedEfforts
+```
+
+Replace the effort `SelectContent` mapping with:
+
+```tsx
+                        <SelectContent>
+                          {effortOptions.map((effort) => (
+                            <SelectItem key={effort} value={effort}>
+                              {effort}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+```
+
+Below the row controls, before the existing item hint, render alias/support hints:
+
+```tsx
+                      {supportInfo?.target ? (
+                        <div className="text-muted-foreground text-xs">
+                          {`Uses ${supportInfo.target} reasoning options.`}
+                        </div>
+                      ) : null}
+                      {modelValue !== defaultModelValue && !supportInfo ? (
+                        <InlineAlert
+                          variant="warning"
+                          title="No reasoning effort metadata"
+                          description="This model does not currently advertise reasoning effort support."
+                        />
+                      ) : null}
+                      {showUnsupportedConfiguredEffort ? (
+                        <InlineAlert
+                          variant="warning"
+                          title="Effort will be normalized"
+                          description={`${item.effort} is kept as intent and normalized at runtime.`}
+                        />
+                      ) : null}
+```
+
+When rendering `ReasoningEffortsCard` inside `SettingsPage`, pass:
+
+```tsx
+              reasoningSupportByModel={reasoningSupportByModel}
+```
+
+- [ ] **Step 6: Run Admin UI tests**
+
+Run:
+
+```bash
+cd admin-ui && bun test tests/settings-page.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Admin UI reasoning options**
+
+```bash
+git add admin-ui/src/lib/admin-api.ts admin-ui/src/pages/settings-page.tsx admin-ui/tests/settings-page.test.tsx
+git commit -m "feat: show model reasoning effort options"
+```
+
+---
+
+### Task 6: Full Verification And Cleanup
+
+**Files:**
+- Verify all files changed in Tasks 1-5.
+- Update tests only if TypeScript reveals exact type mismatches introduced by earlier tasks.
+
+- [ ] **Step 1: Run targeted backend tests**
+
+Run:
+
+```bash
+bun test tests/reasoning-effort.test.ts tests/admin-config.test.ts tests/admin-models-details.test.ts tests/chat-completions-handler.test.ts tests/responses-handler.test.ts tests/messages-handler.test.ts tests/messages-preprocess.test.ts tests/responses-translation.test.ts tests/create-chat-completions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted Admin UI tests**
+
+Run:
+
+```bash
+cd admin-ui && bun test tests/settings-page.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```bash
+bun run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff --check
+```
+
+Expected: `git diff --check` exits 0 with no whitespace errors.
+
+- [ ] **Step 6: Commit final cleanup if any files changed after Task 5**
+
+If Step 1-5 required edits after the Task 5 commit, commit only those edits:
+
+```bash
+git add src/lib/reasoning-effort.ts src/lib/config.ts src/routes/admin-api/route.ts src/services/copilot/create-chat-completions.ts src/services/copilot/create-responses.ts src/routes/chat-completions/handler.ts src/routes/responses/handler.ts src/routes/messages/preprocess.ts src/routes/messages/responses-translation.ts src/routes/messages/handler.ts admin-ui/src/lib/admin-api.ts admin-ui/src/pages/settings-page.tsx tests/reasoning-effort.test.ts tests/admin-config.test.ts tests/admin-models-details.test.ts tests/chat-completions-handler.test.ts tests/responses-handler.test.ts tests/messages-handler.test.ts tests/create-chat-completions.test.ts admin-ui/tests/settings-page.test.tsx
+git commit -m "chore: finalize reasoning effort normalization"
+```
+
+If no files changed during Task 6, skip this commit.

--- a/docs/superpowers/specs/2026-07-01-reasoning-effort-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-01-reasoning-effort-normalization-design.md
@@ -1,0 +1,231 @@
+# Reasoning Effort Normalization Design
+
+> Status: DRAFT, awaiting user review
+> Date: 2026-07-01
+
+## Problem
+
+GitHub Copilot now exposes multiple mainstream model families, including GPT, Claude, and Gemini. Their supported reasoning effort values differ by model and must be discovered from Copilot's upstream `/models` response.
+
+The project already fetches and caches upstream model metadata at startup and during periodic model refreshes. Each model can expose `capabilities.supports.reasoning_effort`, an array of supported effort values.
+
+Today reasoning effort behavior is inconsistent:
+
+- Admin UI shows a fixed global effort list instead of model-specific supported values.
+- `modelReasoningEfforts` validation accepts a fixed global set but does not know which model supports which values.
+- `/v1/messages -> /responses` always writes the configured model effort and can override an explicit downstream effort.
+- `/v1/chat/completions` only injects a configured default for the `gpt-5-mini` family.
+- `/v1/responses` preserves explicit `reasoning.effort` but does not inject a configured default when omitted.
+
+This makes the configured default behave differently depending on route selection and makes user-supplied values unreliable when request and upstream APIs differ.
+
+## Goal
+
+Make reasoning effort handling predictable across Copilot routes:
+
+1. Use upstream model metadata as the source of truth for supported reasoning effort values.
+2. Let Admin UI show model-specific effort choices, including alias models.
+3. Treat configured model effort as a user intent default, not as an unconditional override.
+4. Preserve explicit downstream effort when present.
+5. When an explicit or configured effort is unsupported by the target upstream model, normalize it to the nearest supported value.
+6. Avoid sending reasoning effort fields to upstream models that do not advertise support.
+
+## Non-Goals
+
+- Do not introduce provider-specific reasoning effort support for external providers in this change.
+- Do not add new cross-endpoint routing behavior such as `/v1/chat/completions -> /responses` unless a separate routing design asks for it.
+- Do not infer model support from family names when cached `/models` metadata is unavailable.
+
+## Existing Model Metadata
+
+`src/services/copilot/get-models.ts` already defines `ModelCapabilities.supports.reasoning_effort?: Array<string>`.
+
+`accountsManager.getFirstAccountModels()` already provides the cached Copilot model response used by Admin API and routing code. The reasoning effort design should reuse this cache rather than fetching `/models` on demand from Admin UI or individual request handlers.
+
+Alias models should not define independent capabilities. Their supported effort options come from the resolved target model.
+
+## Canonical Effort Order
+
+Define one ordered effort scale:
+
+```text
+none < minimal < low < medium < high < xhigh < max
+```
+
+The config and downstream request may express any value in this scale, including `max`.
+
+The upstream model may support a subset. For example:
+
+```text
+["low", "medium", "high", "xhigh"]
+```
+
+## Normalization Rule
+
+Reasoning effort processing has two phases:
+
+1. Determine the requested intent effort.
+2. Normalize that intent to the final upstream model support list.
+
+Intent selection:
+
+```text
+explicit downstream effort
+  ?? configured default for requested model / alias fallback
+  ?? no effort
+```
+
+Normalization:
+
+1. If there is no intent effort, do not send effort.
+2. If the target model has no non-empty `reasoning_effort` support list, do not send effort.
+3. If the target model supports the intent effort, send it unchanged.
+4. Otherwise send the closest supported effort by canonical scale distance.
+5. If two supported values are equally close, choose the lower effort.
+
+Examples:
+
+| Intent | Target support | Upstream effort |
+|---|---|---|
+| `max` | `low, medium, high, xhigh` | `xhigh` |
+| `minimal` | `low, medium, high` | `low` |
+| `xhigh` | `low, medium, high` | `high` |
+| `medium` | `low, high` | `low` |
+| `high` | empty / missing | omitted |
+
+## API Field Mapping
+
+Each API has a different effort field:
+
+| API shape | Field |
+|---|---|
+| Messages API | `output_config.effort` |
+| Responses API | `reasoning.effort` |
+| Chat Completions API | `reasoning_effort` |
+
+The same intent and normalization rule applies to direct and translated flows. The only difference is where the normalized effort is written.
+
+## Runtime Flow
+
+After route handling determines the final upstream model and endpoint, call a shared reasoning effort helper with:
+
+- client/request model id
+- final upstream model
+- explicit downstream effort, if any
+- configured `modelReasoningEfforts`
+- model aliases
+
+The helper returns either a normalized effort or `undefined`.
+
+The route or translator writes the result into the target upstream payload:
+
+- `/v1/messages -> /v1/messages`: write `output_config.effort`.
+- `/v1/messages -> /responses`: write `reasoning.effort`.
+- `/v1/messages -> /chat/completions`: write `reasoning_effort`.
+- `/v1/responses -> /responses`: write `reasoning.effort`.
+- `/v1/chat/completions -> /chat/completions`: write `reasoning_effort`.
+
+If the helper returns `undefined`, remove or omit the target effort field so the upstream request does not carry unsupported effort data.
+
+## Direct vs Translated Requests
+
+Direct API flows mean the downstream API shape and upstream API shape match. Explicit downstream effort should be preserved semantically, then normalized only if the final upstream model does not support that exact value.
+
+Translated API flows mean the downstream API shape and upstream API shape differ. The downstream effort should first be extracted as intent, then normalized against the final upstream model, then written in the target API field format.
+
+This keeps direct and translated behavior aligned while still adapting field names.
+
+## Config Semantics
+
+`modelReasoningEfforts` expresses default user intent per model. It is not a guarantee that the exact configured value will be sent upstream.
+
+Rules:
+
+- Values must be in the canonical global set, including `max`.
+- Config may contain aliases or target model ids.
+- Existing alias fallback behavior should continue to work.
+- Config save should not reject a value merely because the current target model does not support it. Runtime normalization adapts it.
+- If a model mapping rewrites the request to another model, the default intent should be resolved from the client/request model, while support should be resolved from the final upstream model.
+
+## Admin API
+
+Extend `/api/admin/models/details` so each item exposes:
+
+```ts
+capabilities: {
+  supports: {
+    reasoning_effort?: string[]
+    // existing support flags...
+  }
+}
+aliases: string[]
+```
+
+The response should include the raw target model support list. Alias-to-target relationships are already available through `aliases`.
+
+The existing `/api/admin/models` string-list endpoint can remain for simple model selectors, but the Settings page reasoning editor should load model details when it needs model-specific effort options.
+
+## Admin UI
+
+The Settings page reasoning editor should use model details to render effort options:
+
+1. Selecting a concrete model shows that model's `reasoning_effort` values.
+2. Selecting an alias shows the alias as the configured model key but uses the alias target model's support list.
+3. If no support list exists, disable the effort select and show that the model does not support reasoning effort.
+4. JSON mode remains available and accepts all canonical values.
+5. Existing values not currently supported by a selected model should not be silently dropped. The UI can show the configured value with an indication that runtime will normalize it.
+
+Form mode should prefer supported values because it represents practical choices. JSON mode remains the escape hatch for intent values like `max`.
+
+## Implementation Boundaries
+
+Add a shared module such as `src/lib/reasoning-effort.ts` for:
+
+- canonical effort types and order
+- effort parsing
+- nearest supported effort normalization
+- helper for extracting model support from a `Model`
+
+Route and translation code should call this module rather than embedding endpoint-specific effort logic.
+
+The `gpt-5-mini`-only default injection in `createChatCompletions()` should be removed or made redundant once route-level normalization covers all supported models. Service clients should primarily send already-prepared payloads.
+
+## Edge Cases
+
+- Unknown effort values from requests are ignored unless they are added to the canonical scale.
+- Unknown effort values from upstream `reasoning_effort` metadata are ignored for nearest-value calculations.
+- If all upstream support values are unknown after filtering, omit effort.
+- If explicit downstream effort is `null`, treat it as omitted and use config default.
+- If config default is present but the target model lacks support metadata, omit effort.
+- If request model is an alias, configured defaults may be found on either alias or target through existing fallback behavior; support comes from the final selected target model.
+
+## Test Plan
+
+Unit tests:
+
+- Normalize `max -> xhigh` when support stops at `xhigh`.
+- Normalize `minimal -> low` when support starts at `low`.
+- Normalize `xhigh -> high` when support stops at `high`.
+- Pick lower effort on ties, such as `medium` with support `low, high`.
+- Return `undefined` when support is missing or empty.
+- Ignore unknown metadata values safely.
+
+Route/translation tests:
+
+- `/v1/messages -> /responses` preserves explicit downstream effort as intent and no longer lets config override it.
+- `/v1/messages -> /messages` injects config default when omitted and normalizes explicit values by support.
+- `/v1/messages -> /chat/completions` writes normalized `reasoning_effort`.
+- `/v1/responses -> /responses` injects config default when omitted and normalizes explicit `reasoning.effort`.
+- `/v1/chat/completions -> /chat/completions` applies default injection consistently for all models with support, not only `gpt-5-mini`.
+
+Admin tests:
+
+- `/api/admin/models/details` includes `reasoning_effort`.
+- Settings page effort options change by selected model.
+- Alias model options inherit the target model's support list.
+- JSON mode accepts `max`.
+- Existing unsupported configured values are preserved in draft state.
+
+## Open Questions
+
+No open business questions remain from the initial design discussion. The implementation plan should decide exact helper function signatures and the smallest set of handler/translator call sites to update.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -797,6 +797,27 @@ function getAliasFallbackValue<T extends string>(
   return undefined
 }
 
+function getRecordValueForModel<T extends string>(
+  record: Record<string, T> | undefined,
+  modelId: string,
+): T | undefined {
+  if (!record) return undefined
+
+  const direct = record[modelId]
+  if (direct !== undefined) return direct
+
+  const normalizedModel = normalizeAliasKey(modelId)
+  if (!normalizedModel) return undefined
+
+  for (const [key, value] of Object.entries(record)) {
+    if (normalizeAliasKey(key) === normalizedModel) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
 export function getExtraPromptForModel(model: string): string {
   const config = getConfig()
   const direct = config.extraPrompts?.[model]
@@ -951,11 +972,26 @@ export function getConfiguredReasoningEffortForModel(
   model: string,
 ): ConfiguredReasoningEffort | undefined {
   const config = getConfig()
-  const direct = config.modelReasoningEfforts?.[model]
+  const efforts = config.modelReasoningEfforts
+  const direct = getRecordValueForModel(efforts, model)
   if (direct !== undefined) return direct
 
   const aliases = getModelAliases()
-  return getAliasFallbackValue(config.modelReasoningEfforts, model, aliases)
+  const normalizedModel = normalizeAliasKey(model)
+  const aliasTarget = normalizedModel ? aliases[normalizedModel] : undefined
+  if (aliasTarget) {
+    const targetDirect = getRecordValueForModel(efforts, aliasTarget)
+    if (targetDirect !== undefined) return targetDirect
+  }
+
+  const aliasFallback = getAliasFallbackValue(efforts, model, aliases)
+  if (aliasFallback !== undefined) return aliasFallback
+
+  if (normalizedModel?.startsWith("gpt-5-mini-")) {
+    return getRecordValueForModel(efforts, "gpt-5-mini")
+  }
+
+  return undefined
 }
 
 export function getReasoningEffortForModel(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,8 @@
 import consola from "consola"
 import fs from "node:fs"
 
+import type { ReasoningEffort } from "~/lib/reasoning-effort"
+
 import { PATHS } from "./paths"
 
 export type LogLevel = "error" | "warn" | "info" | "debug"
@@ -28,14 +30,7 @@ export interface ResolvedQuotaRefreshConfig {
   staggerMaxSeconds: number
 }
 
-export type ConfiguredReasoningEffort =
-  | "none"
-  | "minimal"
-  | "low"
-  | "medium"
-  | "high"
-  | "xhigh"
-  | "max"
+export type ConfiguredReasoningEffort = ReasoningEffort
 
 export interface AppConfig {
   auth?: {
@@ -973,31 +968,36 @@ export function getConfiguredReasoningEffortForModel(
 ): ConfiguredReasoningEffort | undefined {
   const config = getConfig()
   const efforts = config.modelReasoningEfforts
-  const direct = getRecordValueForModel(efforts, model)
+  const direct = getReasoningEffortRecordValue(efforts, model)
   if (direct !== undefined) return direct
 
   const aliases = getModelAliases()
   const normalizedModel = normalizeAliasKey(model)
   const aliasTarget = normalizedModel ? aliases[normalizedModel] : undefined
   if (aliasTarget) {
-    const targetDirect = getRecordValueForModel(efforts, aliasTarget)
+    const targetDirect = getReasoningEffortRecordValue(efforts, aliasTarget)
     if (targetDirect !== undefined) return targetDirect
   }
 
   const aliasFallback = getAliasFallbackValue(efforts, model, aliases)
   if (aliasFallback !== undefined) return aliasFallback
 
-  if (normalizedModel?.startsWith("gpt-5-mini-")) {
-    return getRecordValueForModel(efforts, "gpt-5-mini")
-  }
-
   return undefined
 }
 
-export function getReasoningEffortForModel(
-  model: string,
-): ConfiguredReasoningEffort {
-  return getConfiguredReasoningEffortForModel(model) ?? "high"
+function getReasoningEffortRecordValue(
+  record: Record<string, ConfiguredReasoningEffort> | undefined,
+  modelId: string,
+): ConfiguredReasoningEffort | undefined {
+  const direct = getRecordValueForModel(record, modelId)
+  if (direct !== undefined) return direct
+
+  const normalizedModel = normalizeAliasKey(modelId)
+  if (normalizedModel?.startsWith("gpt-5-mini-")) {
+    return getRecordValueForModel(record, "gpt-5-mini")
+  }
+
+  return undefined
 }
 
 export function isForceAgentEnabled(): boolean {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -44,7 +44,7 @@ export interface AppConfig {
   modelResponsesApiCompactThresholds?: Record<string, number>
   modelReasoningEfforts?: Record<
     string,
-    "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+    "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
   >
   modelAliases?: Record<string, { target: string; allowOriginal?: boolean }>
   allowOriginalModelNamesForAliases?: boolean
@@ -943,7 +943,7 @@ export function getModelResponsesApiCompactThreshold(
 
 export function getReasoningEffortForModel(
   model: string,
-): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" {
+): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" {
   const config = getConfig()
   const direct = config.modelReasoningEfforts?.[model]
   if (direct !== undefined) return direct

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,6 +28,15 @@ export interface ResolvedQuotaRefreshConfig {
   staggerMaxSeconds: number
 }
 
+export type ConfiguredReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+
 export interface AppConfig {
   auth?: {
     apiKeys?: Array<string>
@@ -42,10 +51,7 @@ export interface AppConfig {
   responsesApiContextManagementModels?: Array<string>
   useResponsesApiContextManagement?: boolean
   modelResponsesApiCompactThresholds?: Record<string, number>
-  modelReasoningEfforts?: Record<
-    string,
-    "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
-  >
+  modelReasoningEfforts?: Record<string, ConfiguredReasoningEffort>
   modelAliases?: Record<string, { target: string; allowOriginal?: boolean }>
   allowOriginalModelNamesForAliases?: boolean
   modelMappings?: Record<string, string>
@@ -941,20 +947,21 @@ export function getModelResponsesApiCompactThreshold(
   return threshold
 }
 
-export function getReasoningEffortForModel(
+export function getConfiguredReasoningEffortForModel(
   model: string,
-): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" {
+): ConfiguredReasoningEffort | undefined {
   const config = getConfig()
   const direct = config.modelReasoningEfforts?.[model]
   if (direct !== undefined) return direct
 
   const aliases = getModelAliases()
-  const fallback = getAliasFallbackValue(
-    config.modelReasoningEfforts,
-    model,
-    aliases,
-  )
-  return fallback ?? "high"
+  return getAliasFallbackValue(config.modelReasoningEfforts, model, aliases)
+}
+
+export function getReasoningEffortForModel(
+  model: string,
+): ConfiguredReasoningEffort {
+  return getConfiguredReasoningEffortForModel(model) ?? "high"
 }
 
 export function isForceAgentEnabled(): boolean {

--- a/src/lib/reasoning-effort.ts
+++ b/src/lib/reasoning-effort.ts
@@ -92,12 +92,18 @@ export function resolveReasoningEffortForTarget(params: {
   explicitEffort: unknown
   requestModel: string
   targetModel: Pick<Model, "capabilities"> | undefined
+  targetModelId?: string
   defaultEffortResolver?: (model: string) => ReasoningEffort | undefined
 }): ReasoningEffort | undefined {
   const explicit = parseReasoningEffort(params.explicitEffort)
   const defaultEffortResolver =
     params.defaultEffortResolver ?? getConfiguredReasoningEffortForModel
-  const intent = explicit ?? defaultEffortResolver(params.requestModel)
+  const requestDefault = defaultEffortResolver(params.requestModel)
+  const targetDefault =
+    params.targetModelId && params.targetModelId !== params.requestModel ?
+      defaultEffortResolver(params.targetModelId)
+    : undefined
+  const intent = explicit ?? requestDefault ?? targetDefault
 
   return normalizeReasoningEffortForSupport(
     intent,

--- a/src/lib/reasoning-effort.ts
+++ b/src/lib/reasoning-effort.ts
@@ -27,10 +27,9 @@ export function parseReasoningEffort(
     : undefined
 }
 
-export function getReasoningEffortSupport(
-  model: Pick<Model, "capabilities"> | undefined,
+function parseReasoningEffortSupport(
+  rawSupport: ReadonlyArray<unknown> | undefined,
 ): Array<ReasoningEffort> | undefined {
-  const rawSupport = model?.capabilities.supports.reasoning_effort
   if (!Array.isArray(rawSupport)) return undefined
 
   const seen = new Set<ReasoningEffort>()
@@ -48,6 +47,14 @@ export function getReasoningEffortSupport(
   return support.length > 0 ? support : undefined
 }
 
+export function getReasoningEffortSupport(
+  model: Pick<Model, "capabilities"> | undefined,
+): Array<ReasoningEffort> | undefined {
+  return parseReasoningEffortSupport(
+    model?.capabilities.supports.reasoning_effort,
+  )
+}
+
 export function normalizeReasoningEffortForSupport(
   intent: unknown,
   rawSupport: ReadonlyArray<string> | undefined,
@@ -55,18 +62,7 @@ export function normalizeReasoningEffortForSupport(
   const requested = parseReasoningEffort(intent)
   if (!requested) return undefined
 
-  const support = getReasoningEffortSupport({
-    capabilities: {
-      family: "",
-      limits: {},
-      object: "",
-      supports: {
-        reasoning_effort: rawSupport ? [...rawSupport] : undefined,
-      },
-      tokenizer: "",
-      type: "",
-    },
-  })
+  const support = parseReasoningEffortSupport(rawSupport)
   if (!support) return undefined
 
   if (support.includes(requested)) return requested

--- a/src/lib/reasoning-effort.ts
+++ b/src/lib/reasoning-effort.ts
@@ -27,7 +27,7 @@ export function parseReasoningEffort(
     : undefined
 }
 
-function parseReasoningEffortSupport(
+export function parseReasoningEffortSupport(
   rawSupport: ReadonlyArray<unknown> | undefined,
 ): Array<ReasoningEffort> | undefined {
   if (!Array.isArray(rawSupport)) return undefined
@@ -51,7 +51,7 @@ export function getReasoningEffortSupport(
   model: Pick<Model, "capabilities"> | undefined,
 ): Array<ReasoningEffort> | undefined {
   return parseReasoningEffortSupport(
-    model?.capabilities.supports.reasoning_effort,
+    model?.capabilities?.supports?.reasoning_effort,
   )
 }
 
@@ -95,6 +95,8 @@ export function resolveReasoningEffortForTarget(params: {
   targetModelId?: string
   defaultEffortResolver?: (model: string) => ReasoningEffort | undefined
 }): ReasoningEffort | undefined {
+  if (params.explicitEffort === null) return undefined
+
   const explicit = parseReasoningEffort(params.explicitEffort)
   const defaultEffortResolver =
     params.defaultEffortResolver ?? getConfiguredReasoningEffortForModel
@@ -107,6 +109,6 @@ export function resolveReasoningEffortForTarget(params: {
 
   return normalizeReasoningEffortForSupport(
     intent,
-    params.targetModel?.capabilities.supports.reasoning_effort,
+    params.targetModel?.capabilities?.supports?.reasoning_effort,
   )
 }

--- a/src/lib/reasoning-effort.ts
+++ b/src/lib/reasoning-effort.ts
@@ -1,6 +1,6 @@
 import type { Model } from "~/services/copilot/get-models"
 
-import { getReasoningEffortForModel } from "~/lib/config"
+import { getConfiguredReasoningEffortForModel } from "~/lib/config"
 
 export const REASONING_EFFORTS = [
   "none",
@@ -92,11 +92,11 @@ export function resolveReasoningEffortForTarget(params: {
   explicitEffort: unknown
   requestModel: string
   targetModel: Pick<Model, "capabilities"> | undefined
-  defaultEffortResolver?: (model: string) => ReasoningEffort
+  defaultEffortResolver?: (model: string) => ReasoningEffort | undefined
 }): ReasoningEffort | undefined {
   const explicit = parseReasoningEffort(params.explicitEffort)
   const defaultEffortResolver =
-    params.defaultEffortResolver ?? getReasoningEffortForModel
+    params.defaultEffortResolver ?? getConfiguredReasoningEffortForModel
   const intent = explicit ?? defaultEffortResolver(params.requestModel)
 
   return normalizeReasoningEffortForSupport(

--- a/src/lib/reasoning-effort.ts
+++ b/src/lib/reasoning-effort.ts
@@ -1,0 +1,110 @@
+import type { Model } from "~/services/copilot/get-models"
+
+import { getReasoningEffortForModel } from "~/lib/config"
+
+export const REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number]
+
+const REASONING_EFFORT_RANKS = new Map<ReasoningEffort, number>(
+  REASONING_EFFORTS.map((effort, index) => [effort, index]),
+)
+
+export function parseReasoningEffort(
+  value: unknown,
+): ReasoningEffort | undefined {
+  if (typeof value !== "string") return undefined
+  return REASONING_EFFORT_RANKS.has(value as ReasoningEffort) ?
+      (value as ReasoningEffort)
+    : undefined
+}
+
+export function getReasoningEffortSupport(
+  model: Pick<Model, "capabilities"> | undefined,
+): Array<ReasoningEffort> | undefined {
+  const rawSupport = model?.capabilities.supports.reasoning_effort
+  if (!Array.isArray(rawSupport)) return undefined
+
+  const seen = new Set<ReasoningEffort>()
+  for (const item of rawSupport) {
+    const effort = parseReasoningEffort(item)
+    if (effort) seen.add(effort)
+  }
+
+  const support = [...seen].sort(
+    (left, right) =>
+      (REASONING_EFFORT_RANKS.get(left) ?? 0)
+      - (REASONING_EFFORT_RANKS.get(right) ?? 0),
+  )
+
+  return support.length > 0 ? support : undefined
+}
+
+export function normalizeReasoningEffortForSupport(
+  intent: unknown,
+  rawSupport: ReadonlyArray<string> | undefined,
+): ReasoningEffort | undefined {
+  const requested = parseReasoningEffort(intent)
+  if (!requested) return undefined
+
+  const support = getReasoningEffortSupport({
+    capabilities: {
+      family: "",
+      limits: {},
+      object: "",
+      supports: {
+        reasoning_effort: rawSupport ? [...rawSupport] : undefined,
+      },
+      tokenizer: "",
+      type: "",
+    },
+  })
+  if (!support) return undefined
+
+  if (support.includes(requested)) return requested
+
+  const requestedRank = REASONING_EFFORT_RANKS.get(requested) ?? 0
+  let best = support[0]
+  let bestDistance = Number.POSITIVE_INFINITY
+  let bestRank = REASONING_EFFORT_RANKS.get(best) ?? 0
+
+  for (const candidate of support) {
+    const candidateRank = REASONING_EFFORT_RANKS.get(candidate) ?? 0
+    const distance = Math.abs(candidateRank - requestedRank)
+    if (
+      distance < bestDistance
+      || (distance === bestDistance && candidateRank < bestRank)
+    ) {
+      best = candidate
+      bestDistance = distance
+      bestRank = candidateRank
+    }
+  }
+
+  return best
+}
+
+export function resolveReasoningEffortForTarget(params: {
+  explicitEffort: unknown
+  requestModel: string
+  targetModel: Pick<Model, "capabilities"> | undefined
+  defaultEffortResolver?: (model: string) => ReasoningEffort
+}): ReasoningEffort | undefined {
+  const explicit = parseReasoningEffort(params.explicitEffort)
+  const defaultEffortResolver =
+    params.defaultEffortResolver ?? getReasoningEffortForModel
+  const intent = explicit ?? defaultEffortResolver(params.requestModel)
+
+  return normalizeReasoningEffortForSupport(
+    intent,
+    params.targetModel?.capabilities.supports.reasoning_effort,
+  )
+}

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -36,6 +36,11 @@ import {
 import { PATHS } from "~/lib/paths"
 import { updateQuotaRefreshSchedulerFromConfig } from "~/lib/quota-refresh-scheduler-runtime"
 import {
+  parseReasoningEffortSupport,
+  REASONING_EFFORTS as REASONING_EFFORT_VALUES,
+  type ReasoningEffort,
+} from "~/lib/reasoning-effort"
+import {
   getRequestHistoryStore,
   getStatsStore,
   toAdminRequestLogRow,
@@ -200,15 +205,6 @@ function parsePositiveInt(value: string | null, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-type ReasoningEffort =
-  | "none"
-  | "minimal"
-  | "low"
-  | "medium"
-  | "high"
-  | "xhigh"
-  | "max"
-
 type ConfigErrorType = "bad_request" | "internal_error" | "not_found"
 
 type ConfigErrorPayload = {
@@ -246,15 +242,7 @@ const CONFIG_KEYS = new Set<keyof AppConfig>([
   "quotaRefresh",
 ])
 
-const REASONING_EFFORTS = new Set<ReasoningEffort>([
-  "none",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-])
+const REASONING_EFFORTS = new Set<ReasoningEffort>(REASONING_EFFORT_VALUES)
 
 const LOG_LEVELS = new Set<LogLevel>(["error", "warn", "info", "debug"])
 
@@ -1916,7 +1904,11 @@ function parseCapabilities(
       structured_outputs: toBooleanOrUndefined(supportsRaw?.structured_outputs),
       streaming: toBooleanOrUndefined(supportsRaw?.streaming),
       vision: toBooleanOrUndefined(supportsRaw?.vision),
-      reasoning_effort: parseStringArray(supportsRaw?.reasoning_effort),
+      reasoning_effort: parseReasoningEffortSupport(
+        Array.isArray(supportsRaw?.reasoning_effort) ?
+          supportsRaw.reasoning_effort
+        : undefined,
+      ),
     },
   }
 }

--- a/src/routes/admin-api/route.ts
+++ b/src/routes/admin-api/route.ts
@@ -200,7 +200,14 @@ function parsePositiveInt(value: string | null, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
 
 type ConfigErrorType = "bad_request" | "internal_error" | "not_found"
 
@@ -246,6 +253,7 @@ const REASONING_EFFORTS = new Set<ReasoningEffort>([
   "medium",
   "high",
   "xhigh",
+  "max",
 ])
 
 const LOG_LEVELS = new Set<LogLevel>(["error", "warn", "info", "debug"])
@@ -1809,6 +1817,7 @@ type AdminModelDetailsItem = {
       structured_outputs?: boolean
       streaming?: boolean
       vision?: boolean
+      reasoning_effort?: Array<string>
     }
   }
   aliases: Array<string>
@@ -1907,6 +1916,7 @@ function parseCapabilities(
       structured_outputs: toBooleanOrUndefined(supportsRaw?.structured_outputs),
       streaming: toBooleanOrUndefined(supportsRaw?.streaming),
       vision: toBooleanOrUndefined(supportsRaw?.vision),
+      reasoning_effort: parseStringArray(supportsRaw?.reasoning_effort),
     },
   }
 }

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -124,6 +124,7 @@ export async function handleCompletion(c: Context) {
     (c.get("providerConfigResolver" as never) as
       | typeof getProviderConfig
       | undefined) ?? getProviderConfig
+  const requestedModel = payload.model
   payload.model = mappedModelResolver(payload.model)
 
   const providerModelAlias = resolveExistingProviderModelAlias(
@@ -201,7 +202,7 @@ export async function handleCompletion(c: Context) {
   const upstreamPayload = { ...payload, model: selectedModel.id }
   const reasoningEffort = resolveReasoningEffortForTarget({
     explicitEffort: payload.reasoning_effort,
-    requestModel: clientModel,
+    requestModel: requestedModel,
     targetModel: selectedModel,
   })
   if (reasoningEffort) {

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -25,6 +25,7 @@ import {
   normalizeChatCompletionsUsage,
   type NormalizedUsage,
 } from "~/lib/request-history"
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
 import {
@@ -198,6 +199,16 @@ export async function handleCompletion(c: Context) {
     return unsupportedChatCompletionsModelResponse(c)
   }
   const upstreamPayload = { ...payload, model: selectedModel.id }
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.reasoning_effort,
+    requestModel: clientModel,
+    targetModel: selectedModel,
+  })
+  if (reasoningEffort) {
+    upstreamPayload.reasoning_effort = reasoningEffort
+  } else {
+    delete upstreamPayload.reasoning_effort
+  }
 
   await logTokenCountForRequest({ payload: upstreamPayload, selectedModel })
 

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -204,6 +204,7 @@ export async function handleCompletion(c: Context) {
     explicitEffort: payload.reasoning_effort,
     requestModel: requestedModel,
     targetModel: selectedModel,
+    targetModelId: selectedModel.id,
   })
   if (reasoningEffort) {
     upstreamPayload.reasoning_effort = reasoningEffort

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -848,8 +848,15 @@ const handleWithWebSearchResponsesApi = async (params: {
     instr,
     compactType,
   } = params
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: anthropicPayload.output_config?.effort,
+    requestModel: instr.requestModel,
+    targetModel: selectedModel,
+    targetModelId: selectedModel.id,
+  })
   const responsesPayload = prepareWebSearchResponsesPayload(anthropicPayload, {
     model: selectedModel.id,
+    reasoningEffort,
     subagentAgentId: subagentMarker?.agent_id,
   })
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -482,10 +482,12 @@ export async function handleCompletion(c: Context) {
   const compactType = getCompactType(anthropicPayload)
   const isCompact = compactType !== 0
   const originalRequestModel = anthropicPayload.model
+  let usesInternalModelRewrite = false
 
   // Fix warmup probe: force small model for Claude Code warmup requests (CLAUDE_CODE_SUBAGENT_MODEL also works).
   if (anthropicBeta && isWarmupProbeRequest(anthropicPayload)) {
     anthropicPayload.model = getSmallModel()
+    usesInternalModelRewrite = true
   }
 
   if (compactType !== 0) {
@@ -498,6 +500,7 @@ export async function handleCompletion(c: Context) {
 
   if (compactType === COMPACT_REQUEST && shouldCompactUseSmallModel()) {
     anthropicPayload.model = getSmallModel()
+    usesInternalModelRewrite = true
   }
 
   stripToolReferenceTurnBoundary(anthropicPayload)
@@ -517,6 +520,7 @@ export async function handleCompletion(c: Context) {
   anthropicPayload.model = resolveModelAlias(anthropicPayload.model)
   if (webSearchRoute.kind === "responses") {
     anthropicPayload.model = webSearchRoute.model
+    usesInternalModelRewrite = true
   }
   const routingModel = anthropicPayload.model
   const streamRequested = Boolean(anthropicPayload.stream)
@@ -562,6 +566,8 @@ export async function handleCompletion(c: Context) {
 
   const endpointModel = findEndpointModel(routingModel)
   const resolvedClientModel = endpointModel?.id ?? routingModel
+  const reasoningRequestModel =
+    usesInternalModelRewrite ? resolvedClientModel : requestedModel
   const affinityModelId =
     routingModel !== originalRequestModel ?
       (findEndpointModel(originalRequestModel)?.id ?? originalRequestModel)
@@ -657,7 +663,7 @@ export async function handleCompletion(c: Context) {
     safetyIdentifier: normalizedSafetyIdentifier,
     promptCacheKey: normalizedPromptCacheKey,
     isSubagent: isSubagentRequest,
-    requestModel: requestedModel,
+    requestModel: reasoningRequestModel,
     clientModel,
     account,
     reservation,

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -36,6 +36,7 @@ import { createHandlerLogger, debugJson } from "~/lib/logger"
 import { findEndpointModel } from "~/lib/models"
 import { resolveExistingProviderModelAlias } from "~/lib/provider-model"
 import { checkRateLimit } from "~/lib/rate-limit"
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
 import {
   extractResponsesUsageFromResult,
   extractResponsesUsageFromStreamEvent,
@@ -211,6 +212,7 @@ type InstrumentationContext = {
   responsesItemOwnerLookupKeys?: ReadonlyArray<string>
   responsesItemOwnerRecordedKeys?: ReadonlyArray<string>
 
+  requestModel: string
   clientModel: string
 
   account: AccountRuntime
@@ -654,6 +656,7 @@ export async function handleCompletion(c: Context) {
     safetyIdentifier: normalizedSafetyIdentifier,
     promptCacheKey: normalizedPromptCacheKey,
     isSubagent: isSubagentRequest,
+    requestModel: requestedModel,
     clientModel,
     account,
     reservation,
@@ -737,6 +740,18 @@ const handleWithChatCompletions = async (params: {
     instr,
     compactType,
   } = params
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: openAIPayload.reasoning_effort,
+    requestModel: instr.requestModel,
+    targetModel: selectedModel,
+    targetModelId: selectedModel.id,
+  })
+  if (reasoningEffort) {
+    openAIPayload.reasoning_effort = reasoningEffort
+  } else {
+    delete openAIPayload.reasoning_effort
+  }
+
   debugJson(logger, "Translated OpenAI request payload:", openAIPayload)
 
   const ctx = toAccountContext(instr.account)
@@ -941,10 +956,17 @@ const handleWithResponsesApi = async (params: {
     instr,
     compactType,
   } = params
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: anthropicPayload.output_config?.effort,
+    requestModel: instr.requestModel,
+    targetModel: selectedModel,
+    targetModelId: selectedModel.id,
+  })
   const responsesPayload = translateAnthropicMessagesToResponsesPayload(
     anthropicPayload,
     {
       modelOverride: selectedModel.id,
+      reasoningEffort,
       subagentAgentId: subagentMarker?.agent_id,
     },
   )
@@ -2264,7 +2286,9 @@ const handleWithMessagesApi = async (params: {
     compactType,
   } = params
 
-  prepareMessagesApiPayload(anthropicPayload, selectedModel)
+  prepareMessagesApiPayload(anthropicPayload, selectedModel, {
+    requestModel: instr.requestModel,
+  })
 
   debugJson(logger, "Translated Messages payload:", anthropicPayload)
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -382,6 +382,7 @@ async function handleProviderAliasCompletion(
       instrumentation,
       payload,
       provider,
+      requestModel: originalModel,
     })
   } catch (error) {
     const observableError = await extractErrorObservability(error)

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -10,8 +10,11 @@ import {
   compactTextOnlyGuard,
   type CompactType,
 } from "~/lib/compact"
-import { getReasoningEffortForModel } from "~/lib/config"
 import { normalizeSdkModelId } from "~/lib/models"
+import {
+  type ReasoningEffort,
+  resolveReasoningEffortForTarget,
+} from "~/lib/reasoning-effort"
 
 import type {
   AnthropicAssistantContentBlock,
@@ -919,9 +922,31 @@ const filterAssistantThinkingBlocks = (
   }
 }
 
+type AnthropicOutputConfig = NonNullable<
+  AnthropicMessagesPayload["output_config"]
+>
+type AnthropicOutputEffort = AnthropicOutputConfig["effort"]
+
+const normalizeAdaptiveMessagesEffort = (
+  effort: ReasoningEffort | undefined,
+): AnthropicOutputEffort | undefined => {
+  if (!effort) return undefined
+
+  switch (effort) {
+    case "none":
+    case "minimal":
+      return "low"
+    default:
+      return effort
+  }
+}
+
 export const prepareMessagesApiPayload = (
   payload: AnthropicMessagesPayload,
   selectedModel?: Model,
+  options: {
+    requestModel?: string
+  } = {},
 ): void => {
   stripCacheControl(payload)
   applyTopLevelCacheControl(payload)
@@ -946,17 +971,24 @@ export const prepareMessagesApiPayload = (
     if (shouldSummarizeThinkingDisplayForModel(payload.model)) {
       payload.thinking.display = "summarized"
     }
-    let effort =
-      payload.output_config?.effort ?? getReasoningEffortForModel(payload.model)
-    if (effort === "none" || effort === "minimal") {
-      effort = "low"
-    }
-    const reasoningEffort = selectedModel.capabilities.supports.reasoning_effort
-    if (reasoningEffort && !reasoningEffort.includes(effort)) {
-      effort = reasoningEffort.at(-1) as "low" | "medium" | "high"
-    }
-    payload.output_config = {
-      effort: effort,
+    const effort = normalizeAdaptiveMessagesEffort(
+      resolveReasoningEffortForTarget({
+        explicitEffort: payload.output_config?.effort,
+        requestModel: options.requestModel ?? payload.model,
+        targetModel: selectedModel,
+        targetModelId: selectedModel.id,
+      }),
+    )
+    if (effort) {
+      payload.output_config = {
+        ...payload.output_config,
+        effort,
+      }
+    } else if (payload.output_config) {
+      delete payload.output_config.effort
+      if (Object.keys(payload.output_config).length === 0) {
+        delete payload.output_config
+      }
     }
   }
 

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -941,6 +941,36 @@ const normalizeAdaptiveMessagesEffort = (
   }
 }
 
+const applyMessagesReasoningEffort = (
+  payload: AnthropicMessagesPayload,
+  selectedModel: Model | undefined,
+  requestModel: string,
+): void => {
+  const effort = normalizeAdaptiveMessagesEffort(
+    resolveReasoningEffortForTarget({
+      explicitEffort: payload.output_config?.effort,
+      requestModel,
+      targetModel: selectedModel,
+      targetModelId: selectedModel?.id,
+    }),
+  )
+
+  if (effort) {
+    payload.output_config = {
+      ...payload.output_config,
+      effort,
+    }
+    return
+  }
+
+  if (payload.output_config) {
+    delete payload.output_config.effort
+    if (Object.keys(payload.output_config).length === 0) {
+      delete payload.output_config
+    }
+  }
+}
+
 export const prepareMessagesApiPayload = (
   payload: AnthropicMessagesPayload,
   selectedModel?: Model,
@@ -959,6 +989,11 @@ export const prepareMessagesApiPayload = (
   // Using tool_choice: {"type": "any"} or tool_choice: {"type": "tool", "name": "..."} will result in an error because these options force tool use, which is incompatible with extended thinking.
   const toolChoice = payload.tool_choice
   const disableThink = toolChoice?.type === "any" || toolChoice?.type === "tool"
+  applyMessagesReasoningEffort(
+    payload,
+    selectedModel,
+    options.requestModel ?? payload.model,
+  )
 
   if (selectedModel?.capabilities.supports.adaptive_thinking && !disableThink) {
     payload.thinking = {
@@ -970,25 +1005,6 @@ export const prepareMessagesApiPayload = (
     }
     if (shouldSummarizeThinkingDisplayForModel(payload.model)) {
       payload.thinking.display = "summarized"
-    }
-    const effort = normalizeAdaptiveMessagesEffort(
-      resolveReasoningEffortForTarget({
-        explicitEffort: payload.output_config?.effort,
-        requestModel: options.requestModel ?? payload.model,
-        targetModel: selectedModel,
-        targetModelId: selectedModel.id,
-      }),
-    )
-    if (effort) {
-      payload.output_config = {
-        ...payload.output_config,
-        effort,
-      }
-    } else if (payload.output_config) {
-      delete payload.output_config.effort
-      if (Object.keys(payload.output_config).length === 0) {
-        delete payload.output_config
-      }
     }
   }
 

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -12,10 +12,8 @@ import {
   shouldEnableResponsesToolSearch,
 } from "~/lib/tool-search"
 import { HTTPError } from "~/lib/error"
-import {
-  getExtraPromptForModel,
-  getReasoningEffortForModel,
-} from "~/lib/config"
+import { getExtraPromptForModel } from "~/lib/config"
+import type { ReasoningEffort } from "~/lib/reasoning-effort"
 import { requestContext } from "~/lib/request-context"
 import { parseUserIdMetadata } from "~/lib/utils"
 import {
@@ -74,6 +72,7 @@ export const THINKING_TEXT = "Thinking..."
 
 interface ResponsesTranslationOptions {
   modelOverride?: string
+  reasoningEffort?: ReasoningEffort
   subagentAgentId?: string | null
 }
 
@@ -152,10 +151,15 @@ export const translateAnthropicMessagesToResponsesPayload = (
     stream: payload.stream ?? null,
     store: false,
     parallel_tool_calls: true,
-    reasoning: {
-      effort: getReasoningEffortForModel(model),
-      summary: "auto",
-    },
+    reasoning:
+      options.reasoningEffort ?
+        {
+          effort: options.reasoningEffort,
+          summary: "auto",
+        }
+      : {
+          summary: "auto",
+        },
     include: ["reasoning.encrypted_content"],
   }
 

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -14,6 +14,10 @@ import {
   type ProviderModelAlias,
 } from "~/lib/provider-model"
 import {
+  type ReasoningEffort,
+  resolveReasoningEffortForTarget,
+} from "~/lib/reasoning-effort"
+import {
   createCopilotTokenUsageRecorder,
   mergeCopilotAiuUsage,
   normalizeResponsesUsage,
@@ -212,6 +216,7 @@ export const prepareWebSearchResponsesPayload = (
   payload: AnthropicMessagesPayload,
   options: {
     model?: string
+    reasoningEffort?: ReasoningEffort
     subagentAgentId?: string | null
   } = {},
 ): ResponsesPayload => {
@@ -225,7 +230,10 @@ export const prepareWebSearchResponsesPayload = (
 
   const responsesPayload = translateAnthropicMessagesToResponsesPayload(
     switchedPayload,
-    { subagentAgentId: options.subagentAgentId },
+    {
+      reasoningEffort: options.reasoningEffort,
+      subagentAgentId: options.subagentAgentId,
+    },
   )
   responsesPayload.tools = [buildResponsesWebSearchTool(config)]
   responsesPayload.tool_choice = undefined
@@ -632,16 +640,23 @@ export const handleWebSearchViaResponses = async (
 ) => {
   const { logger, webSearchModel } = options
   const wantsStream = Boolean(payload.stream)
+  const selectedModel: Model | undefined = findEndpointModel(webSearchModel)
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.output_config?.effort,
+    requestModel: payload.model,
+    targetModel: selectedModel,
+    targetModelId: webSearchModel,
+  })
 
   // Switch to the GPT web search model and drop the Anthropic server tool so the
   // standard Anthropic -> Responses translation does not choke on it; the
   // Responses web_search tool is attached to the translated payload instead.
   const responsesPayload = prepareWebSearchResponsesPayload(payload, {
     model: webSearchModel,
+    reasoningEffort,
     subagentAgentId: options.subagentMarker?.agent_id,
   })
 
-  const selectedModel: Model | undefined = findEndpointModel(webSearchModel)
   const { vision, initiator } = getResponsesRequestOptions(responsesPayload)
   const transport =
     getResponsesTransportForModel(selectedModel, {

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -59,6 +59,7 @@ import {
   translateResponsesResultToAnthropic,
 } from "~/routes/messages/responses-translation"
 import { normalizeSystemMessages } from "~/routes/messages/preprocess"
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
 import {
   assertWebSearchResponsesResultSucceeded,
   collectWebSearchResponsesStreamResult,
@@ -284,7 +285,15 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
     : undefined
-  const responsesPayload = prepareWebSearchResponsesPayload(payload)
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.output_config?.effort,
+    requestModel: payload.model,
+    targetModel: selectedModel,
+    targetModelId: selectedModel?.id,
+  })
+  const responsesPayload = prepareWebSearchResponsesPayload(payload, {
+    reasoningEffort,
+  })
   responsesPayload.stream = true
 
   applyResponsesApiContextManagement(
@@ -387,7 +396,18 @@ const handleOpenAIResponsesProviderMessages = async (
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
     : undefined
-  const responsesPayload = translateAnthropicMessagesToResponsesPayload(payload)
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.output_config?.effort,
+    requestModel: payload.model,
+    targetModel: selectedModel,
+    targetModelId: selectedModel?.id,
+  })
+  const responsesPayload = translateAnthropicMessagesToResponsesPayload(
+    payload,
+    {
+      reasoningEffort,
+    },
+  )
 
   applyResponsesApiContextManagement(
     responsesPayload,

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -14,8 +14,10 @@ import type {
   ChatCompletionResponse,
   ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
+import type { Model } from "~/services/copilot/get-models"
 
 import {
+  getConfiguredReasoningEffortForModel,
   getProviderConfig,
   type ModelConfig,
   type ResolvedProviderConfig,
@@ -59,7 +61,11 @@ import {
   translateResponsesResultToAnthropic,
 } from "~/routes/messages/responses-translation"
 import { normalizeSystemMessages } from "~/routes/messages/preprocess"
-import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
+import {
+  parseReasoningEffort,
+  type ReasoningEffort,
+  resolveReasoningEffortForTarget,
+} from "~/lib/reasoning-effort"
 import {
   assertWebSearchResponsesResultSucceeded,
   collectWebSearchResponsesStreamResult,
@@ -88,6 +94,25 @@ import {
 } from "~/services/providers/provider-proxy"
 
 const logger = createHandlerLogger("provider-messages-handler")
+
+const resolveProviderResponsesReasoningEffort = (
+  payload: AnthropicMessagesPayload,
+  selectedModel: Pick<Model, "id" | "capabilities"> | undefined,
+): ReasoningEffort | undefined => {
+  if (selectedModel) {
+    return resolveReasoningEffortForTarget({
+      explicitEffort: payload.output_config?.effort,
+      requestModel: payload.model,
+      targetModel: selectedModel,
+      targetModelId: selectedModel.id,
+    })
+  }
+
+  return (
+    parseReasoningEffort(payload.output_config?.effort)
+    ?? getConfiguredReasoningEffortForModel(payload.model)
+  )
+}
 
 type ProviderConfigResolver = (
   provider: string,
@@ -285,12 +310,10 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
     : undefined
-  const reasoningEffort = resolveReasoningEffortForTarget({
-    explicitEffort: payload.output_config?.effort,
-    requestModel: payload.model,
-    targetModel: selectedModel,
-    targetModelId: selectedModel?.id,
-  })
+  const reasoningEffort = resolveProviderResponsesReasoningEffort(
+    payload,
+    selectedModel,
+  )
   const responsesPayload = prepareWebSearchResponsesPayload(payload, {
     reasoningEffort,
   })
@@ -396,12 +419,10 @@ const handleOpenAIResponsesProviderMessages = async (
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
     : undefined
-  const reasoningEffort = resolveReasoningEffortForTarget({
-    explicitEffort: payload.output_config?.effort,
-    requestModel: payload.model,
-    targetModel: selectedModel,
-    targetModelId: selectedModel?.id,
-  })
+  const reasoningEffort = resolveProviderResponsesReasoningEffort(
+    payload,
+    selectedModel,
+  )
   const responsesPayload = translateAnthropicMessagesToResponsesPayload(
     payload,
     {

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -98,19 +98,22 @@ const logger = createHandlerLogger("provider-messages-handler")
 const resolveProviderResponsesReasoningEffort = (
   payload: AnthropicMessagesPayload,
   selectedModel: Pick<Model, "id" | "capabilities"> | undefined,
+  requestModel = payload.model,
 ): ReasoningEffort | undefined => {
   if (selectedModel) {
     return resolveReasoningEffortForTarget({
       explicitEffort: payload.output_config?.effort,
-      requestModel: payload.model,
+      requestModel,
       targetModel: selectedModel,
       targetModelId: selectedModel.id,
     })
   }
 
+  if (payload.output_config?.effort === null) return undefined
+
   return (
     parseReasoningEffort(payload.output_config?.effort)
-    ?? getConfiguredReasoningEffortForModel(payload.model)
+    ?? getConfiguredReasoningEffortForModel(requestModel)
   )
 }
 
@@ -178,9 +181,10 @@ export async function handleProviderMessagesForProvider(
     instrumentation?: ProviderMessagesInstrumentation
     payload: AnthropicMessagesPayload
     provider: string
+    requestModel?: string
   },
 ): Promise<Response> {
-  const { instrumentation, payload, provider } = options
+  const { instrumentation, payload, provider, requestModel } = options
   const providerConfig = resolveProviderConfig(c, provider)
   if (!providerConfig) {
     const message = `Provider '${provider}' not found or disabled`
@@ -221,6 +225,7 @@ export async function handleProviderMessagesForProvider(
             payload,
             provider,
             providerConfig: effectiveProviderConfig,
+            requestModel,
           })
         }
 
@@ -233,6 +238,7 @@ export async function handleProviderMessagesForProvider(
         payload,
         provider,
         providerConfig: effectiveProviderConfig,
+        requestModel,
       })
     }
 
@@ -303,9 +309,11 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
     payload: AnthropicMessagesPayload
     provider: string
     providerConfig: ResolvedProviderConfig
+    requestModel?: string
   },
 ): Promise<Response> => {
-  const { instrumentation, payload, provider, providerConfig } = options
+  const { instrumentation, payload, provider, providerConfig, requestModel } =
+    options
   const selectedModel =
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
@@ -313,6 +321,7 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
   const reasoningEffort = resolveProviderResponsesReasoningEffort(
     payload,
     selectedModel,
+    requestModel,
   )
   const responsesPayload = prepareWebSearchResponsesPayload(payload, {
     reasoningEffort,
@@ -412,9 +421,11 @@ const handleOpenAIResponsesProviderMessages = async (
     payload: AnthropicMessagesPayload
     provider: string
     providerConfig: ResolvedProviderConfig
+    requestModel?: string
   },
 ): Promise<Response> => {
-  const { instrumentation, payload, provider, providerConfig } = options
+  const { instrumentation, payload, provider, providerConfig, requestModel } =
+    options
   const selectedModel =
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
@@ -422,6 +433,7 @@ const handleOpenAIResponsesProviderMessages = async (
   const reasoningEffort = resolveProviderResponsesReasoningEffort(
     payload,
     selectedModel,
+    requestModel,
   )
   const responsesPayload = translateAnthropicMessagesToResponsesPayload(
     payload,

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -32,6 +32,7 @@ import {
   getRequestHistoryStore,
   type NormalizedUsage,
 } from "~/lib/request-history"
+import { resolveReasoningEffortForTarget } from "~/lib/reasoning-effort"
 import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
@@ -200,6 +201,19 @@ export const handleResponses = async (c: Context) => {
   request.selectionReason = selection.selectionReason
 
   const upstreamPayload = { ...payload, model: selectedModel.id }
+  const reasoningEffort = resolveReasoningEffortForTarget({
+    explicitEffort: payload.reasoning?.effort,
+    requestModel: clientModel,
+    targetModel: selectedModel,
+  })
+  if (reasoningEffort) {
+    upstreamPayload.reasoning = {
+      ...(upstreamPayload.reasoning ?? {}),
+      effort: reasoningEffort,
+    }
+  } else if (upstreamPayload.reasoning) {
+    delete upstreamPayload.reasoning.effort
+  }
   removeUnsupportedTools(upstreamPayload)
 
   const sanitizedImageCount = sanitizeOversizedInputImages(

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -202,7 +202,8 @@ export const handleResponses = async (c: Context) => {
 
   const upstreamPayload = { ...payload, model: selectedModel.id }
   const reasoningEffort = resolveReasoningEffortForTarget({
-    explicitEffort: payload.reasoning?.effort,
+    explicitEffort:
+      payload.reasoning === null ? null : payload.reasoning?.effort,
     requestModel: requestedModel,
     targetModel: selectedModel,
     targetModelId: selectedModel.id,

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -205,6 +205,7 @@ export const handleResponses = async (c: Context) => {
     explicitEffort: payload.reasoning?.effort,
     requestModel: requestedModel,
     targetModel: selectedModel,
+    targetModelId: selectedModel.id,
   })
   if (reasoningEffort) {
     upstreamPayload.reasoning = {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -203,7 +203,7 @@ export const handleResponses = async (c: Context) => {
   const upstreamPayload = { ...payload, model: selectedModel.id }
   const reasoningEffort = resolveReasoningEffortForTarget({
     explicitEffort: payload.reasoning?.effort,
-    requestModel: clientModel,
+    requestModel: requestedModel,
     targetModel: selectedModel,
   })
   if (reasoningEffort) {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -214,6 +214,9 @@ export const handleResponses = async (c: Context) => {
     }
   } else if (upstreamPayload.reasoning) {
     delete upstreamPayload.reasoning.effort
+    if (Object.keys(upstreamPayload.reasoning).length === 0) {
+      delete upstreamPayload.reasoning
+    }
   }
   removeUnsupportedTools(upstreamPayload)
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -2,6 +2,7 @@ import consola from "consola"
 import { events } from "fetch-event-stream"
 
 import type { CompactType } from "~/lib/compact"
+import type { ReasoningEffort } from "~/lib/reasoning-effort"
 import type { SubagentMarker } from "~/lib/subagent"
 import type { AccountContext } from "~/lib/types/account"
 
@@ -234,15 +235,7 @@ export interface ChatCompletionsPayload {
     | { type: "function"; function: { name: string } }
     | null
   user?: string | null
-  reasoning_effort?:
-    | "none"
-    | "minimal"
-    | "low"
-    | "medium"
-    | "high"
-    | "xhigh"
-    | "max"
-    | null
+  reasoning_effort?: ReasoningEffort | null
   stream_options?: {
     include_usage?: boolean | null
   } | null

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -11,7 +11,7 @@ import {
   prepareForCompact,
   prepareInteractionHeaders,
 } from "~/lib/api-config"
-import { getReasoningEffortForModel, isForceAgentEnabled } from "~/lib/config"
+import { isForceAgentEnabled } from "~/lib/config"
 import { logCopilotRateLimits } from "~/lib/copilot-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { captureOutboundHeadersSnapshot } from "~/lib/request-context"
@@ -19,28 +19,6 @@ import { resolveEffectiveInitiator } from "~/lib/request-initiator"
 import { accountFromState } from "~/lib/state"
 
 import { copilotFetch } from "./copilot-fetch"
-
-function isGpt5MiniFamily(modelId: string): boolean {
-  return modelId === "gpt-5-mini" || modelId.startsWith("gpt-5-mini-")
-}
-
-function applyDefaultReasoningEffort(
-  payload: ChatCompletionsPayload,
-): ChatCompletionsPayload {
-  if (!isGpt5MiniFamily(payload.model)) return payload
-
-  // Only inject when omitted/null; allow callers to explicitly override.
-  if (
-    payload.reasoning_effort !== null
-    && payload.reasoning_effort !== undefined
-  )
-    return payload
-
-  return {
-    ...payload,
-    reasoning_effort: getReasoningEffortForModel("gpt-5-mini"),
-  }
-}
 
 export const getChatInitiator = (
   messages: Array<Message>,
@@ -100,7 +78,7 @@ export const createChatCompletions = async (
     headers,
   )
 
-  const upstreamPayload = applyDefaultReasoningEffort(payload)
+  const upstreamPayload = payload
 
   prepareForCompact(headers, options?.compactType)
   captureOutboundHeadersSnapshot(headers)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -3,6 +3,7 @@ import { events } from "fetch-event-stream"
 import { createHash } from "node:crypto"
 import { WebSocket } from "undici"
 
+import type { ReasoningEffort } from "~/lib/reasoning-effort"
 import type { SubagentMarker } from "~/lib/subagent"
 import type { AccountContext } from "~/lib/types/account"
 
@@ -99,15 +100,7 @@ export type ResponseIncludable =
   | "message.output_text.logprobs"
 
 export interface Reasoning {
-  effort?:
-    | "none"
-    | "minimal"
-    | "low"
-    | "medium"
-    | "high"
-    | "xhigh"
-    | "max"
-    | null
+  effort?: ReasoningEffort | null
   summary?: "auto" | "concise" | "detailed" | null
 }
 

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -99,7 +99,15 @@ export type ResponseIncludable =
   | "message.output_text.logprobs"
 
 export interface Reasoning {
-  effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | null
+  effort?:
+    | "none"
+    | "minimal"
+    | "low"
+    | "medium"
+    | "high"
+    | "xhigh"
+    | "max"
+    | null
   summary?: "auto" | "concise" | "detailed" | null
 }
 

--- a/tests/admin-config.test.ts
+++ b/tests/admin-config.test.ts
@@ -1007,7 +1007,7 @@ test("POST /api/admin/config rejects invalid provider model advanced fields", as
   }
 })
 
-test("POST /api/admin/config keeps reasoning max out of config layer", async () => {
+test("POST /api/admin/config accepts max reasoning effort as intent", async () => {
   await withConfig({}, async () => {
     const { server } = await import("../src/server")
 
@@ -1025,10 +1025,12 @@ test("POST /api/admin/config keeps reasoning max out of config layer", async () 
       }),
     )
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(200)
 
-    const body = (await res.json()) as { error?: { message?: string } }
-    expect(body.error?.message).toContain("modelReasoningEfforts.gpt-5.5")
+    const body = (await res.json()) as {
+      modelReasoningEfforts?: Record<string, string>
+    }
+    expect(body.modelReasoningEfforts?.["gpt-5.5"]).toBe("max")
   })
 })
 

--- a/tests/admin-models-details.test.ts
+++ b/tests/admin-models-details.test.ts
@@ -111,6 +111,25 @@ test("GET /api/admin/models/details returns model details with aliases", async (
       await withMockedModels(
         [
           buildModel("gpt-5-mini", {
+            capabilities: {
+              family: "test",
+              limits: {
+                max_context_window_tokens: 128_000,
+                max_prompt_tokens: 96_000,
+                max_output_tokens: 32_000,
+              },
+              object: "capabilities",
+              supports: {
+                tool_calls: true,
+                vision: false,
+                structured_outputs: true,
+                streaming: true,
+                parallel_tool_calls: true,
+                reasoning_effort: ["low", "medium", "high", "xhigh"],
+              },
+              tokenizer: "test",
+              type: "chat",
+            },
             billing: {
               multiplier: 2,
               is_premium: true,
@@ -150,7 +169,10 @@ test("GET /api/admin/models/details returns model details with aliases", async (
                   max_prompt_tokens?: number
                   max_output_tokens?: number
                 }
-                supports: { tool_calls?: boolean }
+                supports: {
+                  tool_calls?: boolean
+                  reasoning_effort?: Array<string>
+                }
               }
             }>
           }
@@ -180,6 +202,12 @@ test("GET /api/admin/models/details returns model details with aliases", async (
           expect(mini?.capabilities.limits.max_prompt_tokens).toBe(96_000)
           expect(mini?.capabilities.limits.max_output_tokens).toBe(32_000)
           expect(mini?.capabilities.supports.tool_calls).toBe(true)
+          expect(mini?.capabilities.supports.reasoning_effort).toEqual([
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+          ])
         },
       )
     },

--- a/tests/admin-models-details.test.ts
+++ b/tests/admin-models-details.test.ts
@@ -125,7 +125,7 @@ test("GET /api/admin/models/details returns model details with aliases", async (
                 structured_outputs: true,
                 streaming: true,
                 parallel_tool_calls: true,
-                reasoning_effort: ["low", "medium", "high", "xhigh"],
+                reasoning_effort: ["xhigh", "low", "ultra", "low", "medium"],
               },
               tokenizer: "test",
               type: "chat",
@@ -205,7 +205,6 @@ test("GET /api/admin/models/details returns model details with aliases", async (
           expect(mini?.capabilities.supports.reasoning_effort).toEqual([
             "low",
             "medium",
-            "high",
             "xhigh",
           ])
         },

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
 
+import "./shared-admin-db-test-home"
+
 import type { AccountRuntime } from "~/lib/types/account"
 import type { Model } from "~/services/copilot/get-models"
 
@@ -56,7 +58,10 @@ function buildAccount(): AccountRuntime {
   }
 }
 
-function buildModel(id: string): Model {
+function buildModel(
+  id: string,
+  reasoningEffort: Array<string> = ["low", "medium", "high", "xhigh"],
+): Model {
   return {
     id,
     name: id,
@@ -75,6 +80,7 @@ function buildModel(id: string): Model {
       supports: {
         adaptive_thinking: true,
         streaming: true,
+        reasoning_effort: reasoningEffort,
       },
       tokenizer: "o200k_base",
       type: "chat",
@@ -82,11 +88,14 @@ function buildModel(id: string): Model {
   }
 }
 
-function buildSelection(modelId: string): SelectionOk {
+function buildSelection(
+  modelId: string,
+  reasoningEffort?: Array<string>,
+): SelectionOk {
   return {
     ok: true,
     account: buildAccount(),
-    selectedModel: buildModel(modelId),
+    selectedModel: buildModel(modelId, reasoningEffort),
     endpoint: "/chat/completions",
     costUnits: 0,
     confirmAffinity: mock(() => {}),
@@ -95,7 +104,7 @@ function buildSelection(modelId: string): SelectionOk {
   }
 }
 
-const fetchMock = mock(() =>
+const fetchMock = mock((_url?: unknown, _opts?: { body?: unknown }) =>
   Promise.resolve(
     new Response(
       JSON.stringify({
@@ -347,5 +356,76 @@ describe("chat completions handler", () => {
       total_nano_aiu: 3_000_000_000,
       total_tokens: 14,
     })
+  })
+
+  test("normalizes explicit reasoning_effort to selected model support", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("gpt-test", ["low", "medium", "high"]))
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchMock.mockImplementationOnce((_url, opts) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "gpt-test",
+            choices: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-test",
+        messages: [{ role: "user", content: "hello" }],
+        reasoning_effort: "max",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.reasoning_effort).toBe("high")
+  })
+
+  test("injects configured fallback effort for any supported chat model", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("gpt-test", ["low", "medium"]))
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchMock.mockImplementationOnce((_url, opts) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "gpt-test",
+            choices: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-test",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.reasoning_effort).toBe("medium")
   })
 })

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -523,6 +523,47 @@ describe("chat completions handler", () => {
     expect(upstreamBody?.reasoning_effort).toBe("high")
   })
 
+  test("uses selected target model configured fallback when request model has none", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {},
+      modelMappings: {},
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("gpt-5-mini", ["low", "medium", "high"]))
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchMock.mockImplementationOnce((_url, opts) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "gpt-5-mini",
+            choices: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "unconfigured-chat-request",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.model).toBe("gpt-5-mini")
+    expect(upstreamBody?.reasoning_effort).toBe("low")
+  })
+
   test("omits reasoning_effort when no explicit or configured default exists", async () => {
     await writeConfig({
       modelReasoningEfforts: {},

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -469,6 +469,48 @@ describe("chat completions handler", () => {
     expect(upstreamBody?.reasoning_effort).toBe("medium")
   })
 
+  test("does not inject configured fallback when reasoning_effort is explicit null", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "gpt-test": "high",
+      },
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("gpt-test", ["low", "medium", "high"]))
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchMock.mockImplementationOnce((_url, opts) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "gpt-test",
+            choices: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-test",
+        messages: [{ role: "user", content: "hello" }],
+        reasoning_effort: null,
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(Object.hasOwn(upstreamBody ?? {}, "reasoning_effort")).toBe(false)
+  })
+
   test("uses requested model configured fallback before modelMappings", async () => {
     await writeConfig({
       modelMappings: {

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
+import fs from "node:fs/promises"
+import path from "node:path"
 
 import "./shared-admin-db-test-home"
 
@@ -15,6 +17,8 @@ await mock.module("~/lib/rate-limit", () => ({
 
 import { state } from "../src/lib/state"
 import { accountsManager } from "../src/lib/accounts-manager"
+import { mergeConfigWithDefaults } from "../src/lib/config"
+import { PATHS } from "../src/lib/paths"
 import {
   closeUsageStore,
   getTokenUsageEventsPage,
@@ -43,7 +47,31 @@ const originalState = {
   vsCodeVersion: state.vsCodeVersion,
 }
 const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
+let configBeforeTest: string | null | undefined
 let dbPathBeforeTest: string | undefined
+
+const readConfigText = async (): Promise<string | null> =>
+  await fs.readFile(PATHS.CONFIG_PATH, "utf8").catch(() => null)
+
+const restoreConfigText = async (configText: string | null): Promise<void> => {
+  if (configText === null) {
+    await fs.rm(PATHS.CONFIG_PATH, { force: true })
+  } else {
+    await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+    await fs.writeFile(PATHS.CONFIG_PATH, configText, "utf8")
+  }
+  mergeConfigWithDefaults()
+}
+
+const writeConfig = async (config: Record<string, unknown>): Promise<void> => {
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+}
 
 function buildAccount(): AccountRuntime {
   return {
@@ -134,6 +162,7 @@ beforeEach(async () => {
   dbPathBeforeTest = process.env[DB_PATH_ENV]
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
+  configBeforeTest = await readConfigText()
 
   state.accountType = "individual"
   state.copilotToken = "test-token"
@@ -174,6 +203,11 @@ afterEach(async () => {
   }
   dbPathBeforeTest = undefined
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
+
+  if (configBeforeTest !== undefined) {
+    await restoreConfigText(configBeforeTest)
+    configBeforeTest = undefined
+  }
 })
 
 describe("chat completions handler", () => {
@@ -395,6 +429,12 @@ describe("chat completions handler", () => {
   })
 
   test("injects configured fallback effort for any supported chat model", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "gpt-test": "high",
+      },
+    })
+
     accountsManager.selectAccountForRequest = () =>
       Promise.resolve(buildSelection("gpt-test", ["low", "medium"]))
 
@@ -427,5 +467,101 @@ describe("chat completions handler", () => {
 
     expect(response.status).toBe(200)
     expect(upstreamBody?.reasoning_effort).toBe("medium")
+  })
+
+  test("uses requested model configured fallback before modelMappings", async () => {
+    await writeConfig({
+      modelMappings: {
+        "chat-requested": "chat-mapped",
+      },
+      modelReasoningEfforts: {
+        "chat-requested": "max",
+        "chat-mapped": "low",
+      },
+    })
+
+    let selectionCandidates:
+      | ReadonlyArray<{ modelId: string; endpoint: string }>
+      | undefined
+    accountsManager.selectAccountForRequest = (candidates) => {
+      selectionCandidates = candidates
+      return Promise.resolve(
+        buildSelection("chat-mapped", ["low", "medium", "high"]),
+      )
+    }
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchMock.mockImplementationOnce((_url, opts) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "chat-mapped",
+            choices: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "chat-requested",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(selectionCandidates?.[0]?.modelId).toBe("chat-mapped")
+    expect(upstreamBody?.model).toBe("chat-mapped")
+    expect(upstreamBody?.reasoning_effort).toBe("high")
+  })
+
+  test("omits reasoning_effort when no explicit or configured default exists", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {},
+      modelMappings: {},
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("unconfigured-chat", ["low", "medium", "high"]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchMock.mockImplementationOnce((_url, opts) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "unconfigured-chat",
+            choices: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "unconfigured-chat",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(Object.hasOwn(upstreamBody ?? {}, "reasoning_effort")).toBe(false)
   })
 })

--- a/tests/create-chat-completions.test.ts
+++ b/tests/create-chat-completions.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test"
 
 import { COMPACT_REQUEST } from "../src/lib/compact"
-import { getReasoningEffortForModel } from "../src/lib/config"
 import { state } from "../src/lib/state"
 import {
   createChatCompletions,
@@ -183,24 +182,7 @@ test("keeps subagent interaction type for compact chat requests", async () => {
   expect(headers["x-initiator"]).toBe("agent")
 })
 
-test("injects reasoning_effort from config for gpt-5-mini when omitted", async () => {
-  const callCountBefore = fetchMock.mock.calls.length
-
-  const payload: ChatCompletionsPayload = {
-    messages: [{ role: "user", content: "hi" }],
-    model: "gpt-5-mini",
-  }
-
-  await callCreateChatCompletions(payload)
-
-  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
-  const upstreamPayload = getLastUpstreamPayload()
-  expect(upstreamPayload["reasoning_effort"]).toBe(
-    getReasoningEffortForModel("gpt-5-mini"),
-  )
-})
-
-test("does not override explicit reasoning_effort for gpt-5-mini", async () => {
+test("passes through explicit reasoning_effort unchanged", async () => {
   const callCountBefore = fetchMock.mock.calls.length
 
   const payload: ChatCompletionsPayload = {
@@ -245,21 +227,4 @@ test("does not inject reasoning_effort for non-gpt-5-mini models when omitted", 
   expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
   const upstreamPayload = getLastUpstreamPayload()
   expect(Object.hasOwn(upstreamPayload, "reasoning_effort")).toBe(false)
-})
-
-test("injects reasoning_effort for gpt-5-mini variant models when omitted", async () => {
-  const callCountBefore = fetchMock.mock.calls.length
-
-  const payload: ChatCompletionsPayload = {
-    messages: [{ role: "user", content: "hi" }],
-    model: "gpt-5-mini-2026-01-01",
-  }
-
-  await callCreateChatCompletions(payload)
-
-  expect(fetchMock.mock.calls.length).toBe(callCountBefore + 1)
-  const upstreamPayload = getLastUpstreamPayload()
-  expect(upstreamPayload["reasoning_effort"]).toBe(
-    getReasoningEffortForModel("gpt-5-mini"),
-  )
 })

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import fs from "node:fs/promises"
 import path from "node:path"
 
+import "./shared-admin-db-test-home"
+
 import type { AccountRuntime } from "~/lib/types/account"
 import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
 import type { Model } from "~/services/copilot/get-models"
@@ -1112,7 +1114,10 @@ describe("messages handler routing", () => {
   })
 
   test("records Copilot AIU when Messages web search routes through Responses", async () => {
-    const selection = buildSelection("/responses", "search-model")
+    const selection = buildSelection("/responses", "search-model", [
+      "low",
+      "high",
+    ])
     accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
 
     let upstreamBody: Record<string, unknown> | undefined
@@ -1152,6 +1157,9 @@ describe("messages handler routing", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(
           createPayload({
+            output_config: {
+              effort: "medium",
+            },
             tools: [
               { type: "web_search_20250305", name: "web_search" },
             ] as never,
@@ -1163,6 +1171,7 @@ describe("messages handler routing", () => {
 
     expect(response.status).toBe(200)
     expect(upstreamBody?.model).toBe("search-model")
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("low")
     expect(await readSingleTokenUsageEvent()).toMatchObject({
       cache_read_input_tokens: 6,
       cost: {

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -688,6 +688,60 @@ describe("messages handler routing", () => {
     )
   })
 
+  test("compact small-model reroutes use routed model reasoning defaults", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "original-model": "max",
+        [getSmallModel()]: "low",
+      },
+    })
+
+    let upstreamBody: Record<string, unknown> | undefined
+
+    const selection = buildSelection("/v1/messages", getSmallModel(), [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ])
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = parseFetchBody(opts?.body)
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildAnthropicResponse(getSmallModel(), "compact")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            system:
+              "You are a helpful AI assistant tasked with summarizing conversations",
+          }),
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect((upstreamBody?.output_config as { effort?: string }).effort).toBe(
+      "low",
+    )
+  })
+
   test("records Copilot AIU from non-streaming Messages API responses", async () => {
     const selection = buildSelection("/v1/messages", "messages-model")
     accountsManager.selectAccountForRequest = () => Promise.resolve(selection)

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
 
 import type { AccountRuntime } from "~/lib/types/account"
 import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
@@ -11,8 +13,9 @@ import {
   compactSummaryPromptStart,
   compactTextOnlyGuard,
 } from "~/lib/compact"
-import { getSmallModel } from "~/lib/config"
+import { getSmallModel, mergeConfigWithDefaults } from "~/lib/config"
 import { HTTPError } from "~/lib/error"
+import { PATHS } from "~/lib/paths"
 import { state } from "~/lib/state"
 import { closeUsageStore, getTokenUsageEventsPage } from "~/lib/token-usage"
 import { getUUID } from "~/lib/utils"
@@ -36,6 +39,30 @@ const originalFinalize = accountsManager.finalizeQuota.bind(accountsManager)
 const originalMarkFailed =
   accountsManager.markAccountFailed.bind(accountsManager)
 let dbPathBeforeTest: string | undefined
+let configBeforeTest: string | null | undefined
+
+const readConfigText = async (): Promise<string | null> =>
+  await fs.readFile(PATHS.CONFIG_PATH, "utf8").catch(() => null)
+
+const restoreConfigText = async (configText: string | null): Promise<void> => {
+  if (configText === null) {
+    await fs.rm(PATHS.CONFIG_PATH, { force: true })
+  } else {
+    await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+    await fs.writeFile(PATHS.CONFIG_PATH, configText, "utf8")
+  }
+  mergeConfigWithDefaults()
+}
+
+const writeConfig = async (config: Record<string, unknown>): Promise<void> => {
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+}
 
 function parseFetchBody(body: unknown): Record<string, unknown> {
   if (typeof body !== "string") {
@@ -58,7 +85,10 @@ function buildAccount(): AccountRuntime {
   }
 }
 
-function buildModel(id: string): Model {
+function buildModel(
+  id: string,
+  reasoningEffort: Array<string> = ["low", "medium", "high", "xhigh"],
+): Model {
   return {
     id,
     name: id,
@@ -77,6 +107,7 @@ function buildModel(id: string): Model {
       supports: {
         adaptive_thinking: true,
         streaming: true,
+        reasoning_effort: reasoningEffort,
       },
       tokenizer: "o200k_base",
       type: "chat",
@@ -84,11 +115,15 @@ function buildModel(id: string): Model {
   }
 }
 
-function buildSelection(endpoint: string, modelId: string): SelectionOk {
+function buildSelection(
+  endpoint: string,
+  modelId: string,
+  reasoningEffort?: Array<string>,
+): SelectionOk {
   return {
     ok: true,
     account: buildAccount(),
-    selectedModel: buildModel(modelId),
+    selectedModel: buildModel(modelId, reasoningEffort),
     endpoint,
     costUnits: 0,
     confirmAffinity: mock(() => {}),
@@ -204,6 +239,7 @@ beforeEach(async () => {
   dbPathBeforeTest = process.env[DB_PATH_ENV]
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
+  configBeforeTest = await readConfigText()
 
   state.manualApprove = false
   state.verbose = false
@@ -228,6 +264,11 @@ afterEach(async () => {
     process.env[DB_PATH_ENV] = dbPathBeforeTest
   }
   dbPathBeforeTest = undefined
+
+  if (configBeforeTest !== undefined) {
+    await restoreConfigText(configBeforeTest)
+    configBeforeTest = undefined
+  }
 })
 
 describe("messages handler sanitization", () => {
@@ -597,6 +638,54 @@ describe("messages handler routing", () => {
     expect(selection.confirmOwnership).toHaveBeenCalledTimes(1)
   })
 
+  test("Messages to native Messages injects request default effort when omitted", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "original-model": "max",
+        "messages-model": "low",
+      },
+    })
+
+    let upstreamBody: Record<string, unknown> | undefined
+
+    const selection = buildSelection("/v1/messages", "messages-model", [
+      "low",
+      "medium",
+      "high",
+    ])
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = parseFetchBody(opts?.body)
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildAnthropicResponse("messages-model", "messages")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload()),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect((upstreamBody?.output_config as { effort?: string }).effort).toBe(
+      "high",
+    )
+  })
+
   test("records Copilot AIU from non-streaming Messages API responses", async () => {
     const selection = buildSelection("/v1/messages", "messages-model")
     accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
@@ -797,6 +886,100 @@ describe("messages handler routing", () => {
     expect(body.content[0].text).toBe("responses")
     expect(selection.confirmAffinity).toHaveBeenCalledTimes(1)
     expect(selection.confirmOwnership).toHaveBeenCalledTimes(1)
+  })
+
+  test("Messages to Responses preserves explicit effort as normalized intent", async () => {
+    let upstreamBody: Record<string, unknown> | undefined
+
+    const selection = buildSelection("/responses", "responses-model", [
+      "low",
+      "high",
+    ])
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = parseFetchBody(opts?.body)
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("responses-model", "responses")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            output_config: {
+              effort: "medium",
+            },
+          }),
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("low")
+  })
+
+  test("Messages to Responses uses request model default before modelMappings", async () => {
+    await writeConfig({
+      modelMappings: {
+        "messages-requested": "mapped-model",
+      },
+      modelReasoningEfforts: {
+        "messages-requested": "max",
+        "mapped-model": "low",
+      },
+    })
+
+    let upstreamBody: Record<string, unknown> | undefined
+
+    const selection = buildSelection("/responses", "mapped-model", [
+      "low",
+      "medium",
+      "high",
+    ])
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = parseFetchBody(opts?.body)
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("mapped-model", "responses")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload({ model: "messages-requested" })),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.model).toBe("mapped-model")
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("high")
   })
 
   test("records Copilot AIU when Messages routes to non-streaming Responses", async () => {
@@ -1041,6 +1224,50 @@ describe("messages handler routing", () => {
     expect(body.content[0].text).toBe("chat")
     expect(selection.confirmAffinity).toHaveBeenCalledTimes(1)
     expect(selection.confirmOwnership).toHaveBeenCalledTimes(1)
+  })
+
+  test("Messages to Chat Completions writes normalized reasoning_effort", async () => {
+    let upstreamBody: Record<string, unknown> | undefined
+
+    const selection = buildSelection("/chat/completions", "chat-model", [
+      "low",
+      "high",
+    ])
+    accountsManager.selectAccountForRequest = () => Promise.resolve(selection)
+
+    const fetchMock = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = parseFetchBody(opts?.body)
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildChatCompletionResponse("chat-model", "chat")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    // @ts-expect-error test mock only implements the used subset
+    fetchHolder.fetch = fetchMock
+
+    const response = await messageRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          createPayload({
+            output_config: {
+              effort: "medium",
+            },
+          }),
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.reasoning_effort).toBe("low")
   })
 
   test("records Copilot AIU when Messages routes to non-streaming Chat Completions", async () => {

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1124,6 +1124,47 @@ describe("prepareMessagesApiPayload", () => {
     expect(payload.output_config).toBeUndefined()
   })
 
+  test("normalizes reasoning effort when tool choice disables adaptive thinking", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "gpt-5.4",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      output_config: {
+        effort: "max",
+        format: {
+          schema: {
+            type: "object",
+          },
+          type: "json_schema",
+        },
+      },
+      tool_choice: {
+        type: "tool",
+        name: "apply_patch",
+      },
+    }
+
+    prepareMessagesApiPayload(payload, {
+      capabilities: {
+        supports: {
+          adaptive_thinking: true,
+          reasoning_effort: ["low", "medium", "high"],
+        },
+      },
+    } as never)
+
+    expect(payload.thinking).toBeUndefined()
+    expect(payload.output_config).toEqual({
+      effort: "high",
+      format: {
+        schema: {
+          type: "object",
+        },
+        type: "json_schema",
+      },
+    })
+  })
+
   test("preserves output format when stripping unsupported reasoning effort", () => {
     const payload: AnthropicMessagesPayload = {
       model: "claude-haiku-4.5",

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1065,6 +1065,7 @@ describe("prepareMessagesApiPayload", () => {
       capabilities: {
         supports: {
           adaptive_thinking: true,
+          reasoning_effort: ["low", "medium", "high", "xhigh"],
         },
       },
     } as never)

--- a/tests/provider-messages-web-search.test.ts
+++ b/tests/provider-messages-web-search.test.ts
@@ -819,6 +819,49 @@ describe("provider messages web_search", () => {
     expect(upstreamBody.reasoning?.effort).toBe("max")
   })
 
+  test("uses provider alias configured reasoning default from original request model", async () => {
+    writeTestConfig({
+      auth: { apiKeys: [] },
+      modelAliases: {
+        "fast-search": {
+          target: "search/gpt-search",
+        },
+      },
+      modelReasoningEfforts: {
+        "fast-search": "max",
+      },
+      providers: {
+        search: searchProviderConfig(),
+      },
+    })
+
+    const app = createApp()
+    const response = await app.request("/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+        model: "fast-search",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://provider.example/v1/responses")
+
+    const upstreamBody = JSON.parse((init as RequestInit).body as string) as {
+      model: string
+      reasoning?: { effort?: string }
+    }
+    expect(upstreamBody.model).toBe("gpt-search")
+    expect(upstreamBody.reasoning?.effort).toBe("max")
+  })
+
   test("streams synthetic Anthropic events after parsing upstream Responses stream", async () => {
     const app = createApp()
     const response = await app.request("/search/v1/messages", {

--- a/tests/provider-messages-web-search.test.ts
+++ b/tests/provider-messages-web-search.test.ts
@@ -692,7 +692,7 @@ describe("provider messages web_search", () => {
         apiKey: "unused",
         authType: "authorization",
         models: {
-          "gpt-search": {
+          "gpt-5.4": {
             toolContentSupportType: [],
           },
         },
@@ -708,7 +708,10 @@ describe("provider messages web_search", () => {
       body: JSON.stringify({
         max_tokens: 128,
         messages: [{ role: "user", content: "What is the Node.js LTS?" }],
-        model: "gpt-search",
+        model: "gpt-5.4",
+        output_config: {
+          effort: "max",
+        },
         tools: [webSearchTool],
       }),
     })
@@ -720,9 +723,11 @@ describe("provider messages web_search", () => {
     expect(url).toBe("https://codex.example/backend-api/codex/responses")
 
     const upstreamBody = JSON.parse((init as RequestInit).body as string) as {
+      reasoning?: { effort?: string }
       stream?: boolean
     }
     expect(upstreamBody.stream).toBe(true)
+    expect(upstreamBody.reasoning?.effort).toBe("xhigh")
 
     const upstreamHeaders = new Headers((init as RequestInit).headers)
     expect(upstreamHeaders.get("accept")).toBe("text/event-stream")
@@ -733,6 +738,51 @@ describe("provider messages web_search", () => {
       "web_search_tool_result",
       "text",
     ])
+  })
+
+  test("normalizes reasoning for codex Responses provider messages", async () => {
+    writeProviderConfig({
+      search: searchProviderConfig(),
+      codex: {
+        name: "codex",
+        type: "openai-responses",
+        baseUrl: "https://codex.example/backend-api",
+        apiKey: "unused",
+        authType: "authorization",
+        models: {
+          "gpt-5.4": {
+            toolContentSupportType: [],
+          },
+        },
+      },
+    })
+
+    const app = createApp()
+    const response = await app.request("/codex/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+        model: "gpt-5.4",
+        output_config: {
+          effort: "max",
+        },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://codex.example/backend-api/codex/responses")
+
+    const upstreamBody = JSON.parse((init as RequestInit).body as string) as {
+      reasoning?: { effort?: string }
+    }
+    expect(upstreamBody.reasoning?.effort).toBe("xhigh")
   })
 
   test("streams synthetic Anthropic events after parsing upstream Responses stream", async () => {

--- a/tests/provider-messages-web-search.test.ts
+++ b/tests/provider-messages-web-search.test.ts
@@ -565,6 +565,9 @@ describe("provider messages web_search", () => {
         max_tokens: 128,
         messages: [{ role: "user", content: "What is the Node.js LTS?" }],
         model: "gpt-search",
+        output_config: {
+          effort: "medium",
+        },
         tools: [webSearchTool],
       }),
     })
@@ -577,11 +580,13 @@ describe("provider messages web_search", () => {
 
     const upstreamBody = JSON.parse((init as RequestInit).body as string) as {
       model: string
+      reasoning?: { effort?: string }
       stream?: boolean
       tool_choice?: unknown
       tools?: Array<Record<string, unknown>>
     }
     expect(upstreamBody.model).toBe("gpt-search")
+    expect(upstreamBody.reasoning?.effort).toBe("medium")
     expect(upstreamBody.stream).toBe(true)
     expect(upstreamBody.tool_choice).toBeUndefined()
     expect(upstreamBody.tools).toEqual([
@@ -783,6 +788,35 @@ describe("provider messages web_search", () => {
       reasoning?: { effort?: string }
     }
     expect(upstreamBody.reasoning?.effort).toBe("xhigh")
+  })
+
+  test("passes explicit reasoning for openai-responses provider messages without Copilot metadata", async () => {
+    const app = createApp()
+    const response = await app.request("/search/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+        model: "gpt-search",
+        output_config: {
+          effort: "max",
+        },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://provider.example/v1/responses")
+
+    const upstreamBody = JSON.parse((init as RequestInit).body as string) as {
+      reasoning?: { effort?: string }
+    }
+    expect(upstreamBody.reasoning?.effort).toBe("max")
   })
 
   test("streams synthetic Anthropic events after parsing upstream Responses stream", async () => {

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test"
+
+import type { Model } from "~/services/copilot/get-models"
+
+import {
+  getReasoningEffortSupport,
+  normalizeReasoningEffortForSupport,
+  parseReasoningEffort,
+  resolveReasoningEffortForTarget,
+} from "~/lib/reasoning-effort"
+
+const buildModel = (
+  reasoningEffort?: Array<string>,
+): Pick<Model, "capabilities"> => ({
+  capabilities: {
+    family: "test",
+    limits: {},
+    object: "capabilities",
+    supports: {
+      reasoning_effort: reasoningEffort,
+    },
+    tokenizer: "test",
+    type: "chat",
+  },
+})
+
+describe("reasoning effort normalization", () => {
+  test("parses only canonical effort values", () => {
+    expect(parseReasoningEffort("none")).toBe("none")
+    expect(parseReasoningEffort("minimal")).toBe("minimal")
+    expect(parseReasoningEffort("low")).toBe("low")
+    expect(parseReasoningEffort("medium")).toBe("medium")
+    expect(parseReasoningEffort("high")).toBe("high")
+    expect(parseReasoningEffort("xhigh")).toBe("xhigh")
+    expect(parseReasoningEffort("max")).toBe("max")
+    expect(parseReasoningEffort("ultra")).toBeUndefined()
+    expect(parseReasoningEffort(null)).toBeUndefined()
+  })
+
+  test("normalizes to the closest supported lower value on ties", () => {
+    expect(
+      normalizeReasoningEffortForSupport("max", [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+      ]),
+    ).toBe("xhigh")
+    expect(
+      normalizeReasoningEffortForSupport("minimal", ["low", "medium", "high"]),
+    ).toBe("low")
+    expect(
+      normalizeReasoningEffortForSupport("xhigh", ["low", "medium", "high"]),
+    ).toBe("high")
+    expect(normalizeReasoningEffortForSupport("medium", ["low", "high"])).toBe(
+      "low",
+    )
+  })
+
+  test("omits effort when support is missing, empty, or unknown", () => {
+    expect(
+      normalizeReasoningEffortForSupport("high", undefined),
+    ).toBeUndefined()
+    expect(normalizeReasoningEffortForSupport("high", [])).toBeUndefined()
+    expect(
+      normalizeReasoningEffortForSupport("high", ["turbo", "ultra"]),
+    ).toBeUndefined()
+  })
+
+  test("extracts sorted unique canonical support from model metadata", () => {
+    expect(
+      getReasoningEffortSupport(
+        buildModel(["xhigh", "low", "low", "ultra", "medium"]),
+      ),
+    ).toEqual(["low", "medium", "xhigh"])
+  })
+
+  test("uses explicit effort before configured default", () => {
+    const model = buildModel(["low", "medium", "high", "xhigh"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: "max",
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "low",
+      }),
+    ).toBe("xhigh")
+  })
+
+  test("uses configured default when explicit effort is omitted or invalid", () => {
+    const model = buildModel(["low", "medium"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "high",
+      }),
+    ).toBe("medium")
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: "ultra",
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "high",
+      }),
+    ).toBe("medium")
+  })
+})

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
 
 import "./shared-admin-db-test-home"
 
 import type { Model } from "~/services/copilot/get-models"
 
+import {
+  getConfiguredReasoningEffortForModel,
+  mergeConfigWithDefaults,
+} from "~/lib/config"
+import { PATHS } from "~/lib/paths"
 import {
   getReasoningEffortSupport,
   normalizeReasoningEffortForSupport,
@@ -24,6 +31,42 @@ const buildModel = (
     tokenizer: "test",
     type: "chat",
   },
+})
+
+let configBeforeTest: string | null | undefined
+
+const readConfigText = async (): Promise<string | null> =>
+  await fs.readFile(PATHS.CONFIG_PATH, "utf8").catch(() => null)
+
+const restoreConfigText = async (configText: string | null): Promise<void> => {
+  if (configText === null) {
+    await fs.rm(PATHS.CONFIG_PATH, { force: true })
+  } else {
+    await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+    await fs.writeFile(PATHS.CONFIG_PATH, configText, "utf8")
+  }
+  mergeConfigWithDefaults()
+}
+
+const writeConfig = async (config: Record<string, unknown>): Promise<void> => {
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+}
+
+beforeEach(async () => {
+  configBeforeTest = await readConfigText()
+})
+
+afterEach(async () => {
+  if (configBeforeTest !== undefined) {
+    await restoreConfigText(configBeforeTest)
+    configBeforeTest = undefined
+  }
 })
 
 describe("reasoning effort normalization", () => {
@@ -124,6 +167,39 @@ describe("reasoning effort normalization", () => {
     ).toBe("low")
   })
 
+  test("uses request model default before target model default", () => {
+    const model = buildModel(["low", "medium", "high"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "requested-model",
+        targetModel: model,
+        targetModelId: "target-model",
+        defaultEffortResolver: (modelId) => {
+          if (modelId === "requested-model") return "max"
+          if (modelId === "target-model") return "low"
+          return undefined
+        },
+      }),
+    ).toBe("high")
+  })
+
+  test("uses target model default when request model has none", () => {
+    const model = buildModel(["low", "medium", "high"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "requested-model",
+        targetModel: model,
+        targetModelId: "target-model",
+        defaultEffortResolver: (modelId) =>
+          modelId === "target-model" ? "medium" : undefined,
+      }),
+    ).toBe("medium")
+  })
+
   test("omits effort when explicit and configured default are missing", () => {
     const model = buildModel(["low", "medium", "high"])
 
@@ -144,8 +220,47 @@ describe("reasoning effort normalization", () => {
         explicitEffort: undefined,
         requestModel: "gpt-test",
         targetModel: model,
+        targetModelId: "gpt-target",
         defaultEffortResolver: () => undefined,
       }),
     ).toBeUndefined()
+  })
+
+  test("uses alias target configured default when alias has no direct value", async () => {
+    await writeConfig({
+      modelAliases: {
+        fast: {
+          target: "gpt-5-mini",
+        },
+      },
+      modelReasoningEfforts: {},
+    })
+
+    expect(getConfiguredReasoningEffortForModel("fast")).toBe("low")
+  })
+
+  test("uses direct alias configured default before alias target default", async () => {
+    await writeConfig({
+      modelAliases: {
+        fast: {
+          target: "gpt-5-mini",
+        },
+      },
+      modelReasoningEfforts: {
+        fast: "medium",
+      },
+    })
+
+    expect(getConfiguredReasoningEffortForModel("fast")).toBe("medium")
+  })
+
+  test("uses gpt-5-mini base default for dated gpt-5-mini variants", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {},
+    })
+
+    expect(getConfiguredReasoningEffortForModel("gpt-5-mini-2026-01-01")).toBe(
+      "low",
+    )
   })
 })

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -155,6 +155,19 @@ describe("reasoning effort normalization", () => {
     ).toBe("medium")
   })
 
+  test("treats explicit null as disabling reasoning effort fallback", () => {
+    const model = buildModel(["low", "medium"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: null,
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => "high",
+      }),
+    ).toBeUndefined()
+  })
+
   test("uses configured model default when no default resolver is provided", () => {
     const model = buildModel(["low", "medium", "high"])
 
@@ -231,6 +244,19 @@ describe("reasoning effort normalization", () => {
       modelAliases: {
         fast: {
           target: "gpt-5-mini",
+        },
+      },
+      modelReasoningEfforts: {},
+    })
+
+    expect(getConfiguredReasoningEffortForModel("fast")).toBe("low")
+  })
+
+  test("uses gpt-5-mini base default for dated alias targets", async () => {
+    await writeConfig({
+      modelAliases: {
+        fast: {
+          target: "gpt-5-mini-2026-01-01",
         },
       },
       modelReasoningEfforts: {},

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -109,4 +109,16 @@ describe("reasoning effort normalization", () => {
       }),
     ).toBe("medium")
   })
+
+  test("uses getReasoningEffortForModel when no default resolver is provided", () => {
+    const model = buildModel(["low", "medium", "high"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "gpt-5-mini",
+        targetModel: model,
+      }),
+    ).toBe("low")
+  })
 })

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
+import "./shared-admin-db-test-home"
+
 import type { Model } from "~/services/copilot/get-models"
 
 import {
@@ -110,7 +112,7 @@ describe("reasoning effort normalization", () => {
     ).toBe("medium")
   })
 
-  test("uses getReasoningEffortForModel when no default resolver is provided", () => {
+  test("uses configured model default when no default resolver is provided", () => {
     const model = buildModel(["low", "medium", "high"])
 
     expect(
@@ -120,5 +122,30 @@ describe("reasoning effort normalization", () => {
         targetModel: model,
       }),
     ).toBe("low")
+  })
+
+  test("omits effort when explicit and configured default are missing", () => {
+    const model = buildModel(["low", "medium", "high"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "unconfigured-reasoning-test-model",
+        targetModel: model,
+      }),
+    ).toBeUndefined()
+  })
+
+  test("omits effort when default resolver has no value", () => {
+    const model = buildModel(["low", "medium", "high"])
+
+    expect(
+      resolveReasoningEffortForTarget({
+        explicitEffort: undefined,
+        requestModel: "gpt-test",
+        targetModel: model,
+        defaultEffortResolver: () => undefined,
+      }),
+    ).toBeUndefined()
   })
 })

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -83,6 +83,16 @@ const restoreConfigText = async (configText: string | null): Promise<void> => {
   mergeConfigWithDefaults()
 }
 
+const writeConfig = async (config: Record<string, unknown>): Promise<void> => {
+  await fs.mkdir(path.dirname(PATHS.CONFIG_PATH), { recursive: true })
+  await fs.writeFile(
+    PATHS.CONFIG_PATH,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  )
+  mergeConfigWithDefaults()
+}
+
 function buildAccount(): AccountRuntime {
   return {
     id: "octocat",
@@ -345,6 +355,12 @@ describe("responses handler reasoning effort normalization", () => {
   })
 
   test("injects configured fallback effort for supported Responses models", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "gpt-test": "high",
+      },
+    })
+
     accountsManager.selectAccountForRequest = () =>
       Promise.resolve(
         buildSelection("/responses", "gpt-test", ["low", "medium"]),
@@ -376,6 +392,112 @@ describe("responses handler reasoning effort normalization", () => {
     expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe(
       "medium",
     )
+  })
+
+  test("uses requested model configured fallback before modelMappings", async () => {
+    await writeConfig({
+      modelMappings: {
+        "responses-requested": "responses-mapped",
+      },
+      modelReasoningEfforts: {
+        "responses-requested": "max",
+        "responses-mapped": "low",
+      },
+    })
+
+    let selectionCandidates:
+      | ReadonlyArray<{ modelId: string; endpoint: string }>
+      | undefined
+    accountsManager.selectAccountForRequest = (candidates) => {
+      selectionCandidates = candidates
+      return Promise.resolve(
+        buildSelection("/responses", "responses-mapped", [
+          "low",
+          "medium",
+          "high",
+        ]),
+      )
+    }
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("responses-mapped", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "responses-requested",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(selectionCandidates?.[0]?.modelId).toBe("responses-mapped")
+    expect(upstreamBody?.model).toBe("responses-mapped")
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("high")
+  })
+
+  test("omits reasoning effort but preserves other reasoning fields without configured default", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {},
+      modelMappings: {},
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("/responses", "unconfigured-responses", [
+          "low",
+          "medium",
+          "high",
+        ]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("unconfigured-responses", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "unconfigured-responses",
+          input: "hello",
+          reasoning: { summary: "auto" },
+        }),
+      }),
+    )
+
+    const reasoning = upstreamBody?.reasoning as
+      | { effort?: string; summary?: string }
+      | undefined
+
+    expect(response.status).toBe(200)
+    expect(reasoning?.summary).toBe("auto")
+    expect(Object.hasOwn(reasoning ?? {}, "effort")).toBe(false)
   })
 })
 

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -96,7 +96,11 @@ function buildAccount(): AccountRuntime {
   }
 }
 
-function buildModel(id: string, maxPromptImageSize?: number): Model {
+function buildModel(
+  id: string,
+  maxPromptImageSize?: number,
+  reasoningEffort: Array<string> = ["low", "medium", "high", "xhigh"],
+): Model {
   return {
     id,
     name: id,
@@ -119,6 +123,7 @@ function buildModel(id: string, maxPromptImageSize?: number): Model {
         adaptive_thinking: true,
         streaming: true,
         vision: maxPromptImageSize !== undefined ? true : undefined,
+        reasoning_effort: reasoningEffort,
       },
       tokenizer: "o200k_base",
       type: "chat",
@@ -126,11 +131,15 @@ function buildModel(id: string, maxPromptImageSize?: number): Model {
   }
 }
 
-function buildSelection(endpoint: string, modelId: string): SelectionOk {
+function buildSelection(
+  endpoint: string,
+  modelId: string,
+  reasoningEffort?: Array<string>,
+): SelectionOk {
   return {
     ok: true,
     account: buildAccount(),
-    selectedModel: buildModel(modelId),
+    selectedModel: buildModel(modelId, undefined, reasoningEffort),
     endpoint,
     costUnits: 0,
     confirmAffinity: mock(() => {}),
@@ -300,6 +309,73 @@ describe("responses handler model mapping", () => {
 
     expect(response.status).toBe(200)
     expect(selectionCandidates?.[0]?.modelId).toBe("gpt-original")
+  })
+})
+
+describe("responses handler reasoning effort normalization", () => {
+  test("normalizes explicit Responses reasoning effort to selected model support", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(buildSelection("/responses", "gpt-test", ["low", "high"]))
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-test", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-test",
+          input: "hello",
+          reasoning: { effort: "medium" },
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("low")
+  })
+
+  test("injects configured fallback effort for supported Responses models", async () => {
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("/responses", "gpt-test", ["low", "medium"]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-test", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-test",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe(
+      "medium",
+    )
   })
 })
 

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -438,6 +438,45 @@ describe("responses handler reasoning effort normalization", () => {
     expect(Object.hasOwn(reasoning ?? {}, "effort")).toBe(false)
   })
 
+  test("preserves explicit null Responses reasoning without injecting fallback", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "gpt-test": "high",
+      },
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("/responses", "gpt-test", ["low", "medium", "high"]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-test", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-test",
+          input: "hello",
+          reasoning: null,
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.reasoning).toBeNull()
+  })
+
   test("uses requested model configured fallback before modelMappings", async () => {
     await writeConfig({
       modelMappings: {

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -394,6 +394,50 @@ describe("responses handler reasoning effort normalization", () => {
     )
   })
 
+  test("does not inject configured fallback when Responses reasoning effort is explicit null", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {
+        "gpt-test": "high",
+      },
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("/responses", "gpt-test", ["low", "medium", "high"]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-test", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-test",
+          input: "hello",
+          reasoning: { effort: null, summary: "auto" },
+        }),
+      }),
+    )
+
+    const reasoning = upstreamBody?.reasoning as
+      | { effort?: string; summary?: string }
+      | undefined
+
+    expect(response.status).toBe(200)
+    expect(reasoning?.summary).toBe("auto")
+    expect(Object.hasOwn(reasoning ?? {}, "effort")).toBe(false)
+  })
+
   test("uses requested model configured fallback before modelMappings", async () => {
     await writeConfig({
       modelMappings: {
@@ -536,6 +580,51 @@ describe("responses handler reasoning effort normalization", () => {
     expect(response.status).toBe(200)
     expect(reasoning?.summary).toBe("auto")
     expect(Object.hasOwn(reasoning ?? {}, "effort")).toBe(false)
+  })
+
+  test("removes Responses reasoning object when effort cleanup leaves it empty", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {},
+      modelMappings: {},
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("/responses", "unconfigured-responses", [
+          "low",
+          "medium",
+          "high",
+        ]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(buildResponsesResult("unconfigured-responses", "ok")),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "unconfigured-responses",
+          input: "hello",
+          reasoning: { effort: null },
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(Object.hasOwn(upstreamBody ?? {}, "reasoning")).toBe(false)
   })
 })
 

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -450,6 +450,44 @@ describe("responses handler reasoning effort normalization", () => {
     expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("high")
   })
 
+  test("uses selected target model configured fallback when request model has none", async () => {
+    await writeConfig({
+      modelReasoningEfforts: {},
+      modelMappings: {},
+    })
+
+    accountsManager.selectAccountForRequest = () =>
+      Promise.resolve(
+        buildSelection("/responses", "gpt-5-mini", ["low", "medium", "high"]),
+      )
+
+    let upstreamBody: Record<string, unknown> | undefined
+    fetchHolder.fetch = mock((_url: string, opts?: FetchOptions) => {
+      upstreamBody = JSON.parse(String(opts?.body)) as Record<string, unknown>
+      return Promise.resolve(
+        new Response(JSON.stringify(buildResponsesResult("gpt-5-mini", "ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    }) as unknown as typeof fetch
+
+    const response = await responsesRoutes.fetch(
+      new Request("http://local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "unconfigured-responses-request",
+          input: "hello",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upstreamBody?.model).toBe("gpt-5-mini")
+    expect((upstreamBody?.reasoning as { effort?: string }).effort).toBe("low")
+  })
+
   test("omits reasoning effort but preserves other reasoning fields without configured default", async () => {
     await writeConfig({
       modelReasoningEfforts: {},


### PR DESCRIPTION
## Summary
- Add model-aware reasoning effort normalization using upstream `/models` capability metadata.
- Preserve explicit downstream intent before configured defaults, then normalize to the nearest supported upstream value.
- Surface model and alias-specific reasoning effort options in Admin UI settings.

## Validation
- bun test tests/settings-page.test.tsx
- bun test tests/reasoning-effort.test.ts tests/chat-completions-handler.test.ts tests/responses-handler.test.ts tests/create-chat-completions.test.ts tests/messages-handler.test.ts tests/messages-preprocess.test.ts tests/responses-translation.test.ts tests/provider-messages-web-search.test.ts
- bun run typecheck
- bun run typecheck:admin
- bun run lint
- bun run lint:admin
- bun test
- bun run build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 设置页和管理接口新增推理强度支持信息，界面可按模型动态展示可用档位。
  * 支持新的推理强度值 `max`，并提升相关配置与请求的兼容性。

* **Bug 修复**
  * 当模型不支持当前推理强度时，会自动归一化为可用值，避免配置丢失或请求失败。
  * 推理元数据加载失败时新增提示，并保留可用的默认行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->